### PR TITLE
fix dockerfiles after bolt update

### DIFF
--- a/pyston/Dockerfile.16.04
+++ b/pyston/Dockerfile.16.04
@@ -18,6 +18,12 @@ RUN apt-get update
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository -y --enable-source ppa:deadsnakes/ppa
 
+# need newer cmake for bolts llvm
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+RUN add-apt-repository -y 'deb https://apt.kitware.com/ubuntu/ xenial main'
+
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -y build-essential ninja-build cmake clang libssl-dev libsqlite3-dev luajit libjemalloc-dev
@@ -46,9 +52,6 @@ RUN git config --global user.name "Your Name"
 
 # copy over whole nitrous dir except of stuff excluded via .dockerignore
 COPY . /src/build/
-
-RUN cd pyston/bolt/llvm && git stash && cd /src/build/
-RUN rm pyston/bolt/llvm/tools/llvm-bolt pyston/bolt/llvm/include/llvm/Support/Alignment.h
 
 # run this to build the package
 #RUN make package

--- a/pyston/Dockerfile.18.04
+++ b/pyston/Dockerfile.18.04
@@ -5,8 +5,14 @@ WORKDIR /src/build
 # have to set this else apt will ask for a config for tzdata
 ARG DEBIAN_FRONTEND=noninteractive
 
-# python3.8 is in universal 
+# python3.8 is in universal
 RUN echo 'deb-src http://archive.ubuntu.com/ubuntu/ bionic-updates universe' >> /etc/apt/sources.list
+
+# need newer cmake for bolts llvm
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+RUN add-apt-repository -y 'deb https://apt.kitware.com/ubuntu/ bionic main'
 
 RUN apt-get update
 RUN apt-get upgrade -y
@@ -42,9 +48,6 @@ RUN git config --global user.name "Your Name"
 
 # copy over whole nitrous dir except of stuff excluded via .dockerignore
 COPY . /src/build/
-
-RUN cd pyston/bolt/llvm && git stash && cd /src/build/
-RUN rm pyston/bolt/llvm/tools/llvm-bolt pyston/bolt/llvm/include/llvm/Support/Alignment.h
 
 # run this to build the package
 #RUN make package

--- a/pyston/Dockerfile.20.04
+++ b/pyston/Dockerfile.20.04
@@ -35,8 +35,5 @@ RUN git config --global user.name "Your Name"
 # copy over whole nitrous dir except of stuff excluded via .dockerignore
 COPY . /src/build/
 
-RUN cd pyston/bolt/llvm && git stash && cd /src/build/
-RUN rm pyston/bolt/llvm/tools/llvm-bolt pyston/bolt/llvm/include/llvm/Support/Alignment.h
-
 # run this to build the package
 #RUN make package


### PR DESCRIPTION
- 16.04 and 18.04 come with an to old cmake - use newest cmake directly from kitware
20.04 is new enough so I just used the stock ubuntu one (which means it will be older then the one on 16.04 and 18.04)

- remove pyston/bolt/llvm stuff