### PR TITLE
Remove UNSAFE_ABI mode

### DIFF
--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -422,13 +422,6 @@ def _init_posix(vars):
     _temp = __import__(name, globals(), locals(), ['build_time_vars'], 0)
     build_time_vars = _temp.build_time_vars
 
-    if "Pyston" in sys.version and sys.implementation.name == "cpython":
-        # unsafe abi mode detected
-        # It's not clear if it's better to overwrite SOABI, since that means
-        # we would create builds with the unsafe soabi suffix
-        # build_time_vars["SOABI"] = build_time_vars["UNSAFE_SOABI"]
-        pass
-
     vars.update(build_time_vars)
 
 def _init_non_posix(vars):

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -40,7 +40,6 @@ LINKCC=		@LINKCC@
 AR=		@AR@
 READELF=	@READELF@
 SOABI=		@SOABI@
-UNSAFE_SOABI=		@UNSAFE_SOABI@
 LDVERSION=	@LDVERSION@
 LIBPYTHON=	@LIBPYTHON@
 GITVERSION=	@GITVERSION@
@@ -796,7 +795,6 @@ Modules/signalmodule.o: $(srcdir)/Modules/signalmodule.c $(srcdir)/Modules/posix
 Python/dynload_shlib.o: $(srcdir)/Python/dynload_shlib.c Makefile
 	$(CC) -c $(PY_CORE_CFLAGS) \
 		-DSOABI='"$(SOABI)"' \
-		-DUNSAFE_SOABI='"$(UNSAFE_SOABI)"' \
 		-o $@ $(srcdir)/Python/dynload_shlib.c
 
 Python/dynload_hpux.o: $(srcdir)/Python/dynload_hpux.c Makefile

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -47,27 +47,6 @@ const char *_PyImport_DynLoadFiletab[] = {
     NULL,
 };
 
