### PR TITLE
Proposal: remove a bunch of debugging features

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -86,6 +86,10 @@ PyAPI_FUNC(int) Py_MakePendingCalls(void);
 PyAPI_FUNC(void) Py_SetRecursionLimit(int);
 PyAPI_FUNC(int) Py_GetRecursionLimit(void);
 
+#if !PY_DEBUGGING_CHECKS
+#define Py_EnterRecursiveCall(where) (0)
+#define Py_LeaveRecursiveCall(where) ((void)0)
+#else
 #define Py_EnterRecursiveCall(where)  \
             (_Py_MakeRecCheck(PyThreadState_GET()->recursion_depth) &&  \
              _Py_CheckRecursiveCall(where))
@@ -93,6 +97,7 @@ PyAPI_FUNC(int) Py_GetRecursionLimit(void);
     do{ if(_Py_MakeEndRecCheck(PyThreadState_GET()->recursion_depth))  \
       PyThreadState_GET()->overflowed = 0;  \
     } while(0)
+#endif
 PyAPI_FUNC(int) _Py_CheckRecursiveCall(const char *where);
 
 /* Due to the macros in which it's used, _Py_CheckRecursionLimit is in

--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -55,9 +55,13 @@ PyAPI_FUNC(int) _PyStack_UnpackDict(
    40 bytes on the stack. */
 #define _PY_FASTCALL_SMALL_STACK 5
 
+#if !PY_DEBUGGING_CHECKS
+#define _Py_CheckFunctionResult(callable, result, where) (result)
+#else
 PyAPI_FUNC(PyObject *) _Py_CheckFunctionResult(PyObject *callable,
                                                PyObject *result,
                                                const char *where);
+#endif
 
 /* === Vectorcall protocol (PEP 590) ============================= */
 

--- a/Include/cpython/objimpl.h
+++ b/Include/cpython/objimpl.h
@@ -15,6 +15,7 @@ PyAPI_FUNC(int) _PyObject_DebugMallocStats(FILE *out);
 #endif
 
 
