### PR TITLE
Backport tp_vectorcall changes and improve AOT traces

### DIFF
--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -71,9 +71,12 @@ PyAPI_FUNC(int) _PyArg_UnpackStack(
     ...);
 
 PyAPI_FUNC(int) _PyArg_NoKeywords(const char *funcname, PyObject *kwargs);
+PyAPI_FUNC(int) _PyArg_NoKwnames(const char *funcname, PyObject *kwnames);
 PyAPI_FUNC(int) _PyArg_NoPositional(const char *funcname, PyObject *args);
 #define _PyArg_NoKeywords(funcname, kwargs) \
     ((kwargs) == NULL || _PyArg_NoKeywords((funcname), (kwargs)))
+#define _PyArg_NoKwnames(funcname, kwnames) \
+    ((kwnames) == NULL || _PyArg_NoKwnames((funcname), (kwnames)))
 #define _PyArg_NoPositional(funcname, args) \
     ((args) == NULL || _PyArg_NoPositional((funcname), (args)))
 

--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -64,6 +64,9 @@ class GeneralFloatCases(unittest.TestCase):
         # See bpo-34087
         self.assertRaises(ValueError, float, '\u3053\u3093\u306b\u3061\u306f')
 
+    def test_noargs(self):
+        self.assertEqual(float(), 0.0)
+
     def test_underscores(self):
         for lit in VALID_UNDERSCORE_LITERALS:
             if not any(ch in lit for ch in 'jJxXoObB'):

--- a/Makefile
+++ b/Makefile
@@ -263,16 +263,16 @@ endef
 $(call make_aot_build,aot,)
 $(call make_aot_build,aot_pic,--pic)
 
-dbg_aot_trace: pyston/aot/all.bc pyston/aot/aot_pre_trace.so pyston/aot/aot_gen.py pyston/build/cpython_bc_install/usr/bin/python3 build_dbg
-	cd pyston/aot; rm -f aot_module*.bc
-	cd pyston/aot; LD_LIBRARY_PATH="`pwd`/../build/PartialDebug/nitrous/:`pwd`/../build/PartialDebug/pystol/" gdb --args ../build/cpython_bc_install/usr/bin/python3 aot_gen.py -vv --action=trace
-	cd pyston/aot; ls -al aot_module*.bc | wc -l
+dbg_aot_trace: pyston/build/aot/all.bc pyston/build/aot/aot_pre_trace.so pyston/aot/aot_gen.py pyston/build/cpython_bc_install/usr/bin/python3 build_dbg
+	cd pyston/build/aot; rm -f aot_module*.bc
+	cd pyston/build/aot; LD_LIBRARY_PATH="`pwd`/../PartialDebug/nitrous/:`pwd`/../PartialDebug/pystol/" gdb --args ../cpython_bc_install/usr/bin/python3 ../../aot/aot_gen.py -vv --action=trace
+	cd pyston/build/aot; ls -al aot_module*.bc | wc -l
 
-aot_trace_only: pyston/aot/all.bc pyston/aot/aot_pre_trace.so pyston/aot/aot_gen.py pyston/build/cpython_bc_install/usr/bin/python3 pyston/build/Release/nitrous/libinterp.so pyston/build/Release/pystol/libpystol.so
-	cd pyston/aot; LD_LIBRARY_PATH="`pwd`/../build/Release/nitrous/:`pwd`/../build/Release/pystol/" ../build/cpython_bc_install/usr/bin/python3 aot_gen.py --action=trace -vv --only=$(ONLY)
+aot_trace_only: pyston/build/aot/all.bc pyston/build/aot/aot_pre_trace.so pyston/aot/aot_gen.py pyston/build/cpython_bc_install/usr/bin/python3 pyston/build/Release/nitrous/libinterp.so pyston/build/Release/pystol/libpystol.so
+	cd pyston/build/aot; LD_LIBRARY_PATH="`pwd`/../Release/nitrous/:`pwd`/../Release/pystol/" ../cpython_bc_install/usr/bin/python3 ../../aot/aot_gen.py --action=trace -vv --only=$(ONLY)
 
