### PR TITLE
Backport -fno-semantic-interposition from cpython

### DIFF
--- a/configure
+++ b/configure
@@ -6470,6 +6470,14 @@ if test "$Py_OPT" = 'true' ; then
   DEF_MAKE_ALL_RULE="profile-opt"
   REQUIRE_PGO="yes"
   DEF_MAKE_RULE="build_all"
+  case $CC in
+    *gcc*)
+      CFLAGS_NODIST="$CFLAGS_NODIST -fno-semantic-interposition"
+      LDFLAGS_NODIST="$LDFLAGS_NODIST -fno-semantic-interposition"
+      ;;
+  esac
+
+
 else
   DEF_MAKE_ALL_RULE="build_all"
   REQUIRE_PGO="no"

--- a/configure.ac
+++ b/configure.ac
@@ -1309,6 +1309,14 @@ if test "$Py_OPT" = 'true' ; then
   DEF_MAKE_ALL_RULE="profile-opt"
   REQUIRE_PGO="yes"
   DEF_MAKE_RULE="build_all"
+  case $CC in
+    *gcc*)
+      CFLAGS_NODIST="$CFLAGS_NODIST -fno-semantic-interposition"
+      LDFLAGS_NODIST="$LDFLAGS_NODIST -fno-semantic-interposition"
+      ;;
+  esac
+
+
 else
   DEF_MAKE_ALL_RULE="build_all"
   REQUIRE_PGO="no"


### PR DESCRIPTION
In https://bugs.python.org/issue38980 they mention that they get a 1.3x speedup with `-fno-semantic-interposition` for the `--enable-shared` build. Now that we support soon this build type it likely makes sense to use the same.
I did not measure that big speedup but nbody improves from 8.78s -> 8.59s on the optshared pyston binary.

Original commit:
bpo-38980: Add -fno-semantic-interposition when building with optimizations (GH-22862)