### PR TITLE
new jit entry

### DIFF
--- a/Include/internal/aot_ceval_jit_helper.h
+++ b/Include/internal/aot_ceval_jit_helper.h
@@ -21,6 +21,10 @@ extern "C" {
 #define JIT_HELPER_WITH_NAME_OPCACHE_AOT1(name_, py1) PyObject* JIT_HELPER_##name_(PyObject* name, PyObject* py1, _PyOpcache *co_opcache)
 #define JIT_HELPER_WITH_NAME_OPCACHE_AOT2(name_, py1, py2) PyObject* JIT_HELPER_##name_(PyObject* name, PyObject* py1, PyObject* py2, _PyOpcache *co_opcache)
 
+long JIT_HELPER_EXCEPTION_UNWIND();
+PyObject* JIT_HELPER_DEOPT(int jit_first_trace_for_line);
+void JIT_HELPER_TRACEFUNC();
+PyObject* JIT_HELPER_USE_TRACING(PyObject* retval);
 
 JIT_HELPER1(UNARY_NOT, value);
 JIT_HELPER1(PRINT_EXPR, value);

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -102,6 +102,11 @@ intern_string_constants(PyObject *tuple)
     return modified;
 }
 
+#if PYSTON_SPEEDUPS && ENABLE_AOT
+PyObject* _Py_HOT_FUNCTION
+_PyEval_EvalFrame_AOT_EntryInterpreter(struct PyFrameObject *f, int throwflag, PyThreadState * const tstate, PyObject** stack_pointer);
+#endif
+
 PyCodeObject *
 PyCode_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount,
                           int nlocals, int stacksize, int flags,
@@ -241,7 +246,11 @@ PyCode_NewWithPosOnlyArgs(int argcount, int posonlyargcount, int kwonlyargcount,
     co->co_opcache_size = 0;
 #if PYSTON_SPEEDUPS
     co->co_builtins_cache_ver = 0;
+#if ENABLE_AOT
+    co->co_jit_code = _PyEval_EvalFrame_AOT_EntryInterpreter;
+#else
     co->co_jit_code = 0;
+#endif
 #endif
     return co;
 }


### PR DESCRIPTION
After an embarrassing long time I finally found all the bugs and it works without failing any tests.
I was expecting that the segfault I tracked down was a bug in the current JIT code but it actually was only a bugs introduced by an old version of this change.
Unfortunately I can't measure any speedup with this change :( (maybe even small slowdown). I verified that the generated code by the compiler is now what I expected. So this is quite disappointing.
Not sure what to do with it now, it does move some C stuff to harder to maintain asm code but on the other hand it removes
all this special return value handling inside `_PyEval_EvalFrame_AOT_JIT`.

- gets rid of `_PyEval_EvalFrame_AOT_JIT`
- instead we include the code inside the JIT compiled code
- this means e.g. if a exception is caught we will stay inside the generated code and jump directly to the continue block
- we don't have to encode magic bits into the return value of `jit_code()` because it will now either return a valid `PyObject*` or `0`.
- `_PyEval_EvalFrame_AOT` main part is a single indirect branch which either jumps to:
    - `_PyEval_EvalFrame_AOT_EntryInterpreter` (default)
    - `_PyEval_EvalFrame_AOT_EntryJitFailed` (goes to interpreter but does not jit again)
    - pointer to jitted code