-dbg_aot_trace_only: pyston/aot/all.bc pyston/aot/aot_pre_trace.so pyston/aot/aot_gen.py pyston/build/cpython_bc_install/usr/bin/python3 build_dbg
-	cd pyston/aot; LD_LIBRARY_PATH="`pwd`/../build/PartialDebug/nitrous/:`pwd`/../build/PartialDebug/pystol/" gdb --ex run --args ../build/cpython_bc_install/usr/bin/python3 aot_gen.py --action=trace -vv --only=$(ONLY)
+dbg_aot_trace_only: pyston/build/aot/all.bc pyston/build/aot/aot_pre_trace.so pyston/aot/aot_gen.py pyston/build/cpython_bc_install/usr/bin/python3 build_dbg
+	cd pyston/build/aot; LD_LIBRARY_PATH="`pwd`/../PartialDebug/nitrous/:`pwd`/../PartialDebug/pystol/" gdb --ex run --args ../cpython_bc_install/usr/bin/python3 ../../aot/aot_gen.py --action=trace -vv --only=$(ONLY)
 
 PYPERF:=pyston/build/system_env/bin/pyperf command -w 0 -l 1 -p 1 -n $(or $(N),$(N),3) -v --affinity 0
 

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -55,6 +55,30 @@ bool_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return PyBool_FromLong(ok);
 }
 
+/* static */ PyObject *
+bool_vectorcall(PyObject *type, PyObject * const*args,
+                size_t nargsf, PyObject *kwnames)
+{
+    long ok = 0;
+    if (!_PyArg_NoKwnames("bool", kwnames)) {
+        return NULL;
+    }
+
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (!_PyArg_CheckPositional("bool", nargs, 0, 1)) {
+        return NULL;
+    }
+
+    assert(PyType_Check(type));
+    if (nargs) {
+        ok = PyObject_IsTrue(args[0]);
+    }
+    if (ok < 0) {
+        return NULL;
+    }
+    return PyBool_FromLong(ok);
+}
+
 /* Arithmetic operations redefined to return bool if both args are bool. */
 
 /* static */ PyObject *
@@ -170,6 +194,7 @@ PyTypeObject PyBool_Type = {
     0,                                          /* tp_init */
     0,                                          /* tp_alloc */
     bool_new,                                   /* tp_new */
+    .tp_vectorcall = bool_vectorcall,
 };
 
 /* The objects representing bool values False and True */

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1639,6 +1639,24 @@ float_subtype_new(PyTypeObject *type, PyObject *x)
     return newobj;
 }
 
+/* static */ PyObject *
+float_vectorcall(PyObject *type, PyObject * const*args,
+                 size_t nargsf, PyObject *kwnames)
+{
+    if (!_PyArg_NoKwnames("float", kwnames)) {
+        return NULL;
+    }
+
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (!_PyArg_CheckPositional("float", nargs, 0, 1)) {
+        return NULL;
+    }
+
+    PyObject *x = nargs >= 1 ? args[0] : _PyLong_Zero;
+    return float_new_impl((PyTypeObject *)type, x);
+}
+
+
 /*[clinic input]
 float.__getnewargs__
 [clinic start generated code]*/
@@ -1924,6 +1942,7 @@ PyTypeObject PyFloat_Type = {
     0,                                          /* tp_init */
     0,                                          /* tp_alloc */
     float_new,                                  /* tp_new */
+    .tp_vectorcall = (vectorcallfunc)float_vectorcall,
 };
 
 int

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2761,6 +2761,33 @@ list___init___impl(PyListObject *self, PyObject *iterable)
     return 0;
 }
 
