### PR TITLE
fix release packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -440,8 +440,9 @@ stocktest: pyston/build/cpython_stockunopt_build/python
 	$(MAKE) -C pyston/build/cpython_stockunopt_build test
 dbg_test: python/test/dbg_method_call_unopt
 
+# llvm-bolt must be build outside of dpkg-buildpackage or it will segfault
 .PHONY: package
-package:
+package: bolt
 ifeq ($(shell lsb_release -sr),16.04)
 	# 16.04 needs this file but on newer ubuntu versions it will make it fail
 	echo 10 > pyston/debian/compat

--- a/pyston/tools/make_portable_dir.py
+++ b/pyston/tools/make_portable_dir.py
@@ -103,11 +103,15 @@ def set_rpath(f, rpath):
 def is_so(filename):
     return filename.endswith(".so")
 
-
 def make_portable_dir(outdir):
     dependencies = recursive_get_dependencies(
         Dependency("pyston", outdir + "/usr/bin/pyston"))
-    path = outdir + "/usr/lib/pyston3.8/lib-dynload/"
+
+    # get output lib directory
+    paths = glob.glob(outdir + "/usr/lib/python3.8-pyston*/lib-dynload/")
+    assert len(paths) == 1 and paths[0].endswith("/")
+    path = paths[0]
+
     for f in filter(is_so, os.listdir(path)):
         dependencies |= recursive_get_dependencies(Dependency(f, path + f))
         set_rpath(path + f, "$ORIGIN/../../../lib")


### PR DESCRIPTION
- llvm-bolt crashes while instrumenting when build via `dpkg-buildpackage`. Building it before fixes the issue.
- make_portable_dir.py: change dir from `/usr/lib/pyston3.8/lib-dynload/` to `/usr/lib/python3.8-pyston2.2/lib-dynload/`

With this changes I can create release packages again.