+#if PY_DEBUGGING_FEATURES
 typedef struct {
     /* user context passed as the first argument to the 2 functions */
     void *ctx;
@@ -31,6 +32,7 @@ PyAPI_FUNC(void) PyObject_GetArenaAllocator(PyObjectArenaAllocator *allocator);
 
 /* Set the arena allocator. */
 PyAPI_FUNC(void) PyObject_SetArenaAllocator(PyObjectArenaAllocator *allocator);
+#endif
 
 
 PyAPI_FUNC(Py_ssize_t) _PyGC_CollectNoFail(void);

--- a/Include/cpython/pymem.h
+++ b/Include/cpython/pymem.h
@@ -42,14 +42,19 @@ typedef enum {
     PYMEM_ALLOCATOR_DEFAULT = 1,
     PYMEM_ALLOCATOR_DEBUG = 2,
     PYMEM_ALLOCATOR_MALLOC = 3,
+#if PY_DEBUGGING_FEATURES
     PYMEM_ALLOCATOR_MALLOC_DEBUG = 4,
+#endif
 #ifdef WITH_PYMALLOC
     PYMEM_ALLOCATOR_PYMALLOC = 5,
+#if PY_DEBUGGING_FEATURES
     PYMEM_ALLOCATOR_PYMALLOC_DEBUG = 6,
+#endif
 #endif
 } PyMemAllocatorName;
 
 
+#if PY_DEBUGGING_FEATURES
 typedef struct {
     /* user context passed as the first argument to the 4 functions */
     void *ctx;
@@ -102,6 +107,7 @@ PyAPI_FUNC(void) PyMem_SetAllocator(PyMemAllocatorDomain domain,
 
    The function does nothing if Python is not compiled is debug mode. */
 PyAPI_FUNC(void) PyMem_SetupDebugHooks(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -148,6 +148,7 @@ struct _gc_runtime_state {
 PyAPI_FUNC(void) _PyGC_Initialize(struct _gc_runtime_state *);
 
 
+#if PY_DEBUGGING_HOOKS
 /* Set the memory allocator of the specified domain to the default.
    Save the old allocator into *old_alloc if it's non-NULL.
    Return on success, or return -1 if the domain is unknown. */
@@ -166,9 +167,11 @@ PyAPI_FUNC(int) _PyMem_SetDefaultAllocator(
    Byte patterns 0xCB, 0xDB and 0xFB have been replaced with 0xCD, 0xDD and
    0xFD to use the same values than Windows CRT debug malloc() and free().
    If modified, _PyMem_IsPtrFreed() should be updated as well. */
+#endif
 #define PYMEM_CLEANBYTE      0xCD
 #define PYMEM_DEADBYTE       0xDD
 #define PYMEM_FORBIDDENBYTE  0xFD
+#if PY_DEBUGGING_HOOKS
 
 /* Heuristic checking if a pointer value is newly allocated
    (uninitialized), newly freed or NULL (is equal to zero).
@@ -196,6 +199,8 @@ static inline int _PyMem_IsPtrFreed(void *ptr)
 #  error "unknown pointer size"
 #endif
 }
+#endif
+#define _PyMem_IsPtrFreed(x) (0)
 
 PyAPI_FUNC(int) _PyMem_GetAllocatorName(
     const char *name,

--- a/Include/object.h
+++ b/Include/object.h
@@ -435,9 +435,11 @@ PyAPI_FUNC(void) _Py_AddToAllObjects(PyObject *, int force);
    inline. */
 static inline void _Py_NewReference(PyObject *op)
 {
+#if PY_DEBUGGING_FEATURES
     if (_Py_tracemalloc_config.tracing) {
         _PyTraceMalloc_NewReference(op);
     }
+#endif
     _Py_INC_TPALLOCS(op);
     _Py_INC_REFTOTAL;
     Py_REFCNT(op) = 1;

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -211,7 +211,11 @@ PyAPI_FUNC(void) PyErr_BadInternalCall(void);
 PyAPI_FUNC(void) _PyErr_BadInternalCall(const char *filename, int lineno);
 /* Mask the old API with a call to the new API for code compiled under
    Python 2.0: */
+#if !PY_DEBUGGING_CHECKS
+#define PyErr_BadInternalCall() ((void)0)
+#else
 #define PyErr_BadInternalCall() _PyErr_BadInternalCall(__FILE__, __LINE__)
+#endif
 
 /* Function to create a new exception */
 PyAPI_FUNC(PyObject *) PyErr_NewException(

--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -101,6 +101,7 @@ PyAPI_FUNC(void) PyMem_Free(void *ptr);
 #define PyMem_Del               PyMem_Free
 #define PyMem_DEL               PyMem_FREE
 
+#if PY_DEBUGGING_FEATURES
 /* bpo-35053: expose _Py_tracemalloc_config for performance:
    _Py_NewReference() needs an efficient check to test if tracemalloc is
    tracing.
@@ -129,6 +130,7 @@ struct _PyTraceMalloc_Config {
 };
 
 PyAPI_DATA(struct _PyTraceMalloc_Config) _Py_tracemalloc_config;
+#endif
 
 #define _PyTraceMalloc_Config_INIT \
     {.initialized = TRACEMALLOC_NOT_INITIALIZED, \

--- a/Lib/ctypes/test/test_as_parameter.py
+++ b/Lib/ctypes/test/test_as_parameter.py
@@ -2,6 +2,7 @@ import unittest
 from ctypes import *
 from ctypes.test import need_symbol
 import _ctypes_test
+import sys
 
 dll = CDLL(_ctypes_test.__file__)
 
@@ -190,6 +191,7 @@ class BasicWrapTestCase(unittest.TestCase):
         self.assertEqual((s8i.a, s8i.b, s8i.c, s8i.d, s8i.e, s8i.f, s8i.g, s8i.h),
                              (9*2, 8*3, 7*4, 6*5, 5*6, 4*7, 3*8, 2*9))
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursive_as_param(self):
         from ctypes import c_int
 

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -5,6 +5,7 @@ Tests common to list and UserList.UserList
 import sys
 import os
 from functools import cmp_to_key
+import unittest
 
 from test import support, seq_tests
 
@@ -59,6 +60,7 @@ class CommonTest(seq_tests.CommonTest):
         self.assertEqual(str(a2), "[0, 1, 2, [...], 3]")
         self.assertEqual(repr(a2), "[0, 1, 2, [...], 3]")
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_repr_deep(self):
         a = self.type2test([])
         for i in range(sys.getrecursionlimit() + 100):

--- a/Lib/test/mapping_tests.py
+++ b/Lib/test/mapping_tests.py
@@ -620,6 +620,7 @@ class TestHashMappingProtocol(TestMappingProtocol):
         d = self._full_mapping({1: BadRepr()})
         self.assertRaises(Exc, repr, d)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_repr_deep(self):
         d = self._empty_mapping()
         for i in range(sys.getrecursionlimit() + 100):

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2354,6 +2354,7 @@ class AbstractPickleTests(unittest.TestCase):
             self.assertEqual(y._reduce_called, 1)
 
     @no_tracing
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_bad_getattr(self):
         # Issue #3514: crash when there is an infinite loop in __getattr__
         x = BadGetattr()

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -694,6 +694,10 @@ class PyMemDebugTests(unittest.TestCase):
                  r"Enable tracemalloc to get the memory block allocation traceback\n"
                  r"\n"
                  r"Fatal Python error: bad trailing pad byte")
+        if hasattr(sys, "pyston_version_info"):
+            regex = regex.split('\\n')
+            del regex[-3:-1]
+            regex = '\\n'.join(regex)
         regex = regex.format(ptr=self.PTR_REGEX)
         regex = re.compile(regex, flags=re.DOTALL)
         self.assertRegex(out, regex)
@@ -710,6 +714,10 @@ class PyMemDebugTests(unittest.TestCase):
                  r"Enable tracemalloc to get the memory block allocation traceback\n"
                  r"\n"
                  r"Fatal Python error: bad ID: Allocated using API 'm', verified using API 'r'\n")
+        if hasattr(sys, "pyston_version_info"):
+            regex = regex.split('\\n')
+            del regex[-4:-2]
+            regex = '\\n'.join(regex)
         regex = regex.format(ptr=self.PTR_REGEX)
         self.assertRegex(out, regex)
 

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -259,6 +259,8 @@ class CAPITest(unittest.TestCase):
         _opcache_thresh = int(os.environ["OPCACHE_MIN_RUNS"])
     else:
         _opcache_thresh = int(os.environ.get("JIT_MIN_RUNS", "2000")) / 2
+
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables memory hooks")
     @unittest.skipIf(_opcache_thresh < 200, "We might allocate an opcache in the middle of this test")
     def test_set_nomemory(self):
         code = """if 1:
@@ -668,6 +670,7 @@ class Test_testcapi(unittest.TestCase):
                     if name.startswith('test_') and not name.endswith('_code'))
 
 
+@unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables memory hooks")
 class PyMemDebugTests(unittest.TestCase):
     PYTHONMALLOC = 'debug'
     # '0x04c06e0' or '04C06E0'

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -183,6 +183,7 @@ class CAPITest(unittest.TestCase):
         self.assertEqual(o.__ipow__(1), (1, None))
         self.assertEqual(o.__ipow__(2, 2), (2, 2))
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disabled this check")
     def test_return_null_without_error(self):
         # Issue #23571: A function must not return NULL without setting an
         # error
@@ -212,6 +213,7 @@ class CAPITest(unittest.TestCase):
                              'return_null_without_error.* '
                              'returned NULL without setting an error')
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disabled this check")
     def test_return_result_with_error(self):
         # Issue #23571: A function must not return a result with an error set
         if Py_DEBUG:

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -1,5 +1,6 @@
 "Test the functionality of Python classes implementing operators."
 
+import sys
 import unittest
 
 
@@ -490,6 +491,7 @@ class ClassTests(unittest.TestCase):
         self.assertRaises(TypeError, hash, C2())
 
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def testSFBug532646(self):
         # Test for SF bug 532646
 

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -383,6 +383,7 @@ if check_impl_detail(cpython=True) and ctypes is not None:
             # away, so we eval a lambda.
             return eval('lambda:42')
 
+        @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disabled this check")
         def test_get_non_code(self):
             f = self.get_func()
 
@@ -391,6 +392,7 @@ if check_impl_detail(cpython=True) and ctypes is not None:
             self.assertRaises(SystemError, GetExtra, 42, FREE_INDEX,
                               ctypes.c_voidp(100))
 
+        @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disabled this check")
         def test_bad_index(self):
             f = self.get_func()
             self.assertRaises(SystemError, SetExtra, f.__code__,

--- a/Lib/test/test_copy.py
+++ b/Lib/test/test_copy.py
@@ -5,6 +5,7 @@ import copyreg
 import weakref
 import abc
 from operator import le, lt, ge, gt, eq, ne
+import sys
 
 import unittest
 
@@ -372,8 +373,9 @@ class TestCopy(unittest.TestCase):
         x = []
         x.append(x)
         y = copy.deepcopy(x)
-        for op in comparisons:
-            self.assertRaises(RecursionError, op, y, x)
+        if not hasattr(sys, "pyston_version_info"):
+            for op in comparisons:
+                self.assertRaises(RecursionError, op, y, x)
         self.assertIsNot(y, x)
         self.assertIs(y[0], y)
         self.assertEqual(len(y), 1)
@@ -399,8 +401,9 @@ class TestCopy(unittest.TestCase):
         x = ([],)
         x[0].append(x)
         y = copy.deepcopy(x)
-        for op in comparisons:
-            self.assertRaises(RecursionError, op, y, x)
+        if not hasattr(sys, "pyston_version_info"):
+            for op in comparisons:
+                self.assertRaises(RecursionError, op, y, x)
         self.assertIsNot(y, x)
         self.assertIsNot(y[0], x[0])
         self.assertIs(y[0][0], y)
@@ -418,8 +421,9 @@ class TestCopy(unittest.TestCase):
         y = copy.deepcopy(x)
         for op in order_comparisons:
             self.assertRaises(TypeError, op, y, x)
-        for op in equality_comparisons:
-            self.assertRaises(RecursionError, op, y, x)
+        if not hasattr(sys, "pyston_version_info"):
+            for op in equality_comparisons:
+                self.assertRaises(RecursionError, op, y, x)
         self.assertIsNot(y, x)
         self.assertIs(y['foo'], y)
         self.assertEqual(len(y), 1)

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -3568,6 +3568,7 @@ order (MRO) for bases """
                            encoding='latin1', errors='replace')
         self.assertEqual(ba, b'abc\xbd?')
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursive_call(self):
         # Testing recursive __call__() by setting to instance of class...
         class A(object):
@@ -4666,6 +4667,7 @@ order (MRO) for bases """
         with self.assertRaises(TypeError):
             str.__add__(fake_str, "abc")
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_repr_as_str(self):
         # Issue #11603: crash or infinite loop when rebinding __str__ as
         # __repr__.

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1410,7 +1410,8 @@ class CAPITest(unittest.TestCase):
         self.assertEqual(dict_getitem_knownhash(d, 'z', hash('z')), 3)
 
         # not a dict
-        self.assertRaises(SystemError, dict_getitem_knownhash, [], 1, hash(1))
+        if not hasattr(sys, "pyston_version_info"):
+            self.assertRaises(SystemError, dict_getitem_knownhash, [], 1, hash(1))
         # key does not exist
         self.assertRaises(KeyError, dict_getitem_knownhash, {}, 1, hash(1))
 

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -541,6 +541,7 @@ class DictTest(unittest.TestCase):
         d = {1: BadRepr()}
         self.assertRaises(Exc, repr, d)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables these checks")
     def test_repr_deep(self):
         d = {}
         for i in range(sys.getrecursionlimit() + 100):

--- a/Lib/test/test_dictviews.py
+++ b/Lib/test/test_dictviews.py
@@ -213,6 +213,7 @@ class DictSetTest(unittest.TestCase):
         # Again.
         self.assertIsInstance(r, str)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disabled this check")
     def test_deeply_nested_repr(self):
         d = {}
         for i in range(sys.getrecursionlimit() + 100):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -560,6 +560,7 @@ class ExceptionTests(unittest.TestCase):
         self.assertEqual(x.fancy_arg, 42)
 
     @no_tracing
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def testInfiniteRecursion(self):
         def f():
             return f()
@@ -973,16 +974,18 @@ class ExceptionTests(unittest.TestCase):
             else:
                 self.fail("Should have raised KeyError")
 
-        def g():
-            try:
-                return g()
-            except RecursionError:
-                return sys.exc_info()
-        e, v, tb = g()
-        self.assertIsInstance(v, RecursionError, type(v))
-        self.assertIn("maximum recursion depth exceeded", str(v))
+        if not hasattr(sys, "pyston_version_info"):
+            def g():
+                try:
+                    return g()
+                except RecursionError:
+                    return sys.exc_info()
+            e, v, tb = g()
+            self.assertIsInstance(v, RecursionError, type(v))
+            self.assertIn("maximum recursion depth exceeded", str(v))
 
     @cpython_only
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursion_normalizing_exception(self):
         # Issue #22898.
         # Test that a RecursionError is raised when tstate->recursion_depth is
@@ -1164,6 +1167,7 @@ class ExceptionTests(unittest.TestCase):
         self.assertEqual(wr(), None)
 
     @no_tracing
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursion_error_cleanup(self):
         # Same test as above, but with "recursion exceeded" errors
         class C:

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1062,6 +1062,7 @@ class ExceptionTests(unittest.TestCase):
                       b'while normalizing an exception', err)
         self.assertIn(b'Done.', out)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables memory hooks")
     @cpython_only
     def test_recursion_normalizing_with_no_memory(self):
         # Issue #30697. Test that in the abort that occurs when there is no
@@ -1229,6 +1230,7 @@ class ExceptionTests(unittest.TestCase):
                     self.assertIn("test message", report)
                 self.assertTrue(report.endswith("\n"))
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables memory hooks")
     @cpython_only
     def test_memory_error_in_PyErr_PrintEx(self):
         code = """if 1:

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -176,6 +176,7 @@ class AutoFileTests:
         finally:
             os.close(fd)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def testRecursiveRepr(self):
         # Issue #25455
         with swap_attr(self.f, 'name', self.f):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -326,14 +326,15 @@ class TestPartial:
 
     def test_recursive_pickle(self):
         with self.AllowPickle():
-            f = self.partial(capture)
-            f.__setstate__((f, (), {}, {}))
-            try:
-                for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                    with self.assertRaises(RecursionError):
-                        pickle.dumps(f, proto)
-            finally:
-                f.__setstate__((capture, (), {}, {}))
+            if not hasattr(sys, "pyston_version_info"):
+                f = self.partial(capture)
+                f.__setstate__((f, (), {}, {}))
+                try:
+                    for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                        with self.assertRaises(RecursionError):
+                            pickle.dumps(f, proto)
+                finally:
+                    f.__setstate__((capture, (), {}, {}))
 
             f = self.partial(capture)
             f.__setstate__((capture, (f,), {}, {}))

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -1126,6 +1126,7 @@ class CommonBufferedTests:
         raw.name = b"dummy"
         self.assertRegex(repr(b), "<%s name=b'dummy'>" % clsname)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursive_repr(self):
         # Issue #25455
         raw = self.MockRawIO()
@@ -2628,6 +2629,7 @@ class TextIOWrapperTest(unittest.TestCase):
         t.buffer.detach()
         repr(t)  # Should not raise an exception
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursive_repr(self):
         # Issue #25455
         raw = self.BytesIO()

--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -241,11 +241,13 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
         self.assertEqual(True, issubclass(int, (int, (float, int))))
         self.assertEqual(True, issubclass(str, (str, (Child, str))))
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_subclass_recursion_limit(self):
         # make sure that issubclass raises RecursionError before the C stack is
         # blown
         self.assertRaises(RecursionError, blowstack, issubclass, str, str)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_isinstance_recursion_limit(self):
         # make sure that issubclass raises RecursionError before the C stack is
         # blown
@@ -271,6 +273,7 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
 
         self.assertEqual(True, issubclass(B(), int))
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_infinite_recursion_in_bases(self):
         class X:
             @property

--- a/Lib/test/test_json/test_recursion.py
+++ b/Lib/test/test_json/test_recursion.py
@@ -1,4 +1,6 @@
+import sys
 from test.test_json import PyTest, CTest
+import unittest
 
 
 class JSONTestObject:
@@ -65,6 +67,7 @@ class TestRecursion:
             self.fail("didn't raise ValueError on default recursion")
 
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_highly_nested_objects_decoding(self):
         # test that loading highly-nested objects doesn't segfault when C
         # accelerations are used. See #12017
@@ -75,6 +78,7 @@ class TestRecursion:
         with self.assertRaises(RecursionError):
             self.loads('[' * 100000 + '1' + ']' * 100000)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_highly_nested_objects_encoding(self):
         # See #12051
         l, d = [], {}
@@ -85,6 +89,7 @@ class TestRecursion:
         with self.assertRaises(RecursionError):
             self.dumps(d)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_endless_recursion(self):
         # See #12051
         class EndlessJSONEncoder(self.json.JSONEncoder):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4288,6 +4288,7 @@ class ModuleLevelMiscTest(BaseTest):
         self.assertIn("exception in __del__", err)
         self.assertIn("ValueError: some error", err)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursion_error(self):
         # Issue 36272
         code = """if 1:

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -12,6 +12,7 @@ import binascii
 import collections
 from test import support
 from io import BytesIO
+import sys
 
 from plistlib import UID
 
@@ -907,6 +908,7 @@ class TestBinaryPlistlib(unittest.TestCase):
         b = plistlib.loads(plistlib.dumps(a, fmt=plistlib.FMT_BINARY))
         self.assertIs(b['x'], b)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_deep_nesting(self):
         for N in [300, 100000]:
             chunks = [b'\xa1' + (i + 1).to_bytes(4, 'big') for i in range(N)]

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -38,6 +38,7 @@ def spawn_repl(*args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kw):
 
 class TestInteractiveInterpreter(unittest.TestCase):
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables memory hooks")
     @cpython_only
     def test_no_memory(self):
         # Issue #30696: Fix the interactive interpreter looping endlessly when

--- a/Lib/test/test_richcmp.py
+++ b/Lib/test/test_richcmp.py
@@ -2,6 +2,7 @@
 
 import unittest
 from test import support
+import sys
 
 import operator
 
@@ -220,6 +221,7 @@ class MiscTest(unittest.TestCase):
         for func in (do, operator.not_):
             self.assertRaises(Exc, func, Bad())
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     @support.no_tracing
     def test_recursion(self):
         # Check that comparison for recursive objects fails gracefully

--- a/Lib/test/test_runpy.py
+++ b/Lib/test/test_runpy.py
@@ -733,6 +733,7 @@ class RunPathTestCase(unittest.TestCase, CodeExecutionMixin):
             self._check_import_error(zip_name, msg)
 
     @no_tracing
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_main_recursion_error(self):
         with temp_dir() as script_dir, temp_dir() as dummy_dir:
             mod_name = '__main__'

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -211,6 +211,7 @@ class SysModuleTest(unittest.TestCase):
         finally:
             sys.setswitchinterval(orig)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursionlimit(self):
         self.assertRaises(TypeError, sys.getrecursionlimit, 42)
         oldlimit = sys.getrecursionlimit()
@@ -220,6 +221,7 @@ class SysModuleTest(unittest.TestCase):
         self.assertEqual(sys.getrecursionlimit(), 10000)
         sys.setrecursionlimit(oldlimit)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursionlimit_recovery(self):
         if hasattr(sys, 'gettrace') and sys.gettrace():
             self.skipTest('fatal error if run with a trace function')
@@ -243,6 +245,7 @@ class SysModuleTest(unittest.TestCase):
         finally:
             sys.setrecursionlimit(oldlimit)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     @test.support.cpython_only
     def test_setrecursionlimit_recursion_depth(self):
         # Issue #25274: Setting a low recursion limit must be blocked if the
@@ -278,6 +281,7 @@ class SysModuleTest(unittest.TestCase):
         finally:
             sys.setrecursionlimit(oldlimit)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursionlimit_fatalerror(self):
         # A fatal error occurs if a second recursion limit is hit when recovering
         # from a first one.

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1049,6 +1049,7 @@ class ThreadingExceptionTests(BaseTestCase):
         lock = threading.Lock()
         self.assertRaises(RuntimeError, lock.release)
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursion_limit(self):
         # Issue 9670
         # test that excessive recursion within a non-main thread causes

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -300,6 +300,7 @@ class TracebackFormatTests(unittest.TestCase):
         ])
 
     # issue 26823 - Shrink recursive tracebacks
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def _check_recursive_traceback_display(self, render_exc):
         # Always show full diffs when this test fails
         # Note that rearranging things may require adjusting

--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -1,7 +1,8 @@
 import contextlib
 import os
 import sys
-import tracemalloc
+if not hasattr(sys, "pyston_version_info"):
+    import tracemalloc
 import unittest
 from unittest.mock import patch
 from test.support.script_helper import (assert_python_ok, assert_python_failure,
@@ -84,6 +85,7 @@ def traceback_filename(filename):
     return traceback_lineno(filename, 0)
 
 
+@unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables tracemalloc")
 class TestTracemallocEnabled(unittest.TestCase):
     def setUp(self):
         if tracemalloc.is_tracing():
@@ -317,6 +319,7 @@ class TestTracemallocEnabled(unittest.TestCase):
             self.assertEqual(exitcode, 0)
 
 
+@unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables tracemalloc")
 class TestSnapshot(unittest.TestCase):
     maxDiff = 4000
 
@@ -626,6 +629,7 @@ class TestSnapshot(unittest.TestCase):
                               '    <b.py, 4>'])
 
 
+@unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables tracemalloc")
 class TestFilters(unittest.TestCase):
     maxDiff = 2048
 
@@ -837,6 +841,7 @@ class TestFilters(unittest.TestCase):
         self.assertFalse(f._match_traceback(unknown))
 
 
+@unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables tracemalloc")
 class TestCommandLine(unittest.TestCase):
     def test_env_var_disabled_by_default(self):
         # not tracing by default
@@ -929,6 +934,7 @@ class TestCommandLine(unittest.TestCase):
         assert_python_ok('-X', 'tracemalloc', '-c', code)
 
 
+@unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables tracemalloc")
 @unittest.skipIf(_testcapi is None, 'need _testcapi')
 class TestCAPI(unittest.TestCase):
     maxDiff = 80 * 20

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2469,7 +2469,8 @@ class ForwardRefTests(BaseTestCase):
         r1 = namespace1()
         r2 = namespace2()
         self.assertIsNot(r1, r2)
-        self.assertRaises(RecursionError, cmp, r1, r2)
+        if not hasattr(sys, "pyston_version_info"):
+            self.assertRaises(RecursionError, cmp, r1, r2)
 
     def test_union_forward_recursion(self):
         ValueList = List['Value']

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -926,6 +926,7 @@ class CWarningsDisplayTests(WarningsDisplayTests, unittest.TestCase):
 class PyWarningsDisplayTests(WarningsDisplayTests, unittest.TestCase):
     module = py_warnings
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables tracemalloc")
     def test_tracemalloc(self):
         self.addCleanup(support.unlink, support.TESTFN)
 

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2321,6 +2321,7 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
         e.extend([ET.Element('bar')])
         self.assertRaises(ValueError, e.remove, X('baz'))
 
+    @unittest.skipIf(hasattr(sys, "pyston_version_info"), "Pyston disables recursion checking")
     def test_recursive_repr(self):
         # Issue #25455
         e = ET.Element('foo')

--- a/Makefile
+++ b/Makefile
@@ -77,16 +77,18 @@ PROFILE_TASK:=../../../Lib/test/regrtest.py -j 1 -unone,decimal -x test_posix te
 MAKEFILE_DEPENDENCIES:=Makefile.pre.in configure
 pyston/build/cpython_bc_build/Makefile: $(CLANG) $(MAKEFILE_DEPENDENCIES)
 	mkdir -p pyston/build/cpython_bc_build
-	cd pyston/build/cpython_bc_build; WRAPPER_REALCC=$(realpath $(CLANG)) WRAPPER_OUTPUT_PREFIX=../cpython_bc CC=../../../pyston/clang_wrapper.py CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -Wno-unused-command-line-argument" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS)" ../../../configure --prefix=/usr --disable-aot
+	cd pyston/build/cpython_bc_build; WRAPPER_REALCC=$(realpath $(CLANG)) WRAPPER_OUTPUT_PREFIX=../cpython_bc CC=../../../pyston/clang_wrapper.py CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -Wno-unused-command-line-argument" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS)" ../../../configure --prefix=/usr --disable-aot --disable-debugging-features
 pyston/build/cpython_unopt_build/Makefile: $(MAKEFILE_DEPENDENCIES)
 	mkdir -p pyston/build/cpython_unopt_build
-	cd pyston/build/cpython_unopt_build; CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl,--emit-relocs" ../../../configure --prefix=/usr
+	cd pyston/build/cpython_unopt_build; CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl,--emit-relocs" ../../../configure --prefix=/usr --disable-debugging-features
 pyston/build/cpython_opt_build/Makefile: $(MAKEFILE_DEPENDENCIES)
 	mkdir -p pyston/build/cpython_opt_build
-	cd pyston/build/cpython_opt_build; PROFILE_TASK="$(PROFILE_TASK)" CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl,--emit-relocs" ../../../configure --prefix=/usr --enable-optimizations --with-lto
+	cd pyston/build/cpython_opt_build; PROFILE_TASK="$(PROFILE_TASK)" CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl,--emit-relocs" ../../../configure --prefix=/usr --enable-optimizations --with-lto --disable-debugging-features
+# We have to --disable-debugging-features for consistency with the bc build
+# If we had a separate bc-dbg build then we could change this
 pyston/build/cpython_dbg_build/Makefile: $(MAKEFILE_DEPENDENCIES)
 	mkdir -p pyston/build/cpython_dbg_build
-	cd pyston/build/cpython_dbg_build; CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl,--emit-relocs" ../../../configure --prefix=/usr --with-pydebug
+	cd pyston/build/cpython_dbg_build; CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl,--emit-relocs" ../../../configure --prefix=/usr --with-pydebug --disable-debugging-features
 pyston/build/cpython_stock_build/Makefile: $(MAKEFILE_DEPENDENCIES)
 	mkdir -p pyston/build/cpython_stock_build
 	cd pyston/build/cpython_stock_build; PROFILE_TASK="$(PROFILE_TASK) || true" CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS)" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS)" ../../../configure --prefix=/usr --enable-optimizations --with-lto --disable-pyston

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4590,6 +4590,7 @@ pyobject_malloc_without_gil(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
+#if PY_DEBUGGING_FEATURES
 static PyObject *
 tracemalloc_track(PyObject *self, PyObject *args)
 {
@@ -4661,6 +4662,7 @@ tracemalloc_get_traceback(PyObject *self, PyObject *args)
 
     return _PyTraceMalloc_GetTraceback(domain, (uintptr_t)ptr);
 }
+#endif
 
 static PyObject *
 dict_get_version(PyObject *self, PyObject *args)
@@ -5318,9 +5320,11 @@ static PyMethodDef TestMethods[] = {
     {"check_pyobject_forbidden_bytes_is_freed", check_pyobject_forbidden_bytes_is_freed, METH_NOARGS},
     {"check_pyobject_freed_is_freed", check_pyobject_freed_is_freed, METH_NOARGS},
     {"pyobject_malloc_without_gil", pyobject_malloc_without_gil, METH_NOARGS},
+#if PY_DEBUGGING_FEATURES
     {"tracemalloc_track", tracemalloc_track, METH_VARARGS},
     {"tracemalloc_untrack", tracemalloc_untrack, METH_VARARGS},
     {"tracemalloc_get_traceback", tracemalloc_get_traceback, METH_VARARGS},
+#endif
     {"dict_get_version", dict_get_version, METH_VARARGS},
     {"raise_SIGINT_then_send_None", raise_SIGINT_then_send_None, METH_VARARGS},
     {"pyobject_fastcall", test_pyobject_fastcall, METH_VARARGS},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -831,6 +831,7 @@ static PyObject *
 test_long_as_unsigned_long_long_mask(PyObject *self,
                                      PyObject *Py_UNUSED(ignored))
 {
+#if PY_DEBUGGING_CHECKS
     unsigned long long res = PyLong_AsUnsignedLongLongMask(NULL);
 
     if (res != (unsigned long long)-1 || !PyErr_Occurred()) {
@@ -844,6 +845,7 @@ test_long_as_unsigned_long_long_mask(PyObject *self,
                               "something other than SystemError");
     }
     PyErr_Clear();
+#endif
     Py_RETURN_NONE;
 }
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3675,6 +3675,7 @@ test_pymem_alloc0(PyObject *self, PyObject *Py_UNUSED(ignored))
     Py_RETURN_NONE;
 }
 
+#if PY_DEBUGGING_FEATURES
 typedef struct {
     PyMemAllocatorEx alloc;
 
@@ -3992,6 +3993,7 @@ remove_mem_hooks(PyObject *self, PyObject *Py_UNUSED(ignored))
     fm_remove_hooks();
     Py_RETURN_NONE;
 }
+#endif // PY_DEBUGGING_FEATURES
 
 PyDoc_STRVAR(docstring_empty,
 ""
@@ -4444,6 +4446,7 @@ test_PyTime_AsMicroseconds(PyObject *self, PyObject *args)
     return _PyTime_AsNanosecondsObject(ms);
 }
 
+#if PY_DEBUGGING_FEATURES
 static PyObject*
 get_recursion_depth(PyObject *self, PyObject *args)
 {
@@ -4592,7 +4595,6 @@ pyobject_malloc_without_gil(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
-#if PY_DEBUGGING_FEATURES
 static PyObject *
 tracemalloc_track(PyObject *self, PyObject *args)
 {
@@ -5252,6 +5254,7 @@ static PyMethodDef TestMethods[] = {
     {"with_tp_del",             with_tp_del,                     METH_VARARGS},
     {"create_cfunction",        create_cfunction,                METH_NOARGS},
     {"test_pymem_alloc0",       test_pymem_alloc0,               METH_NOARGS},
+#if PY_DEBUGGING_FEATURES
     {"test_pymem_setrawallocators",test_pymem_setrawallocators,  METH_NOARGS},
     {"test_pymem_setallocators",test_pymem_setallocators,        METH_NOARGS},
     {"test_pyobject_setallocators",test_pyobject_setallocators,  METH_NOARGS},
@@ -5259,6 +5262,7 @@ static PyMethodDef TestMethods[] = {
      PyDoc_STR("set_nomemory(start:int, stop:int = 0)")},
     {"remove_mem_hooks",        remove_mem_hooks,                METH_NOARGS,
      PyDoc_STR("Remove memory hooks.")},
+#endif
     {"no_docstring",
         (PyCFunction)test_with_docstring, METH_NOARGS},
     {"docstring_empty",
@@ -5312,6 +5316,7 @@ static PyMethodDef TestMethods[] = {
 #endif
     {"PyTime_AsMilliseconds", test_PyTime_AsMilliseconds, METH_VARARGS},
     {"PyTime_AsMicroseconds", test_PyTime_AsMicroseconds, METH_VARARGS},
+#if PY_DEBUGGING_FEATURES
     {"get_recursion_depth", get_recursion_depth, METH_NOARGS},
     {"pymem_buffer_overflow", pymem_buffer_overflow, METH_NOARGS},
     {"pymem_api_misuse", pymem_api_misuse, METH_NOARGS},
@@ -5322,7 +5327,6 @@ static PyMethodDef TestMethods[] = {
     {"check_pyobject_forbidden_bytes_is_freed", check_pyobject_forbidden_bytes_is_freed, METH_NOARGS},
     {"check_pyobject_freed_is_freed", check_pyobject_freed_is_freed, METH_NOARGS},
     {"pyobject_malloc_without_gil", pyobject_malloc_without_gil, METH_NOARGS},
-#if PY_DEBUGGING_FEATURES
     {"tracemalloc_track", tracemalloc_track, METH_VARARGS},
     {"tracemalloc_untrack", tracemalloc_untrack, METH_VARARGS},
     {"tracemalloc_get_traceback", tracemalloc_get_traceback, METH_VARARGS},

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -5,6 +5,7 @@
 #include "pythread.h"
 #include "osdefs.h"
 
+#if PY_DEBUGGING_FEATURES
 #include "clinic/_tracemalloc.c.h"
 /*[clinic input]
 module _tracemalloc
@@ -1768,3 +1769,16 @@ _PyTraceMalloc_GetTraceback(unsigned int domain, uintptr_t ptr)
 
     return traceback_to_pyobject(traceback, NULL);
 }
+#else //#if PY_DEBUGGING_FEATURES
+
+// Hack: it would be nice to eliminate this module entirely, but makesetup assumes that
+// every .c file in Modules will compile to a module with an init function, so just
+// provide this stub:
+PyMODINIT_FUNC
+PyInit__tracemalloc(void)
+{
+    PyErr_SetString(PyExc_ImportError,
+                    "Pyston disables tracemalloc");
+    return NULL;
+}
+#endif

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -19,6 +19,7 @@ null_error(void)
 }
 
 
+#if PY_DEBUGGING_CHECKS
 PyObject*
 _Py_CheckFunctionResult(PyObject *callable, PyObject *result, const char *where)
 {
@@ -66,6 +67,7 @@ _Py_CheckFunctionResult(PyObject *callable, PyObject *result, const char *where)
     }
     return result;
 }
+#endif
 
 
 /* --- Core PyObject call functions ------------------------------- */

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2253,7 +2253,9 @@ _PyObject_AssertFailed(PyObject *obj, const char *expr, const char *msg,
         else {
             ptr = (void *)obj;
         }
+#if PY_DEBUGGING_FEATURES
         _PyMem_DumpTraceback(fileno(stderr), ptr);
+#endif
 
         /* This might succeed or fail, but we're about to abort, so at least
            try to provide any extra info we can: */

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -81,10 +81,12 @@ static void* _PyObject_Realloc(void *ctx, void *ptr, size_t size);
 #endif
 
 
+#if PY_DEBUGGING_FEATURES
 /* bpo-35053: Declare tracemalloc configuration here rather than
    Modules/_tracemalloc.c because _tracemalloc can be compiled as dynamic
    library, whereas _Py_NewReference() requires it. */
 struct _PyTraceMalloc_Config _Py_tracemalloc_config = _PyTraceMalloc_Config_INIT;
+#endif
 
 
 static void *
@@ -2489,7 +2491,9 @@ _PyObject_DebugDumpAddress(const void *p)
     fputc('\n', stderr);
 
     fflush(stderr);
+#if PY_DEBUGGING_FEATURES
     _PyMem_DumpTraceback(fileno(stderr), p);
+#endif
 }
 
 

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -14,6 +14,7 @@ extern void _PyMem_DumpTraceback(int fd, const void *ptr);
 #define uint    unsigned int    /* assuming >= 16 bits */
 
 /* Forward declaration */
+#if PY_DEBUGGING_FEATURES
 static void* _PyMem_DebugRawMalloc(void *ctx, size_t size);
 static void* _PyMem_DebugRawCalloc(void *ctx, size_t nelem, size_t elsize);
 static void* _PyMem_DebugRawRealloc(void *ctx, void *ptr, size_t size);
@@ -23,6 +24,7 @@ static void* _PyMem_DebugMalloc(void *ctx, size_t size);
 static void* _PyMem_DebugCalloc(void *ctx, size_t nelem, size_t elsize);
 static void* _PyMem_DebugRealloc(void *ctx, void *ptr, size_t size);
 static void _PyMem_DebugFree(void *ctx, void *p);
+#endif
 
 static void _PyObject_DebugDumpAddress(const void *p);
 static void _PyMem_DebugCheckAddress(char api_id, const void *p);
@@ -177,6 +179,7 @@ _PyObject_ArenaFree(void *ctx, void *ptr, size_t size)
 }
 #endif
 
+#if PY_DEBUGGING_FEATURES
 #define MALLOC_ALLOC {NULL, _PyMem_RawMalloc, _PyMem_RawCalloc, _PyMem_RawRealloc, _PyMem_RawFree}
 #ifdef WITH_PYMALLOC
 #  define PYMALLOC_ALLOC {NULL, _PyObject_Malloc, _PyObject_Calloc, _PyObject_Realloc, _PyObject_Free}
@@ -421,6 +424,7 @@ _PyMem_GetCurrentAllocatorName(void)
     }
     return NULL;
 }
+#endif
 
 
 #undef MALLOC_ALLOC
@@ -433,6 +437,7 @@ _PyMem_GetCurrentAllocatorName(void)
 #undef PYDBGOBJ_ALLOC
 
 
+#if PY_DEBUGGING_FEATURES
 static PyObjectArenaAllocator _PyObject_Arena = {NULL,
 #ifdef MS_WINDOWS
     _PyObject_ArenaVirtualAlloc, _PyObject_ArenaVirtualFree
@@ -442,27 +447,35 @@ static PyObjectArenaAllocator _PyObject_Arena = {NULL,
     _PyObject_ArenaMalloc, _PyObject_ArenaFree
 #endif
     };
+#endif
 
 #ifdef WITH_PYMALLOC
+#if PY_DEBUGGING_FEATURES
 static int
 _PyMem_DebugEnabled(void)
 {
     return (_PyObject.malloc == _PyMem_DebugMalloc);
 }
+#endif
 
 static int
 _PyMem_PymallocEnabled(void)
 {
+#if PY_DEBUGGING_FEATURES
     if (_PyMem_DebugEnabled()) {
         return (_PyMem_Debug.obj.alloc.malloc == _PyObject_Malloc);
     }
     else {
         return (_PyObject.malloc == _PyObject_Malloc);
     }
+#else
+    return 1;
+#endif
 }
 #endif
 
 
+#if PY_DEBUGGING_FEATURES
 static void
 _PyMem_SetupDebugHooksDomain(PyMemAllocatorDomain domain)
 {
@@ -559,6 +572,7 @@ PyObject_SetArenaAllocator(PyObjectArenaAllocator *allocator)
 {
     _PyObject_Arena = *allocator;
 }
+#endif
 
 void *
 PyMem_RawMalloc(size_t size)
@@ -571,7 +585,11 @@ PyMem_RawMalloc(size_t size)
      */
     if (size > (size_t)PY_SSIZE_T_MAX)
         return NULL;
+#if PY_DEBUGGING_FEATURES
     return _PyMem_Raw.malloc(_PyMem_Raw.ctx, size);
+#else
+    return _PyMem_RawMalloc(NULL, size);
+#endif
 }
 
 void *
@@ -580,7 +598,11 @@ PyMem_RawCalloc(size_t nelem, size_t elsize)
     /* see PyMem_RawMalloc() */
     if (elsize != 0 && nelem > (size_t)PY_SSIZE_T_MAX / elsize)
         return NULL;
+#if PY_DEBUGGING_FEATURES
     return _PyMem_Raw.calloc(_PyMem_Raw.ctx, nelem, elsize);
+#else
+    return _PyMem_RawCalloc(NULL, nelem, elsize);
+#endif
 }
 
 void*
@@ -589,12 +611,20 @@ PyMem_RawRealloc(void *ptr, size_t new_size)
     /* see PyMem_RawMalloc() */
     if (new_size > (size_t)PY_SSIZE_T_MAX)
         return NULL;
+#if PY_DEBUGGING_FEATURES
     return _PyMem_Raw.realloc(_PyMem_Raw.ctx, ptr, new_size);
+#else
+    return _PyMem_RawRealloc(NULL, ptr, new_size);
+#endif
 }
 
 void PyMem_RawFree(void *ptr)
 {
+#if PY_DEBUGGING_FEATURES
     _PyMem_Raw.free(_PyMem_Raw.ctx, ptr);
+#else
+    _PyMem_RawFree(NULL, ptr);
+#endif
 }
 
 
@@ -604,7 +634,11 @@ PyMem_Malloc(size_t size)
     /* see PyMem_RawMalloc() */
     if (size > (size_t)PY_SSIZE_T_MAX)
         return NULL;
+#if PY_DEBUGGING_FEATURES
     return _PyMem.malloc(_PyMem.ctx, size);
+#else
+    return _PyObject_Malloc(NULL, size);
+#endif
 }
 
 void *
@@ -613,7 +647,11 @@ PyMem_Calloc(size_t nelem, size_t elsize)
     /* see PyMem_RawMalloc() */
     if (elsize != 0 && nelem > (size_t)PY_SSIZE_T_MAX / elsize)
         return NULL;
+#if PY_DEBUGGING_FEATURES
     return _PyMem.calloc(_PyMem.ctx, nelem, elsize);
+#else
+    return _PyObject_Calloc(NULL, nelem, elsize);
+#endif
 }
 
 void *
@@ -622,13 +660,21 @@ PyMem_Realloc(void *ptr, size_t new_size)
     /* see PyMem_RawMalloc() */
     if (new_size > (size_t)PY_SSIZE_T_MAX)
         return NULL;
+#if PY_DEBUGGING_FEATURES
     return _PyMem.realloc(_PyMem.ctx, ptr, new_size);
+#else
+    return _PyObject_Realloc(NULL, ptr, new_size);
+#endif
 }
 
 void
 PyMem_Free(void *ptr)
 {
+#if PY_DEBUGGING_FEATURES
     _PyMem.free(_PyMem.ctx, ptr);
+#else
+    _PyObject_Free(NULL, ptr);
+#endif
 }
 
 
@@ -684,7 +730,11 @@ PyObject_Malloc(size_t size)
     /* see PyMem_RawMalloc() */
     if (size > (size_t)PY_SSIZE_T_MAX)
         return NULL;
+#if PY_DEBUGGING_FEATURES
     return _PyObject.malloc(_PyObject.ctx, size);
+#else
+    return _PyObject_Malloc(NULL, size);
+#endif
 }
 
 void *
