### PR TITLE
AOT: add __builtin_assume() for CALL_{FUNCTION,METHOD} traces

### DIFF
--- a/pyston/aot/aot_gen.py
+++ b/pyston/aot/aot_gen.py
@@ -359,6 +359,10 @@ class CallableHandler(Handler):
             print(f"    __builtin_assume(ret != (PyObject*)0x1);", file=f)
             print(f"    return ret;", file=f)
             print("  }", file=f)
+
+            for assumption in signature.getAssumptions(arg_names):
+                print(f"  __builtin_assume({assumption});", file=f)
+
             for line in signature.getSpecialTracingCode(arg_names):
                 print(f"  {line}", file=f)
             print(f"  return {self.case.unspecialized_name}(tstate, stack, oparg);", file=f)


### PR DESCRIPTION
this eliminates a few NULL pointer checks.
E.g. `call_function_ceval_no_kwFloat2` will remove one (verified by looking at the IR code and disassembly)

This was easier then I expected :smile: 