### PR TITLE
add script to benchmark release packages

### DIFF
--- a/pyston/tools/bench_release.sh
+++ b/pyston/tools/bench_release.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+VERSION=2.2
+INPUT_DIR=${PWD}/release/${VERSION}
+OUTPUT_DIR=`realpath ${INPUT_DIR}/bench`
+
+if [ -d $OUTPUT_DIR ]
+then
+    echo "Directory $OUTPUT_DIR already exists";
+    exit 1
+fi
+mkdir -p $OUTPUT_DIR
+
+for DIST in 16.04 18.04 20.04
+do
+    echo "Benchmarking $DIST release"
+    # mount input dir readonly to make sure we are not accidently modifying it
+    docker run -iv${INPUT_DIR}:/host-volume-in:ro -iv${OUTPUT_DIR}:/host-volume-out --rm ubuntu:$DIST sh -s <<EOF
+set -ex
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get upgrade -y
+apt-get install -y build-essential git time libffi-dev
+# pillow deps:
+apt-get install -y libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk libharfbuzz-dev libfribidi-dev libxcb1-dev
+
+git clone https://github.com/pyston/python-macrobenchmarks.git
+# disble pytorch test
+sed -i 's/pytorch_alexnet_inference//g' python-macrobenchmarks/run_all.sh
+
+# pyston deb package
+apt-get install -y /host-volume-in/pyston_${VERSION}_${DIST}.deb
+pyston -mpip install pyperformance virtualenv
+pyston -mpyperformance run -f -o /host-volume-out/pyston_${VERSION}_${DIST}.json
+chown -R $(id -u):$(id -g) /host-volume-out/pyston_${VERSION}_${DIST}.json
+
+python-macrobenchmarks/run_all.sh /usr/bin/pyston
+mv results /host-volume-out/results_pyston_${DIST}
+chown -R $(id -u):$(id -g) /host-volume-out/results_pyston_${DIST}
+
+# cpython
+# some benchmarks don't run on python 3.5/3.6 so only run this benchmarks on 3.8 (20.04)
+if [ "$DIST" = "20.04" ]; then
+    apt-get install -y python3 python3-dev python3-pip python3-venv
+    pyston -mpyperformance run -f -p /usr/bin/python3 -o /host-volume-out/cpython_${DIST}.json
+    chown -R $(id -u):$(id -g) /host-volume-out/cpython_${DIST}.json
+    pyston -mpyperformance compare -O table /host-volume-out/cpython_${DIST}.json /host-volume-out/pyston_${VERSION}_${DIST}.json > /host-volume-out/pyperformance_diff_${DIST}.txt
+    chown -R $(id -u):$(id -g) /host-volume-out/pyperformance_diff_${DIST}.txt
+    
+    python-macrobenchmarks/run_all.sh /usr/bin/python3
+    mv results /host-volume-out/results_cpython_${DIST}
+    chown -R $(id -u):$(id -g) /host-volume-out/results_cpython_${DIST}
+fi
+EOF
+done
+
+echo "FINISHED: wrote benchmark results to $OUTPUT_DIR"
+
+# display a summary of the benchmark results:
+cat ${OUTPUT_DIR}/pyperformance_diff_20.04.txt
+
+for f in ${OUTPUT_DIR}/results_pyston_20.04/*.out
+do
+    echo "benchmark: `basename $f`"
+    for DIST in 16.04 18.04 20.04
+    do
+        f_pyston=${f/20.04/$DIST}
+        f_cpython=${f_pyston/results_pyston/results_cpython}
+        t_pyston=`cat $f_pyston | grep 'User time' | cut -d' ' -f4`
+        if [ -f "$f_cpython" ]; then
+            t_cpython=`cat $f_cpython | grep 'User time' | cut -d' ' -f4`
+            echo "  $DIST# pyston: $t_pyston cpython: $t_cpython"
+	else
+            echo "  $DIST# pyston: $t_pyston"
+        fi
+    done
+done
+


### PR DESCRIPTION
This script runs our benchmarks and pyperformance on all supported distros.
It will save the benchmark results and display a summary.
Idea is that this script makes it easier to spot a problem with a release
because they should all have similar performance also it makes sure
that every package can at least run the benchmarks without problems.

As I know I'm not familiar with bash script so there may be some stupid bugs :/ but here is the output I got for our 2.2 rc0 packages:
```
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| Benchmark               | cpython_20.04.json | pyston_2.2_20.04.json | Change       | Significance           |
+=========================+====================+=======================+==============+========================+
| 2to3                    | 397 ms             | 256 ms                | 1.55x faster | Significant (t=188.77) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| chameleon               | 12.5 ms            | 6.78 ms               | 1.85x faster | Significant (t=55.96)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| chaos                   | 139 ms             | 60.6 ms               | 2.29x faster | Significant (t=243.01) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| crypto_pyaes            | 128 ms             | 76.8 ms               | 1.66x faster | Significant (t=146.87) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| deltablue               | 9.30 ms            | 4.70 ms               | 1.98x faster | Significant (t=140.49) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| django_template         | 65.7 ms            | 36.1 ms               | 1.82x faster | Significant (t=43.21)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| dulwich_log             | 77.9 ms            | 39.1 ms               | 1.99x faster | Significant (t=259.41) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| fannkuch                | 632 ms             | 367 ms                | 1.72x faster | Significant (t=392.18) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| float                   | 142 ms             | 72.0 ms               | 1.97x faster | Significant (t=358.36) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| genshi_text             | 40.5 ms            | 21.8 ms               | 1.86x faster | Significant (t=94.55)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| genshi_xml              | 83.1 ms            | 46.3 ms               | 1.80x faster | Significant (t=72.10)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| go                      | 331 ms             | 170 ms                | 1.94x faster | Significant (t=317.07) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| hexiom                  | 13.1 ms            | 6.42 ms               | 2.04x faster | Significant (t=502.56) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| json_dumps              | 15.1 ms            | 11.9 ms               | 1.27x faster | Significant (t=100.97) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| json_loads              | 26.5 us            | 25.3 us               | 1.05x faster | Significant (t=21.54)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| logging_format          | 11.1 us            | 4.97 us               | 2.23x faster | Significant (t=210.69) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| logging_silent          | 270 ns             | 141 ns                | 1.91x faster | Significant (t=37.46)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| logging_simple          | 10.3 us            | 4.62 us               | 2.23x faster | Significant (t=117.40) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| mako                    | 20.3 ms            | 11.7 ms               | 1.73x faster | Significant (t=278.40) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| meteor_contest          | 125 ms             | 93.1 ms               | 1.35x faster | Significant (t=64.09)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| nbody                   | 154 ms             | 61.4 ms               | 2.51x faster | Significant (t=697.07) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| nqueens                 | 124 ms             | 77.0 ms               | 1.60x faster | Significant (t=64.35)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| pathlib                 | 22.9 ms            | 18.2 ms               | 1.26x faster | Significant (t=103.15) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| pickle                  | 10.7 us            | 9.57 us               | 1.12x faster | Significant (t=62.14)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| pickle_dict             | 21.4 us            | 21.7 us               | 1.01x slower | Not significant        |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| pickle_list             | 3.09 us            | 3.07 us               | 1.01x faster | Not significant        |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| pickle_pure_python      | 611 us             | 282 us                | 2.16x faster | Significant (t=67.22)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| pidigits                | 179 ms             | 178 ms                | 1.01x faster | Not significant        |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| pyflate                 | 909 ms             | 532 ms                | 1.71x faster | Significant (t=258.54) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| python_startup          | 7.98 ms            | 7.68 ms               | 1.04x faster | Significant (t=111.31) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| python_startup_no_site  | 5.29 ms            | 5.12 ms               | 1.03x faster | Significant (t=90.11)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| raytrace                | 639 ms             | 311 ms                | 2.06x faster | Significant (t=333.18) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| regex_compile           | 222 ms             | 93.4 ms               | 2.38x faster | Significant (t=152.15) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| regex_dna               | 171 ms             | 180 ms                | 1.05x slower | Significant (t=-14.86) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| regex_effbot            | 3.22 ms            | 3.16 ms               | 1.02x faster | Not significant        |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| regex_v8                | 25.3 ms            | 24.4 ms               | 1.04x faster | Significant (t=29.44)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| richards                | 94.3 ms            | 51.0 ms               | 1.85x faster | Significant (t=184.70) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| scimark_fft             | 387 ms             | 233 ms                | 1.66x faster | Significant (t=125.63) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| scimark_lu              | 193 ms             | 99.8 ms               | 1.93x faster | Significant (t=85.65)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| scimark_monte_carlo     | 124 ms             | 48.4 ms               | 2.56x faster | Significant (t=291.59) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| scimark_sor             | 244 ms             | 106 ms                | 2.30x faster | Significant (t=297.60) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| scimark_sparse_mat_mult | 5.26 ms            | 3.02 ms               | 1.74x faster | Significant (t=70.29)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| spectral_norm           | 177 ms             | 99.6 ms               | 1.77x faster | Significant (t=116.17) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| sqlalchemy_declarative  | 168 ms             | 115 ms                | 1.47x faster | Significant (t=53.00)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| sqlalchemy_imperative   | 29.8 ms            | 15.9 ms               | 1.87x faster | Significant (t=268.70) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| sqlite_synth            | 3.52 us            | 2.91 us               | 1.21x faster | Significant (t=49.37)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| sympy_expand            | 601 ms             | 326 ms                | 1.85x faster | Significant (t=142.89) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| sympy_integrate         | 27.8 ms            | 17.2 ms               | 1.61x faster | Significant (t=111.98) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| sympy_str               | 386 ms             | 210 ms                | 1.84x faster | Significant (t=295.10) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| sympy_sum               | 230 ms             | 133 ms                | 1.73x faster | Significant (t=182.00) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| telco                   | 7.60 ms            | 5.58 ms               | 1.36x faster | Significant (t=102.08) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| tornado_http            | 144 ms             | 84.2 ms               | 1.71x faster | Significant (t=89.20)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| unpack_sequence         | 141 ns             | 76.6 ns               | 1.84x faster | Significant (t=200.97) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| unpickle                | 16.6 us            | 15.7 us               | 1.06x faster | Significant (t=27.64)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| unpickle_list           | 7.61 us            | 7.12 us               | 1.07x faster | Significant (t=69.14)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| unpickle_pure_python    | 461 us             | 208 us                | 2.22x faster | Significant (t=75.66)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| xml_etree_generate      | 113 ms             | 81.7 ms               | 1.38x faster | Significant (t=70.11)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| xml_etree_iterparse     | 116 ms             | 92.4 ms               | 1.26x faster | Significant (t=139.45) |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| xml_etree_parse         | 169 ms             | 158 ms                | 1.07x faster | Significant (t=23.17)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
| xml_etree_process       | 91.3 ms            | 62.2 ms               | 1.47x faster | Significant (t=71.64)  |
+-------------------------+--------------------+-----------------------+--------------+------------------------+
benchmark: aiohttp.out
  16.04# pyston: 2.18 
  18.04# pyston: 2.19 
  20.04# pyston: 2.13 cpython: 3.13
benchmark: djangocms.out
  16.04# pyston: 14.14 
  18.04# pyston: 12.62 
  20.04# pyston: 13.44 cpython: 18.75
benchmark: flaskblogging.out
  16.04# pyston: 5.52 
  18.04# pyston: 5.65 
  20.04# pyston: 5.57 cpython: 8.16
benchmark: gevent_bench_hub.out
  16.04# pyston: 5.65 
  18.04# pyston: 5.33 
  20.04# pyston: 5.15 cpython: 5.89
benchmark: gunicorn.out
  16.04# pyston: 2.09 
  18.04# pyston: 2.09 
  20.04# pyston: 2.12 cpython: 3.13
benchmark: mypy_bench.out
  16.04# pyston: 16.16 
  18.04# pyston: 16.04 
  20.04# pyston: 16.04 cpython: 6.27
benchmark: pycparser_bench.out
  16.04# pyston: 25.86 
  18.04# pyston: 25.58 
  20.04# pyston: 25.52 cpython: 43.65
benchmark: pylint_bench.out
  16.04# pyston: 4.93 
  18.04# pyston: 5.02 
  20.04# pyston: 5.03 cpython: 6.77
benchmark: thrift_bench.out
  16.04# pyston: 0.81 
  18.04# pyston: 0.81 
  20.04# pyston: 0.81 cpython: 1.21
```