@@ -693,7 +743,11 @@ PyObject_Calloc(size_t nelem, size_t elsize)
     /* see PyMem_RawMalloc() */
     if (elsize != 0 && nelem > (size_t)PY_SSIZE_T_MAX / elsize)
         return NULL;
+#if PY_DEBUGGING_FEATURES
     return _PyObject.calloc(_PyObject.ctx, nelem, elsize);
+#else
+    return _PyObject_Calloc(NULL, nelem, elsize);
+#endif
 }
 
 void *
@@ -702,13 +756,21 @@ PyObject_Realloc(void *ptr, size_t new_size)
     /* see PyMem_RawMalloc() */
     if (new_size > (size_t)PY_SSIZE_T_MAX)
         return NULL;
+#if PY_DEBUGGING_FEATURES
     return _PyObject.realloc(_PyObject.ctx, ptr, new_size);
+#else
+    return _PyObject_Realloc(NULL, ptr, new_size);
+#endif
 }
 
 void
 PyObject_Free(void *ptr)
 {
+#if PY_DEBUGGING_FEATURES
     _PyObject.free(_PyObject.ctx, ptr);
+#else
+    _PyObject_Free(NULL, ptr);
+#endif
 }
 
 
@@ -1284,7 +1346,11 @@ new_arena(void)
     arenaobj = unused_arena_objects;
     unused_arena_objects = arenaobj->nextarena;
     assert(arenaobj->address == 0);