+/*static*/ PyObject *
+list_vectorcall(PyObject *type, PyObject * const*args,
+                size_t nargsf, PyObject *kwnames)
+{
+    if (!_PyArg_NoKwnames("list", kwnames)) {
+        return NULL;
+    }
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (!_PyArg_CheckPositional("list", nargs, 0, 1)) {
+        return NULL;
+    }
+
+    assert(PyType_Check(type));
+    PyObject *list = PyType_GenericAlloc((PyTypeObject *)type, 0);
+    if (list == NULL) {
+        return NULL;
+    }
+    if (nargs) {
+        if (list___init___impl((PyListObject *)list, args[0])) {
+            Py_DECREF(list);
+            return NULL;
+        }
+    }
+    return list;
+}
+
+
 /*[clinic input]
 list.__sizeof__
 
@@ -3074,6 +3101,7 @@ PyTypeObject PyList_Type = {
     PyType_GenericAlloc,                        /* tp_alloc */
     PyType_GenericNew,                          /* tp_new */
     PyObject_GC_Del,                            /* tp_free */
+    .tp_vectorcall = list_vectorcall,
 };
 
 /*********************** List Iterator **************************/

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -146,8 +146,7 @@ range_vectorcall(PyTypeObject *type, PyObject *const *args,
                  size_t nargsf, PyObject *kwnames)
 {
     Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
-    if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
-        PyErr_Format(PyExc_TypeError, "range() takes no keyword arguments");
+    if (!_PyArg_NoKwnames("range", kwnames)) {
         return NULL;
     }
     return range_from_array(type, args, nargs);

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2000,6 +2000,28 @@ set_init(PySetObject *self, PyObject *args, PyObject *kwds)
     return set_update_internal(self, iterable);
 }
 
