### PR TITLE
Remove usage of /usr/bin/time

### DIFF
--- a/pyston/run_profile_task.py
+++ b/pyston/run_profile_task.py
@@ -2,10 +2,10 @@ import os
 import subprocess
 import sys
 
-exe = sys.executable
+exe = os.path.abspath(sys.executable)
 
 def run(bench, *args):
-    subprocess.check_call(["/usr/bin/time", exe, bench] + list(args))
+    subprocess.check_call([exe, bench] + list(args))
 
 if __name__ == "__main__":
     os.chdir(os.path.dirname(__file__))


### PR DESCRIPTION
It's no longer necessary since we only use this script as a profile task
and don't look at the output.

Should fix the second issue in #22 