+#if PY_DEBUGGING_FEATURES
     address = _PyObject_Arena.alloc(_PyObject_Arena.ctx, ARENA_SIZE);
+#else
+    address = _PyObject_ArenaMmap(NULL, ARENA_SIZE);
+#endif
     if (address == NULL) {
         /* The allocation failed: return NULL after putting the
          * arenaobj back.
@@ -1801,8 +1867,13 @@ pymalloc_free(void *ctx, void *p)
         unused_arena_objects = ao;
 
         /* Free the entire arena. */
+#if PY_DEBUGGING_FEATURES
         _PyObject_Arena.free(_PyObject_Arena.ctx,
                              (void *)ao->address, ARENA_SIZE);
+#else
+        _PyObject_ArenaMunmap(NULL,
+                             (void *)ao->address, ARENA_SIZE);
+#endif
         ao->address = 0;                        /* mark unassociated */
         --narenas_currently_allocated;
 
@@ -2060,6 +2131,7 @@ write_size_t(void *p, size_t n)
     }
 }
 
+#if PY_DEBUGGING_FEATURES
 /* Let S = sizeof(size_t).  The debug malloc asks for 4 * S extra bytes and
    fills them with useful stuff, here calling the underlying malloc's result p:
 
@@ -2495,6 +2567,7 @@ _PyObject_DebugDumpAddress(const void *p)
     _PyMem_DumpTraceback(fileno(stderr), p);
 #endif
 }
+#endif
 
 
 static size_t

--- a/PC/config.c
+++ b/PC/config.c
@@ -12,7 +12,9 @@ extern PyObject* PyInit_binascii(void);
 extern PyObject* PyInit_cmath(void);
 extern PyObject* PyInit_errno(void);
 extern PyObject* PyInit_faulthandler(void);
+#if PY_DEBUGGING_FEATURES
 extern PyObject* PyInit__tracemalloc(void);
+#endif
 extern PyObject* PyInit_gc(void);
 extern PyObject* PyInit_math(void);
 extern PyObject* PyInit__md5(void);
@@ -109,7 +111,9 @@ struct _inittab _PyImport_Inittab[] = {
     {"msvcrt", PyInit_msvcrt},
     {"_locale", PyInit__locale},
 #endif
+#if PY_DEBUGGING_FEATURES
     {"_tracemalloc", PyInit__tracemalloc},
+#endif
     /* XXX Should _winapi go in a WIN32 block?  not WIN64? */
     {"_winapi", PyInit__winapi},
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -294,15 +294,19 @@ _PyImport_Fini(void)
 void
 _PyImport_Fini2(void)
 {
+#if PY_DEBUGGING_FEATURES
     /* Use the same memory allocator than PyImport_ExtendInittab(). */
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     /* Free memory allocated by PyImport_ExtendInittab() */
     PyMem_RawFree(inittab_copy);
     inittab_copy = NULL;
 
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 }
 
 /* Helper for sys */
