### PR TITLE
AOT: trace into builtin isinstance, len, ord 

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -39,6 +39,7 @@ typedef struct _Py_Identifier {
 #define _Py_string_init(value) { .next = NULL, .string = value, .object = NULL }
 #define _Py_string(varname, value)  _Py_Identifier varname = _Py_string_init(value)
 #define _Py_NONSTATIC_IDENTIFIER(varname) _Py_string(PyId_##varname, #varname)
+#define _Py_EXTERN_NONSTATIC_IDENTIFIER(varname) extern _Py_Identifier PyId_##varname
 
 /* buffer interface */
 typedef struct bufferinfo {

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -2421,12 +2421,13 @@ check_class(PyObject *cls, const char *error)
     return -1;
 }
 
+_Py_EXTERN_NONSTATIC_IDENTIFIER(__class__); // defined in typeobject.c
 /* static */ int
 recursive_isinstance(PyObject *inst, PyObject *cls)
 {
     PyObject *icls;
     int retval;
-    _Py_IDENTIFIER(__class__);
+    //_Py_IDENTIFIER(__class__);
 
     if (PyType_Check(cls)) {
         retval = PyObject_TypeCheck(inst, (PyTypeObject *)cls);
@@ -2459,10 +2460,11 @@ recursive_isinstance(PyObject *inst, PyObject *cls)
     return retval;
 }
 
+_Py_NONSTATIC_IDENTIFIER(__instancecheck__);
 int
 PyObject_IsInstance(PyObject *inst, PyObject *cls)
 {
-    _Py_IDENTIFIER(__instancecheck__);
+    //_Py_IDENTIFIER(__instancecheck__);
     PyObject *checker;
 
     /* Quick test for an exact match */

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -298,6 +298,10 @@ PyByteArray_Concat(PyObject *a, PyObject *b)
 static Py_ssize_t
 bytearray_length(PyByteArrayObject *self)
 {
+#if PYSTON_SPEEDUPS
+    if (Py_SIZE(self) < 0)
+        __builtin_unreachable();
+#endif
     return Py_SIZE(self);
 }
 

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1423,6 +1423,10 @@ bytes_str(PyObject *op)
 static Py_ssize_t
 bytes_length(PyBytesObject *a)
 {
+#if PYSTON_SPEEDUPS
+    if (Py_SIZE(a) < 0)
+        __builtin_unreachable();
+#endif
     return Py_SIZE(a);
 }
 

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -157,7 +157,7 @@ member_get(PyMemberDescrObject *descr, PyObject *obj, PyObject *type)
     return PyMember_GetOne((char *)obj, descr->d_member);
 }
 
-static PyObject *
+/*static*/ PyObject *
 getset_get(PyGetSetDescrObject *descr, PyObject *obj, PyObject *type)
 {
     PyObject *res;

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2241,6 +2241,10 @@ error:
 /* static */ Py_ssize_t
 dict_length(PyDictObject *mp)
 {
+#if PYSTON_SPEEDUPS
+    if (mp->ma_used < 0)
+        __builtin_unreachable();
+#endif
     return mp->ma_used;
 }
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -444,6 +444,10 @@ error:
 /* static */ Py_ssize_t
 list_length(PyListObject *a)
 {
+#if PYSTON_SPEEDUPS
+    if (Py_SIZE(a) < 0)
+        __builtin_unreachable();
+#endif
     return Py_SIZE(a);
 }
 

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -459,6 +459,30 @@ PyModule_AddFunctions(PyObject *m, PyMethodDef *functions)
     return res;
 }
 
+#if PYSTON_SPEEDUPS
+PyObject *_PyCFunction_NewStatic(PyMethodDef *ml, PyObject *self, PyObject *module, PyCFunctionObject* op);
+// add a function to the module and store it inside the supplied static variable
+int _PyModule_AddFunctionStatic(PyObject *m, PyMethodDef *fdef, PyCFunctionObject* op)
+{
+    PyObject *name = PyModule_GetNameObject(m);
+    if (name == NULL) {
+        return -1;
+    }
+
+    PyObject* func = _PyCFunction_NewStatic(fdef, (PyObject*)m, name, op);
+    if (func == NULL) {
+        return -1;
+    }
+    if (PyObject_SetAttrString(m, fdef->ml_name, func) != 0) {
+        Py_DECREF(func);
+        return -1;
+    }
+    Py_DECREF(func);
+    Py_DECREF(name);
+    return 0;
+}
+#endif
+
 int
 PyModule_SetDocString(PyObject *m, const char *doc)
 {

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -623,6 +623,10 @@ done:
 /* static */ Py_ssize_t
 set_len(PyObject *so)
 {
+#if PYSTON_SPEEDUPS
+    if (((PySetObject *)so)->used < 0)
+        __builtin_unreachable();
+#endif
     return ((PySetObject *)so)->used;
 }
 

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -509,6 +509,10 @@ tuplehash(PyTupleObject *v)
 /* static */ Py_ssize_t
 tuplelength(PyTupleObject *a)
 {
+#if PYSTON_SPEEDUPS
+    if (Py_SIZE(a) < 0)
+        __builtin_unreachable();
+#endif
     return Py_SIZE(a);
 }
 

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1787,7 +1787,7 @@ ord as builtin_ord
 Return the Unicode code point for a one-character string.
 [clinic start generated code]*/
 
-static PyObject *
+/*static*/ PyObject *
 builtin_ord(PyObject *module, PyObject *c)
 /*[clinic end generated code: output=4fa5e87a323bae71 input=3064e5d6203ad012]*/
 {
@@ -2525,7 +2525,7 @@ check against. This is equivalent to ``isinstance(x, A) or isinstance(x, B)
 or ...`` etc.
 [clinic start generated code]*/
 
-static PyObject *
+/*static*/ PyObject *
 builtin_isinstance_impl(PyObject *module, PyObject *obj,
                         PyObject *class_or_tuple)
 /*[clinic end generated code: output=6faf01472c13b003 input=ffa743db1daf7549]*/
@@ -2791,16 +2791,22 @@ static PyMethodDef builtin_methods[] = {
     BUILTIN_HEX_METHODDEF
     BUILTIN_ID_METHODDEF
     BUILTIN_INPUT_METHODDEF
+#if !PYSTON_SPEEDUPS
     BUILTIN_ISINSTANCE_METHODDEF
+#endif
     BUILTIN_ISSUBCLASS_METHODDEF
     {"iter",            (PyCFunction)(void(*)(void))builtin_iter,       METH_FASTCALL, iter_doc},
+#if !PYSTON_SPEEDUPS
     BUILTIN_LEN_METHODDEF
+#endif
     BUILTIN_LOCALS_METHODDEF
     {"max",             (PyCFunction)(void(*)(void))builtin_max,        METH_VARARGS | METH_KEYWORDS, max_doc},
     {"min",             (PyCFunction)(void(*)(void))builtin_min,        METH_VARARGS | METH_KEYWORDS, min_doc},
     {"next",            (PyCFunction)(void(*)(void))builtin_next,       METH_FASTCALL, next_doc},
     BUILTIN_OCT_METHODDEF
+#if !PYSTON_SPEEDUPS
     BUILTIN_ORD_METHODDEF
+#endif
     BUILTIN_POW_METHODDEF
     {"print",           (PyCFunction)(void(*)(void))builtin_print,      METH_FASTCALL | METH_KEYWORDS, print_doc},
     BUILTIN_REPR_METHODDEF
@@ -2811,6 +2817,16 @@ static PyMethodDef builtin_methods[] = {
     {"vars",            builtin_vars,       METH_VARARGS, vars_doc},
     {NULL,              NULL},
 };
+
+#if PYSTON_SPEEDUPS
+int _PyModule_AddFunctionStatic(PyObject *m, PyMethodDef *fdef, PyCFunctionObject* op);
+
+PyMethodDef builtin_method_isinstance[] = { BUILTIN_ISINSTANCE_METHODDEF };
+PyMethodDef builtin_method_len[] = { BUILTIN_LEN_METHODDEF };
+PyMethodDef builtin_method_ord[] = { BUILTIN_ORD_METHODDEF };
+
+PyCFunctionObject builtin_isinstance_obj, builtin_len_obj, builtin_ord_obj;
+#endif
 
 PyDoc_STRVAR(builtin_doc,
 "Built-in functions, exceptions, and other objects.\n\
@@ -2828,10 +2844,6 @@ static struct PyModuleDef builtinsmodule = {
     NULL,
     NULL
 };
-
-#if PYSTON_SPEEDUPS
-PyObject* builtin_isinstance_obj;
-#endif
 
 PyObject *
 _PyBuiltin_Init(void)
@@ -2906,8 +2918,9 @@ _PyBuiltin_Init(void)
     Py_DECREF(debug);
 
 #if PYSTON_SPEEDUPS
-    builtin_isinstance_obj = PyDict_GetItemString(dict, "isinstance");
-    MAKE_IMMORTAL(builtin_isinstance_obj);
+    _PyModule_AddFunctionStatic(mod, builtin_method_isinstance, &builtin_isinstance_obj);
+    _PyModule_AddFunctionStatic(mod, builtin_method_len, &builtin_len_obj);
+    _PyModule_AddFunctionStatic(mod, builtin_method_ord, &builtin_ord_obj);
 #endif
 
     return mod;

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -894,11 +894,11 @@ PyDoc_STRVAR(builtin_isinstance__doc__,
 #define BUILTIN_ISINSTANCE_METHODDEF    \
     {"isinstance", (PyCFunction)(void(*)(void))builtin_isinstance, METH_FASTCALL, builtin_isinstance__doc__},
 
-static PyObject *
+/*static*/ PyObject *
 builtin_isinstance_impl(PyObject *module, PyObject *obj,
                         PyObject *class_or_tuple);
 
-static PyObject *
+/*static*/ PyObject *
 builtin_isinstance(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;

--- a/pyston/nitrous/interp.cpp
+++ b/pyston/nitrous/interp.cpp
@@ -35,7 +35,7 @@ namespace nitrous {
 static unique_ptr<SymbolFinder> symbol_finder;
 static unique_ptr<LLVMCompiler> compiler;
 static unique_ptr<JitConsts> jit_consts;
-static unordered_set<string> do_not_trace;
+static unordered_set<string> do_not_trace, always_trace;
 
 string findNameForAddress(void* address) {
     return symbol_finder->lookupAddress(address);
@@ -240,6 +240,9 @@ public:
     bool shouldTraceInto(llvm::StringRef function_name) {
         if (do_not_trace.count(function_name))
             return false;
+
+        if (always_trace.count(function_name))
+            return true;
 
         if (function_name == "PyObject_Malloc")
             return false;
@@ -1117,6 +1120,14 @@ void clearDoNotTrace() {
 
 void addDoNotTrace(const char* function_name) {
     nitrous::do_not_trace.insert(function_name);
+}
+
+void clearAlwaysTrace() {
+    nitrous::always_trace.clear();
+}
+
+void addAlwaysTrace(const char* function_name) {
+    nitrous::always_trace.insert(function_name);
 }
 
 JitTarget* createJitTarget(void* function, int num_args, int num_traces_until_jit) {

--- a/pyston/nitrous/interp.h
+++ b/pyston/nitrous/interp.h
@@ -15,6 +15,9 @@ DEF void initializeJIT(int verbosity, int pic);
 DEF void clearDoNotTrace();
 DEF void addDoNotTrace(const char* function_name);
 
+DEF void clearAlwaysTrace();
+DEF void addAlwaysTrace(const char* function_name);
+
 DEF void loadBitcode(const char* llvm_filename);
 
 typedef struct _JitTarget {

--- a/pyston/pystol/pystol.cpp
+++ b/pyston/pystol/pystol.cpp
@@ -409,6 +409,8 @@ using namespace pystol;
 
 extern "C" {
 
+PyCFunctionObject builtin_isinstance_obj, builtin_len_obj, builtin_ord_obj;
+
 void pystolGlobalPythonSetup() {
     addMallocLikeFunc("PyObject_Malloc");
     addMallocLikeFunc("PyTuple_New");
@@ -418,6 +420,10 @@ void pystolGlobalPythonSetup() {
     pystolAddConstObj(Py_False);
     pystolAddConstObj(Py_None);
     pystolAddConstObj(Py_NotImplemented);
+
+    pystolAddConstObj((PyObject*)&builtin_isinstance_obj);
+    pystolAddConstObj((PyObject*)&builtin_len_obj);
+    pystolAddConstObj((PyObject*)&builtin_ord_obj);
 
     MARKCONST((char*)_Py_SwappedOp, sizeof(_Py_SwappedOp[0]) * 6);
 
@@ -438,6 +444,10 @@ void pystolAddConstObj(PyObject* x) {
                                            - offset);
     else if (PyFloat_CheckExact(x))
         MARKCONST(((char*)x) + offset, sizeof(PyFloatObject) - offset);
+    else if (PyCFunction_Check(x)) {
+        MARKCONST(((char*)x) + offset, sizeof(PyCFunctionObject) - offset);
+        MARKCONST(((PyCFunctionObject*)x)->m_ml, sizeof(PyMethodDef));
+    }
     else
         MARKCONST(((char*)x) + offset, sizeof(PyObject) - offset);
 }


### PR DESCRIPTION
Unfortunately even after many many hours spend I was not able to expand nitrous to automatically
constant fold the constant builtin PyFunctionObjects. I tried different ways: facts, custom pass... but nothing worked.

The only robust way I found which optimizes everything away is by not heap allocating the PyCFunctionObjects.
So this is how I implemented it now. 
It should be easy to add more builtins.

- isinstance: before we stopped at 'builtin_isinstance' we now trace it completely
- isinstance: give better tracing examples and verify they return what expected
- len: added a few __builtin_assume/__builtin_unreachable checks which removes so unnecessary error handling