### PR TITLE
AOT: add isinstance() traces

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2829,6 +2829,9 @@ static struct PyModuleDef builtinsmodule = {
     NULL
 };
 
+#if PYSTON_SPEEDUPS
+PyObject* builtin_isinstance_obj;
+#endif
 
 PyObject *
 _PyBuiltin_Init(void)
@@ -2901,6 +2904,10 @@ _PyBuiltin_Init(void)
         return NULL;
     }
     Py_DECREF(debug);
+
+#if PYSTON_SPEEDUPS
+    builtin_isinstance_obj = PyDict_GetItemString(dict, "isinstance");
+#endif
 
     return mod;
 #undef ADD_TO_ALL


### PR DESCRIPTION
this adds traces for the builtin `isinstance()` function.
It type specializes it also to the second argument and uses `PyType_FastSubclass()` when possible.

I notices a frequent call to `isinstance(x, (str,))` thats why I also added a special case for a tuple with single element.

This improves the following code from 0.96 to 0.64s:
```python
def f():
    t = (str,)
    for i in range(10000000):
        isinstance(1, int)
        isinstance(1, int)
        isinstance(1, int)
        isinstance(1, int)
        isinstance(1, int)
        isinstance("", t)
        isinstance("", t)
        isinstance("", t)
        isinstance("", t)
        isinstance("", t)
```

I'm not eliminating yet all overhead/inlining to the `builtin_isinstance()` call but working on it in a
new PR because I run into some problems.