@@ -2408,10 +2412,12 @@ PyImport_ExtendInittab(struct _inittab *newtab)
     for (i = 0; PyImport_Inittab[i].name != NULL; i++)
         ;
 
+#if PY_DEBUGGING_FEATURES
     /* Force default raw memory allocator to get a known allocator to be able
        to release the memory in _PyImport_Fini2() */
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     /* Allocate new memory for the combined table */
     p = NULL;
@@ -2433,7 +2439,9 @@ PyImport_ExtendInittab(struct _inittab *newtab)
     PyImport_Inittab = inittab_copy = p;
 
 done:
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
     return res;
 }
 

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -443,11 +443,13 @@ Py_SetStandardStreamEncoding(const char *encoding, const char *errors)
 
     int res = 0;
 
+#if PY_DEBUGGING_FEATURES
     /* Py_SetStandardStreamEncoding() can be called before Py_Initialize(),
        but Py_Initialize() can change the allocator. Use a known allocator
        to be able to release the memory later. */
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     /* Can't call PyErr_NoMemory() on errors, as Python hasn't been
      * initialised yet.
@@ -482,7 +484,9 @@ Py_SetStandardStreamEncoding(const char *encoding, const char *errors)
 #endif
 
 done:
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     return res;
 }
@@ -491,9 +495,11 @@ done:
 void
 _Py_ClearStandardStreamEncoding(void)
 {
+#if PY_DEBUGGING_FEATURES
     /* Use the same allocator than Py_SetStandardStreamEncoding() */
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     /* We won't need them anymore. */
     if (_Py_StandardStreamEncoding) {
@@ -505,7 +511,9 @@ _Py_ClearStandardStreamEncoding(void)
         _Py_StandardStreamErrors = NULL;
     }
 
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 }
 
 
@@ -518,12 +526,16 @@ static PyWideStringList orig_argv = {.length = 0, .items = NULL};
 void
 _Py_ClearArgcArgv(void)
 {
+#if PY_DEBUGGING_FEATURES
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     _PyWideStringList_Clear(&orig_argv);
 
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 }
 
 
@@ -533,12 +545,16 @@ _Py_SetArgcArgv(Py_ssize_t argc, wchar_t * const *argv)
     const PyWideStringList argv_list = {.length = argc, .items = (wchar_t **)argv};
     int res;
 
