### PR TITLE
Pystol: remove refcount changes to immortal objects

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1838,12 +1838,22 @@ PyObject _Py_NotImplementedStruct = {
 PyStatus
 _PyTypes_Init(void)
 {
+#if PYSTON_SPEEDUPS
+#define INIT_TYPE(TYPE, NAME) \
+    do { \
+        if (PyType_Ready(TYPE) < 0) { \
+            return _PyStatus_ERR("Can't initialize " NAME " type"); \
+        } \
+        MAKE_IMMORTAL((PyObject*)TYPE); \
+    } while (0)
+#else
 #define INIT_TYPE(TYPE, NAME) \
     do { \
         if (PyType_Ready(TYPE) < 0) { \
             return _PyStatus_ERR("Can't initialize " NAME " type"); \
         } \
     } while (0)
+#endif
 
     INIT_TYPE(&PyBaseObject_Type, "object");
     INIT_TYPE(&PyType_Type, "type");

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2907,6 +2907,7 @@ _PyBuiltin_Init(void)
 
 #if PYSTON_SPEEDUPS
     builtin_isinstance_obj = PyDict_GetItemString(dict, "isinstance");
+    MAKE_IMMORTAL(builtin_isinstance_obj);
 #endif
 
     return mod;

--- a/pyston/nitrous/jit.cpp
+++ b/pyston/nitrous/jit.cpp
@@ -684,8 +684,8 @@ struct RemoveICmpPtrPass : public FunctionPass {
 };
 char RemoveICmpPtrPass::ID = 0;
 
-vector<function<FunctionPass*()>> pass_factories;
-void registerPassFactory(function<FunctionPass*()> factory) {
+vector<function<FunctionPass*(LLVMEvaluator& eval)>> pass_factories;
+void registerPassFactory(function<FunctionPass*(LLVMEvaluator& eval)> factory) {
     pass_factories.push_back(move(factory));
 }
 
@@ -746,7 +746,7 @@ void LLVMJit::optimizeFunc(LLVMEvaluator& eval) {
         //fpm.add(new RemoveICmpPtrPass(eval));
 
         for (auto& factory : pass_factories) {
-            fpm.add(factory());
+            fpm.add(factory(eval));
             fpm.add(llvm::createInstructionCombiningPass());
         }
 

--- a/pyston/nitrous/optimization_hooks.h
+++ b/pyston/nitrous/optimization_hooks.h
@@ -181,7 +181,7 @@ public:
 
 void registerFactDeriver(std::unique_ptr<FactDeriver> deriver);
 
-void registerPassFactory(std::function<llvm::FunctionPass*()> factory);
+void registerPassFactory(std::function<llvm::FunctionPass*(LLVMEvaluator& eval)> factory);
 
 }
 

--- a/pyston/pystol/pystol.cpp
+++ b/pyston/pystol/pystol.cpp
@@ -100,8 +100,12 @@ bool isNamedStructPointer(Type* t, const char* name) {
     return st->getName() == name;
 }
 
-static bool isPyObjectPtr(Type* t) {
+bool isPyObjectPtr(Type* t) {
     return isNamedStructPointer(t, "struct._object");
+}
+
+bool isPyTypeObjectPtr(Type* t) {
+    return isNamedStructPointer(t, "struct._typeobject");
 }
 
 static Knowledge* getTypeFact(Value* v, FactSet& facts) {
@@ -420,7 +424,7 @@ void pystolGlobalPythonSetup() {
     addConstTypeAndConstSubclasses(&PyBaseObject_Type);
 
     registerFactDeriver(make_unique<PystolFactDeriver>());
-    registerPassFactory([] { return new RemoveRecursionChecksPass(); });
+    registerPassFactory([](LLVMEvaluator& eval) { return new RemoveRecursionChecksPass(); });
     registerPassFactory(createMiscOptsPass);
     registerPassFactory(createExceptionTrackingPass);
 }

--- a/pyston/pystol/pystol_internal.h
+++ b/pyston/pystol/pystol_internal.h
@@ -240,7 +240,11 @@ public:
     bool runOnFunction(llvm::Function &F) override;
 };
 
-llvm::FunctionPass* createExceptionTrackingPass();
-llvm::FunctionPass* createMiscOptsPass();
+llvm::FunctionPass* createExceptionTrackingPass(nitrous::LLVMEvaluator& eval);
+llvm::FunctionPass* createMiscOptsPass(nitrous::LLVMEvaluator& eval);
+
+
+bool isPyObjectPtr(llvm::Type* t);
+bool isPyTypeObjectPtr(llvm::Type* t);
 
 } // namespace pystol


### PR DESCRIPTION
If we know that always the same immortal object is decref/increfed we can
remove the update.
E.g for `call_function_ceval_no_kwisinstanceLong3` we have a `Py_DECREF(stack[-oparg+1])`
but we do guard that `stack[-oparg+1] == (PyObject*)&PyLong_Type` so we know that we can remove it.

This is triggering on a lot of our traces.
It's currently not yet triggering for `builtin_isinstance_obj` because the python object
is heap allocated but I'm trying to solve this in the near future.