-// In unsafe-abi mode, add the cpython abis to the end of the filetab
-#if PYSTON_SPEEDUPS
-const char *_PyImport_UnsafeDynLoadFiletab[] = {
-#ifdef __CYGWIN__
-    ".dll",
-#else  /* !__CYGWIN__ */
-    "." SOABI ".so",
-#ifdef ALT_SOABI
-    "." ALT_SOABI ".so",
-#endif
-    ".abi" PYTHON_ABI_STRING ".so",
-    ".so",
-    "." UNSAFE_SOABI ".so",
-#ifdef UNSAFE_ALT_SOABI
-    "." UNSAFE_ALT_SOABI ".so",
-#endif
-#endif  /* __CYGWIN__ */
-    NULL,
-};
-#endif
-
 static struct {
     dev_t dev;
     ino_t ino;

--- a/Python/import.c
+++ b/Python/import.c
@@ -2058,14 +2058,7 @@ _imp_extension_suffixes_impl(PyObject *module)
     const char *suffix;
     unsigned int index = 0;
 
-    const char** filetab = _PyImport_DynLoadFiletab;
-#if PYSTON_SPEEDUPS
-    const char *envar = getenv("PYSTON_UNSAFE_ABI");
-    if (envar && atoll(envar)) {
-        filetab = _PyImport_UnsafeDynLoadFiletab;
-    }
-#endif
-    while ((suffix = filetab[index])) {
+    while ((suffix = _PyImport_DynLoadFiletab[index])) {
         PyObject *item = PyUnicode_FromString(suffix);
         if (item == NULL) {
             Py_DECREF(list);

--- a/Python/importdl.h
+++ b/Python/importdl.h
@@ -7,9 +7,6 @@ extern "C" {
 
 
 extern const char *_PyImport_DynLoadFiletab[];
-#if PYSTON_SPEEDUPS
-extern const char *_PyImport_UnsafeDynLoadFiletab[];
-#endif
 
 extern PyObject *_PyImport_LoadDynamicModuleWithSpec(PyObject *spec, FILE *);
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2616,11 +2616,6 @@ const char *_PySys_ImplName = IMPLEMENTATION_NAME;
 #endif
 #define TAG IMPLEMENTATION_NAME "-" MAJOR MINOR
 const char *_PySys_ImplCacheTag = TAG;
-#if PYSTON_SPEEDUPS
-#define UNSAFE_TAG "cpython" "-" Py_STRINGIFY(PY_MAJOR_VERSION) Py_STRINGIFY(PY_MINOR_VERSION)
-const char *_PySys_UnsafeImplCacheTag = UNSAFE_TAG;
-const char *_PySys_UnsafeImplName = "cpython";
-#endif
 #undef MAJOR
 #undef MINOR
 #undef TAG
@@ -2637,16 +2632,7 @@ make_impl_info(PyObject *version_info)
 
     /* populate the dict */
 
-#if PYSTON_SPEEDUPS
-    const char *envar = getenv("PYSTON_UNSAFE_ABI");
-    int unsafe_abi = envar && atoll(envar);
-    if (unsafe_abi)
-        value = PyUnicode_FromString(_PySys_UnsafeImplName);
-    else
-        value = PyUnicode_FromString(_PySys_ImplName);
-#else
     value = PyUnicode_FromString(_PySys_ImplName);
-#endif
     if (value == NULL)
         goto error;
     res = PyDict_SetItemString(impl_info, "name", value);
@@ -2654,14 +2640,7 @@ make_impl_info(PyObject *version_info)
     if (res < 0)
         goto error;
 
-#if PYSTON_SPEEDUPS
-    if (unsafe_abi)
-        value = PyUnicode_FromString(_PySys_UnsafeImplCacheTag);
-    else
-        value = PyUnicode_FromString(_PySys_ImplCacheTag);
-#else
     value = PyUnicode_FromString(_PySys_ImplCacheTag);
-#endif
     if (value == NULL)
         goto error;
     res = PyDict_SetItemString(impl_info, "cache_tag", value);

--- a/configure
+++ b/configure
@@ -633,9 +633,7 @@ LIBPL
 PY_ENABLE_SHARED
 LIBPYTHON
 EXT_SUFFIX
-UNSAFE_ALT_SOABI
 ALT_SOABI
-UNSAFE_SOABI
 SOABI
 LIBC
 LIBM
@@ -15321,20 +15319,12 @@ _ACEOF
 SOABI=${IMPLEMENTATION_NAME}-`echo ${SOABI_VERSION} | tr -d .`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $SOABI" >&5
 $as_echo "$SOABI" >&6; }
-if test $PYSTON != no; then
-
-    UNSAFE_SOABI=cpython-`echo ${VERSION} | tr -d .``echo ${ABIFLAGS} | tr -d a`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
-fi
 
 # Release and debug (Py_DEBUG) ABI are compatible, but not Py_TRACE_REFS ABI
 if test "$Py_DEBUG" = 'true' -a "$with_trace_refs" != "yes"; then
   # Similar to SOABI but remove "d" flag from ABIFLAGS
 
   ALT_SOABI=${IMPLEMENTATION_NAME}-`echo ${SOABI_VERSION} | tr -d .``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
-  if test $PYSTON != no; then
-
-      UNSAFE_ALT_SOABI=cpython-`echo ${VERSION} | tr -d .``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
-  fi
 
 cat >>confdefs.h <<_ACEOF
 #define ALT_SOABI "${ALT_SOABI}"

--- a/configure.ac
+++ b/configure.ac
@@ -4741,20 +4741,12 @@ AC_DEFINE_UNQUOTED(IMPLEMENTATION_NAME, "${IMPLEMENTATION_NAME}")
 
 SOABI=${IMPLEMENTATION_NAME}-`echo ${SOABI_VERSION} | tr -d .`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
 AC_MSG_RESULT($SOABI)
-if test $PYSTON != no; then
-    AC_SUBST(UNSAFE_SOABI)
-    UNSAFE_SOABI=cpython-`echo ${VERSION} | tr -d .``echo ${ABIFLAGS} | tr -d a`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
-fi
 
 # Release and debug (Py_DEBUG) ABI are compatible, but not Py_TRACE_REFS ABI
 if test "$Py_DEBUG" = 'true' -a "$with_trace_refs" != "yes"; then
   # Similar to SOABI but remove "d" flag from ABIFLAGS
   AC_SUBST(ALT_SOABI)
   ALT_SOABI=${IMPLEMENTATION_NAME}-`echo ${SOABI_VERSION} | tr -d .``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
-  if test $PYSTON != no; then
-      AC_SUBST(UNSAFE_ALT_SOABI)
-      UNSAFE_ALT_SOABI=cpython-`echo ${VERSION} | tr -d .``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
-  fi
   AC_DEFINE_UNQUOTED(ALT_SOABI, "${ALT_SOABI}",
             [Alternative SOABI used in debug build to load C extensions built in release mode])
 fi

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -15,7 +15,6 @@
 /* Alternative SOABI used in debug build to load C extensions built in release
    mode */
 #undef ALT_SOABI
-#undef UNSAFE_ALT_SOABI
 
 /* The Android API level. */
 #undef ANDROID_API_LEVEL


### PR DESCRIPTION
Our ABI has diverged enough that this is unlikely to work and is more scary than it was before.


I'm open to the idea of trying to make it work (add stub functions for all of the functions we turned into macros), but I feel like this is something we'll remove later anyway.