+#if PY_DEBUGGING_FEATURES
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     res = _PyWideStringList_Copy(&orig_argv, &argv_list);
 
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
     return res;
 }
 

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -40,8 +40,10 @@ pathconfig_clear(_PyPathConfig *config)
     /* _PyMem_SetDefaultAllocator() is needed to get a known memory allocator,
        since Py_SetPath(), Py_SetPythonHome() and Py_SetProgramName() can be
        called before Py_Initialize() which can changes the memory allocator. */
+#if PY_DEBUGGING_FEATURES
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
 #define CLEAR(ATTR) \
     do { \
@@ -61,7 +63,9 @@ pathconfig_clear(_PyPathConfig *config)
 
 #undef CLEAR
 
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 }
 
 
@@ -98,12 +102,16 @@ pathconfig_copy(_PyPathConfig *config, const _PyPathConfig *config2)
 void
 _PyPathConfig_ClearGlobal(void)
 {
+#if PY_DEBUGGING_FEATURES
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     pathconfig_clear(&_Py_path_config);
 
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 }
 
 
@@ -142,8 +150,10 @@ static PyStatus
 pathconfig_set_from_config(_PyPathConfig *pathconfig, const PyConfig *config)
 {
     PyStatus status;
+#if PY_DEBUGGING_FEATURES
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     if (config->module_search_paths_set) {
         PyMem_RawFree(pathconfig->module_search_path);
@@ -180,7 +190,9 @@ no_memory:
     status = _PyStatus_NO_MEMORY();
 
 done:
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
     return status;
 }
 
@@ -261,8 +273,10 @@ pathconfig_calculate(_PyPathConfig *pathconfig, const PyConfig *config)
 {
     PyStatus status;
 
+#if PY_DEBUGGING_FEATURES
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     status = pathconfig_copy(pathconfig, &_Py_path_config);
     if (_PyStatus_EXCEPTION(status)) {
@@ -282,7 +296,9 @@ pathconfig_calculate(_PyPathConfig *pathconfig, const PyConfig *config)
     }
 
 done:
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
     return status;
 }
 
@@ -447,8 +463,10 @@ Py_SetPath(const wchar_t *path)
         return;
     }
 