+/* static */ PyObject*
+set_vectorcall(PyObject *type, PyObject * const*args,
+               size_t nargsf, PyObject *kwnames)
+{
+    assert(PyType_Check(type));
+
+    if (!_PyArg_NoKwnames("set", kwnames)) {
+        return NULL;
+    }
+
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (!_PyArg_CheckPositional("set", nargs, 0, 1)) {
+        return NULL;
+    }
+
+    if (nargs) {
+        return make_new_set((PyTypeObject *)type, args[0]);
+    }
+
+    return make_new_set((PyTypeObject *)type, NULL);
+}
+
 /* static */ PySequenceMethods set_as_sequence = {
     set_len,                            /* sq_length */
     0,                                  /* sq_concat */
@@ -2148,6 +2170,7 @@ PyTypeObject PySet_Type = {
     PyType_GenericAlloc,                /* tp_alloc */
     set_new,                            /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
+    .tp_vectorcall = set_vectorcall,
 };
 
 /* frozenset object ********************************************************/

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -846,8 +846,7 @@ tuple_new_impl(PyTypeObject *type, PyObject *iterable)
 tuple_vectorcall(PyObject *type, PyObject * const*args,
                  size_t nargsf, PyObject *kwnames)
 {
-    if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
-        PyErr_Format(PyExc_TypeError, "tuple() takes no keyword arguments");
+    if (!_PyArg_NoKwnames("tuple", kwnames)) {
         return NULL;
     }
     Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -849,9 +849,9 @@ tuple_vectorcall(PyObject *type, PyObject * const*args,
     if (!_PyArg_NoKwnames("tuple", kwnames)) {
         return NULL;
     }
+
     Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
-    if (nargs > 1) {
-        PyErr_Format(PyExc_TypeError, "tuple() expected at most 1 argument, got %zd", nargs);
+    if (!_PyArg_CheckPositional("tuple", nargs, 0, 1)) {
         return NULL;
     }
 

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -843,6 +843,26 @@ tuple_new_impl(PyTypeObject *type, PyObject *iterable)
 }
 
 /* static */ PyObject *
+tuple_vectorcall(PyObject *type, PyObject * const*args,
+                 size_t nargsf, PyObject *kwnames)
+{
+    if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
+        PyErr_Format(PyExc_TypeError, "tuple() takes no keyword arguments");
+        return NULL;
+    }
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (nargs > 1) {
+        PyErr_Format(PyExc_TypeError, "tuple() expected at most 1 argument, got %zd", nargs);
+        return NULL;
+    }
+
+    if (nargs) {
+        return tuple_new_impl((PyTypeObject *)type, args[0]);
+    }
+    return PyTuple_New(0);
+}
+
+/* static */ PyObject *
 tuple_subtype_new(PyTypeObject *type, PyObject *iterable)
 {
     PyObject *tmp, *newobj, *item;
@@ -1002,6 +1022,7 @@ PyTypeObject PyTuple_Type = {
     0,                                          /* tp_alloc */
     tuple_new,                                  /* tp_new */
     PyObject_GC_Del,                            /* tp_free */
+    .tp_vectorcall = tuple_vectorcall,
 };
 
 /* The following function breaks the notion that tuples are immutable:

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3738,7 +3738,7 @@ PyTypeObject PyType_Type = {
     sizeof(PyHeapTypeObject),                   /* tp_basicsize */
     sizeof(PyMemberDef),                        /* tp_itemsize */
     (destructor)type_dealloc,                   /* tp_dealloc */
-    0,                                          /* tp_vectorcall_offset */
+    offsetof(PyTypeObject, tp_vectorcall),      /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_as_async */
@@ -3753,7 +3753,8 @@ PyTypeObject PyType_Type = {
     (setattrofunc)type_setattro,                /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE | Py_TPFLAGS_TYPE_SUBCLASS,         /* tp_flags */
+    Py_TPFLAGS_BASETYPE | Py_TPFLAGS_TYPE_SUBCLASS |
+    _Py_TPFLAGS_HAVE_VECTORCALL,                /* tp_flags */
     type_doc,                                   /* tp_doc */
     (traverseproc)type_traverse,                /* tp_traverse */
     (inquiry)type_clear,                        /* tp_clear */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2922,6 +2922,24 @@ error:
     return NULL;
 }
 
+/*static*/ PyObject *
+type_vectorcall(PyObject *metatype, PyObject *const *args,
+                 size_t nargsf, PyObject *kwnames)
+{
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (nargs == 1 && metatype == (PyObject *)&PyType_Type){
+        if (!_PyArg_NoKwnames("type", kwnames)) {
+            return NULL;
+        }
+        PyTypeObject* type = Py_TYPE(args[0]);
+        Py_INCREF(type);
+        return type;
+    }
+    /* In other (much less common) cases, fall back to
+       more flexible calling conventions. */
+    return _PyObject_MakeTpCall(metatype, args, nargs, kwnames);
+}
+
 /* static */ const short slotoffsets[] = {
     -1, /* invalid slot */
 #include "typeslots.inc"
@@ -3775,6 +3793,7 @@ PyTypeObject PyType_Type = {
     type_new,                                   /* tp_new */
     PyObject_GC_Del,                            /* tp_free */
     (inquiry)type_is_gc,                        /* tp_is_gc */
+    .tp_vectorcall = type_vectorcall,
 };
 
 

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -2163,9 +2163,8 @@ void* jit_func(PyCodeObject* co, PyThreadState* tstate) {
             deferred_vs_apply(Dst);
             | mov arg1, tstate
 
-            // arg2 = &sp
-            | mov [rsp], vsp
-            | mov arg2, rsp
+            // arg2 = vsp
+            | mov arg2, vsp
 
             emit_mov_imm(Dst, arg3_idx, oparg);
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5039,12 +5039,12 @@ call_function_ceval(PyThreadState *tstate, PyObject ***pp_stack, Py_ssize_t opar
 }
 
 PyObject * _Py_HOT_FUNCTION
-call_function_ceval_no_kw(PyThreadState *tstate, PyObject ***pp_stack, Py_ssize_t oparg) {
-    return call_function_ceval(tstate, pp_stack, oparg, NULL /*kwnames*/);
+call_function_ceval_no_kw(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg) {
+    return call_function_ceval(tstate, &stack, oparg, NULL /*kwnames*/);
 }
 PyObject * _Py_HOT_FUNCTION
-call_method_ceval_no_kw(PyThreadState *tstate, PyObject ***pp_stack, Py_ssize_t oparg) {
-    return call_function_ceval(tstate, pp_stack, oparg, NULL /*kwnames*/);
+call_method_ceval_no_kw(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg) {
+    return call_function_ceval(tstate, &stack, oparg, NULL /*kwnames*/);
 }
 PyObject* PyNumber_PowerNone(PyObject *v, PyObject *w) {
   return PyNumber_Power(v, w, Py_None);

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2895,6 +2895,7 @@ _PyArg_UnpackStack(PyObject *const *args, Py_ssize_t nargs, const char *name,
 
 
 #undef _PyArg_NoKeywords
+#undef _PyArg_NoKwnames
 #undef _PyArg_NoPositional
 
 /* For type constructors that don't take keyword args
@@ -2921,7 +2922,6 @@ _PyArg_NoKeywords(const char *funcname, PyObject *kwargs)
     return 0;
 }
 
-
 int
 _PyArg_NoPositional(const char *funcname, PyObject *args)
 {
@@ -2936,6 +2936,23 @@ _PyArg_NoPositional(const char *funcname, PyObject *args)
 
     PyErr_Format(PyExc_TypeError, "%.200s() takes no positional arguments",
                     funcname);
+    return 0;
+}
+
+int
+_PyArg_NoKwnames(const char *funcname, PyObject *kwnames)
+{
+    if (kwnames == NULL) {
+        return 1;
+    }
+
+    assert(PyTuple_CheckExact(kwnames));
+
+    if (PyTuple_GET_SIZE(kwnames) == 0) {
+        return 1;
+    }
+
+    PyErr_Format(PyExc_TypeError, "%s() takes no keyword arguments", funcname);
     return 0;
 }
 

--- a/pyston/aot/aot_gen.py
+++ b/pyston/aot/aot_gen.py
@@ -425,10 +425,12 @@ def loadCases():
              "Bool": [(bool, (1,), (False,))],
              "Type": [(type, (1,))],
              "Object": [(object, ())],
-             # "Tuple": [(tuple, ([1,2,3], ), ((1,2,3), ))]
+             "Tuple": [(tuple, ([1,2,3], ), ((1,2,3), ))],
+             "List": [(list, ([1,2,3], ), ((1,2,3), ))],
+             "Set": [(set, ([1,2,3], ), ((1,2,3), ))],
 
              # TODO: e.g.:
-             # super, list, tuple, set, staticmethod, classmethod, property
+             # super, staticmethod, classmethod, property
              # what can we do for python classes?
 
              }

--- a/pyston/pystol/pystol.cpp
+++ b/pyston/pystol/pystol.cpp
@@ -1006,6 +1006,7 @@ void pystolAddConstObj(PyObject* x) {
 void pystolAddConstType(PyTypeObject* x) {
     // refcount is never zero but not const!
     MARKNOTZERO(&x->ob_base.ob_base.ob_refcnt, sizeof(x->ob_base.ob_base.ob_refcnt));
+    MARKCONST(&x->ob_base.ob_base.ob_type, sizeof(x->ob_base.ob_base.ob_type));
 
     MARKCONST(&x->tp_name, sizeof(x->tp_name));
     MARKCONST(&x->tp_basicsize, sizeof(x->tp_basicsize));
@@ -1076,5 +1077,7 @@ void pystolAddConstType(PyTypeObject* x) {
 
     // not const in AOT mode:
     // addImmortalTuple(x->tp_mro);
+
+    MARKCONST(&x->tp_vectorcall, sizeof(x->tp_vectorcall));
 }
 }


### PR DESCRIPTION
This example:
```python
def f():
    l = [1,2,3]
    for i in range(10000000):
        type(l)
        list(l)
        tuple(l)
        set(l)
        float(42)
        bool(1)
        range(1)
f()
```
Takes now:
```
cpython 3.8.5: 5.41s
pyston before: 2.54s
pyston new   : 1.94s
```

- generated code is good with the change to pystol
- added traces for `list`, `tuple` and `set`
- had to change most patches slightly e.g. `/* static */` or where they depend on previous unrelated patches.
- I did not backport all of them: e.g. `frozenset` and `dict` are missing
- our testsuite is currently failing on my machine (cpython testsuite is working) so I could not test it on everything yet
-  should I add `PYSTON_SPEEDUPS` ifdefs around all changes?