+#if PY_DEBUGGING_FEATURES
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     /* Getting the program full path calls pathconfig_global_init() */
     wchar_t *program_full_path = _PyMem_RawWcsdup(Py_GetProgramFullPath());
@@ -463,7 +481,9 @@ Py_SetPath(const wchar_t *path)
     _Py_path_config.exec_prefix = _PyMem_RawWcsdup(L"");
     _Py_path_config.module_search_path = _PyMem_RawWcsdup(path);
 
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     if (_Py_path_config.program_full_path == NULL
         || _Py_path_config.prefix == NULL
@@ -482,13 +502,17 @@ Py_SetPythonHome(const wchar_t *home)
         return;
     }
 
+#if PY_DEBUGGING_FEATURES
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     PyMem_RawFree(_Py_path_config.home);
     _Py_path_config.home = _PyMem_RawWcsdup(home);
 
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     if (_Py_path_config.home == NULL) {
         Py_FatalError("Py_SetPythonHome() failed: out of memory");
@@ -503,13 +527,17 @@ Py_SetProgramName(const wchar_t *program_name)
         return;
     }
 
+#if PY_DEBUGGING_FEATURES
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     PyMem_RawFree(_Py_path_config.program_name);
     _Py_path_config.program_name = _PyMem_RawWcsdup(program_name);
 
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     if (_Py_path_config.program_name == NULL) {
         Py_FatalError("Py_SetProgramName() failed: out of memory");
@@ -523,13 +551,17 @@ _Py_SetProgramFullPath(const wchar_t *program_full_path)
         return;
     }
 
+#if PY_DEBUGGING_FEATURES
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     PyMem_RawFree(_Py_path_config.program_full_path);
     _Py_path_config.program_full_path = _PyMem_RawWcsdup(program_full_path);
 
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     if (_Py_path_config.program_full_path == NULL) {
         Py_FatalError("_Py_SetProgramFullPath() failed: out of memory");

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -290,7 +290,9 @@ _PyPreConfig_InitCompatConfig(PyPreConfig *config)
     config->coerce_c_locale_warn = 0;
 
     config->dev_mode = -1;
+#if PY_DEBUGGING_FEATURES
     config->allocator = PYMEM_ALLOCATOR_NOT_SET;
+#endif
 #ifdef MS_WINDOWS
     config->legacy_windows_fs_encoding = -1;
 #endif
@@ -379,7 +381,9 @@ preconfig_copy(PyPreConfig *config, const PyPreConfig *config2)
     COPY_ATTR(coerce_c_locale);
     COPY_ATTR(coerce_c_locale_warn);
     COPY_ATTR(utf8_mode);
+#if PY_DEBUGGING_FEATURES
     COPY_ATTR(allocator);
+#endif
 #ifdef MS_WINDOWS
     COPY_ATTR(legacy_windows_fs_encoding);
 #endif
@@ -423,7 +427,9 @@ _PyPreConfig_AsDict(const PyPreConfig *config)
     SET_ITEM_INT(legacy_windows_fs_encoding);
 #endif
     SET_ITEM_INT(dev_mode);
+#if PY_DEBUGGING_FEATURES
     SET_ITEM_INT(allocator);
+#endif
     return dict;
 
 fail:
@@ -700,6 +706,7 @@ preconfig_init_coerce_c_locale(PyPreConfig *config)
 }
 
 
+#if PY_DEBUGGING_FEATURES
 static PyStatus
 preconfig_init_allocator(PyPreConfig *config)
 {
@@ -723,6 +730,7 @@ preconfig_init_allocator(PyPreConfig *config)
     }
     return _PyStatus_OK();
 }
+#endif
 
 
 static PyStatus
@@ -751,11 +759,13 @@ preconfig_read(PyPreConfig *config, _PyPreCmdline *cmdline)
         return status;
     }
 
+#if PY_DEBUGGING_FEATURES
     /* allocator */
     status = preconfig_init_allocator(config);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
+#endif
 
     assert(config->coerce_c_locale >= 0);
     assert(config->coerce_c_locale_warn >= 0);
@@ -939,12 +949,14 @@ _PyPreConfig_Write(const PyPreConfig *src_config)
         return _PyStatus_OK();
     }
 
+#if PY_DEBUGGING_FEATURES
     PyMemAllocatorName name = (PyMemAllocatorName)config.allocator;
     if (name != PYMEM_ALLOCATOR_NOT_SET) {
         if (_PyMem_SetupAllocators(name) < 0) {
             return _PyStatus_ERR("Unknown PYTHONMALLOC allocator");
         }
     }
+#endif
 
     preconfig_set_global_vars(&config);
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -971,9 +971,11 @@ pyinit_main(_PyRuntimeState *runtime, PyInterpreterState *interp)
         return _PyStatus_ERR("can't initialize signals");
     }
 
+#if PY_DEBUGGING_FEATURES
     if (_PyTraceMalloc_Init(config->tracemalloc) < 0) {
         return _PyStatus_ERR("can't initialize tracemalloc");
     }
+#endif
 
     status = add_main_module(interp);
     if (_PyStatus_EXCEPTION(status)) {
@@ -1275,9 +1277,11 @@ Py_FinalizeEx(void)
     _PyGC_CollectIfEnabled();
 #endif
 
+#if PY_DEBUGGING_FEATURES
     /* Disable tracemalloc after all Python objects have been destroyed,
        so it is possible to use tracemalloc in objects destructor. */
     _PyTraceMalloc_Fini();
+#endif
 
     /* Destroy the database used by _PyImport_{Fixup,Find}Extension */
     _PyImport_Fini();

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2016,6 +2016,12 @@ list_builtin_module_names(void)
     if (list == NULL)
         return NULL;
     for (i = 0; PyImport_Inittab[i].name != NULL; i++) {
+#if !PY_DEBUGGING_FEATURES
+        // It's easier to blacklist _tracemalloc here than update Modules/makesetup
+        // to not include it in the first place
+        if (!strcmp(PyImport_Inittab[i].name, "_tracemalloc"))
+            continue;
+#endif
         PyObject *name = PyUnicode_FromString(
             PyImport_Inittab[i].name);
         if (name == NULL)

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1721,6 +1721,7 @@ sys_gettotalrefcount_impl(PyObject *module)
 }
 #endif /* Py_REF_DEBUG */
 
+#if PY_DEBUGGING_FEATURES
 /*[clinic input]
 sys.getallocatedblocks -> Py_ssize_t
 
@@ -1733,6 +1734,7 @@ sys_getallocatedblocks_impl(PyObject *module)
 {
     return _Py_GetAllocatedBlocks();
 }
+#endif
 
 #ifdef COUNT_ALLOCS
 /*[clinic input]
@@ -1965,7 +1967,9 @@ static PyMethodDef sys_methods[] = {
     SYS_EXIT_METHODDEF
     SYS_GETDEFAULTENCODING_METHODDEF
     SYS_GETDLOPENFLAGS_METHODDEF
+#if PY_DEBUGGING_FEATURES
     SYS_GETALLOCATEDBLOCKS_METHODDEF
+#endif
     SYS_GETCOUNTS_METHODDEF
 #ifdef DYNAMIC_EXECUTION_PROFILE
     {"getdxp",          _Py_GetDXProfile, METH_VARARGS},
@@ -2072,11 +2076,13 @@ _alloc_preinit_entry(const wchar_t *value)
     /* To get this to work, we have to initialize the runtime implicitly */
     _PyRuntime_Initialize();
 
+#if PY_DEBUGGING_FEATURES
     /* Force default allocator, so we can ensure that it also gets used to
      * destroy the linked list in _clear_preinit_entries.
      */
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 
     _Py_PreInitEntry node = PyMem_RawCalloc(1, sizeof(*node));
     if (node != NULL) {
@@ -2087,7 +2093,9 @@ _alloc_preinit_entry(const wchar_t *value)
         };
     };
 
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
     return node;
 }
 
@@ -2118,16 +2126,20 @@ _clear_preinit_entries(_Py_PreInitEntry *optionlist)
 {
     _Py_PreInitEntry current = *optionlist;
     *optionlist = NULL;
+#if PY_DEBUGGING_FEATURES
     /* Deallocate the nodes and their contents using the default allocator */
     PyMemAllocatorEx old_alloc;
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
     while (current != NULL) {
         _Py_PreInitEntry next = current->next;
         PyMem_RawFree(current->value);
         PyMem_RawFree(current);
         current = next;
     }
+#if PY_DEBUGGING_FEATURES
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+#endif
 }
 
 

--- a/configure
+++ b/configure
@@ -822,6 +822,7 @@ with_assertions
 enable_optimizations
 enable_pyston
 enable_aot
+enable_debugging_features
 with_lto
 with_hash_algorithm
 with_address_sanitizer
@@ -1498,6 +1499,8 @@ Optional Features:
                           Disabled by default.
   --disable-pyston        Disable non-jit Pyston speedups.
   --disable-aot           Disable AOT traces and the JIT.
+  --disable-debugging-features
+                          Disable various debugging features for performance.
   --enable-loadable-sqlite-extensions
                           support loadable extensions in _sqlite module
   --enable-ipv6           Enable ipv6 (with ipv4) support
@@ -6518,6 +6521,37 @@ if test "$USE_AOT" != "false"
 then
     CFLAGS="$CFLAGS -DENABLE_AOT"
 fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for --disable-debugging-features" >&5
+$as_echo_n "checking for --disable-debugging-features... " >&6; }
+# Check whether --enable-debugging-features was given.
+if test "${enable_debugging_features+set}" = set; then :
+  enableval=$enable_debugging_features;
+if test "$enableval" != no
+then
+  $as_echo "#define PY_DEBUGGING_FEATURES 1" >>confdefs.h
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+  # 'a' for "asserts" ('d' makes more sense but is already taken)
+  ABIFLAGS="${ABIFLAGS}a"
+else
+  $as_echo "#define PY_DEBUGGING_FEATURES 0" >>confdefs.h
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+else
+
+  $as_echo "#define PY_DEBUGGING_FEATURES 1" >>confdefs.h
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+  # 'a' for "asserts" ('d' makes more sense but is already taken)
+  ABIFLAGS="${ABIFLAGS}a"
+
+fi
+
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking PROFILE_TASK" >&5
@@ -15289,7 +15323,7 @@ SOABI=${IMPLEMENTATION_NAME}-`echo ${SOABI_VERSION} | tr -d .`${ABIFLAGS}${PLATF
 $as_echo "$SOABI" >&6; }
 if test $PYSTON != no; then
 
-    UNSAFE_SOABI=cpython-`echo ${VERSION} | tr -d .`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+    UNSAFE_SOABI=cpython-`echo ${VERSION} | tr -d .``echo ${ABIFLAGS} | tr -d a`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
 fi
 
 # Release and debug (Py_DEBUG) ABI are compatible, but not Py_TRACE_REFS ABI
@@ -15307,6 +15341,7 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 fi
+
 
 EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX}
 

--- a/configure.ac
+++ b/configure.ac
@@ -1347,6 +1347,26 @@ then
     CFLAGS="$CFLAGS -DENABLE_AOT"
 fi
 
+AC_MSG_CHECKING(for --disable-debugging-features)
+AC_ARG_ENABLE(debugging-features, AS_HELP_STRING([--disable-debugging-features], [Disable various debugging features for performance.]),
+[
+if test "$enableval" != no
+then
+  AC_DEFINE(PY_DEBUGGING_FEATURES, 1, [])
+  AC_MSG_RESULT(no)
+  # 'a' for "asserts" ('d' makes more sense but is already taken)
+  ABIFLAGS="${ABIFLAGS}a"
+else
+  AC_DEFINE(PY_DEBUGGING_FEATURES, 0, [])
+  AC_MSG_RESULT(yes)
+fi],
+[
+  AC_DEFINE(PY_DEBUGGING_FEATURES, 1, [])
+  AC_MSG_RESULT(no)
+  # 'a' for "asserts" ('d' makes more sense but is already taken)
+  ABIFLAGS="${ABIFLAGS}a"
+])
+
 AC_ARG_VAR(PROFILE_TASK, Python args for PGO generation task)
 AC_MSG_CHECKING(PROFILE_TASK)
 if test -z "$PROFILE_TASK"
@@ -4723,7 +4743,7 @@ SOABI=${IMPLEMENTATION_NAME}-`echo ${SOABI_VERSION} | tr -d .`${ABIFLAGS}${PLATF
 AC_MSG_RESULT($SOABI)
 if test $PYSTON != no; then
     AC_SUBST(UNSAFE_SOABI)
-    UNSAFE_SOABI=cpython-`echo ${VERSION} | tr -d .`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+    UNSAFE_SOABI=cpython-`echo ${VERSION} | tr -d .``echo ${ABIFLAGS} | tr -d a`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
 fi
 
 # Release and debug (Py_DEBUG) ABI are compatible, but not Py_TRACE_REFS ABI

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1656,6 +1656,8 @@
 
 #undef IMPLEMENTATION_NAME
 
+#undef PY_DEBUGGING_FEATURES
+
 /* Define the macros needed if on a UnixWare 7.x system. */
 #if defined(__USLC__) && defined(__SCO_VERSION__)
 #define STRICT_SYSV_CURSES /* Don't use ncurses extensions */


### PR DESCRIPTION
This PR removes
- tracemalloc
- _Py_CheckFunctionResult
- PyErr_BadInternalCall (and thus the checks surrounding it)
- recursion checking

Here are the perf results:
```
4086eaa3 26.66+-0.04              net -15.7% Add a --disable-debug-checks configure flag
0ed12549 26.52+-0.03  -0.5%+-0.2% net -16.2% Remove tracemalloc
7a1680e5 26.39+-0.04  -0.5%+-0.2% net -16.6% Remove _Py_CheckFunctionResult
0f35dd42 26.36+-0.02  -0.1%+-0.1% net -16.7% Remove PyErr_BadInternalCall
4fe43a54 26.29+-0.04  -0.3%+-0.1% net -16.9% Disable recursion checking
```

The numbers per change are somewhat variable (usually I see that tracemalloc is smaller and recursion checking is bigger) but the >1% total improvement seems consistent.

This is probably one of the biggest semantic changes that we'd be making so I think we should talk about it first.  I'm not really sure though how to get feedback about this, other than just putting out a release without them and seeing if people ask for them back.