### PR TITLE
AOT: use non arg type optimized trace if guard fails

### DIFF
--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -295,7 +295,7 @@ PyByteArray_Concat(PyObject *a, PyObject *b)
 
 /* Functions stuffed into the type object */
 
-static Py_ssize_t
+/*static*/ Py_ssize_t
 bytearray_length(PyByteArrayObject *self)
 {
 #if PYSTON_SPEEDUPS

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1420,7 +1420,7 @@ bytes_str(PyObject *op)
     return bytes_repr(op);
 }
 
-static Py_ssize_t
+/*static*/ Py_ssize_t
 bytes_length(PyBytesObject *a)
 {
 #if PYSTON_SPEEDUPS


### PR DESCRIPTION
If we have e.g.
```python
t = str
c = C()
for i in range(10000000):
    if i == 10000000/2:
        t = int
    isinstance("", t)
```
We will now switch from using `call_function_ceval_no_kwisinstanceUnicode3` to `call_function_ceval_no_kwisinstance3`
which is still optimized for isinstance but not type specific.
Before we switched to generic `call_function_ceval_no_kw` which is much slower.
Similar for `len(x)` where the type of x is changing.

Generated C code:
```C
PyObject* call_function_ceval_no_kwisinstanceUnicode3(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg) {
  if (unlikely(oparg != 2)) {
    __builtin_unreachable();
  }
  PyObject* f = stack[-oparg - 1];
  if (unlikely(!(f == (PyObject*)&builtin_isinstance_obj && stack[-oparg+1] == (PyObject*)&PyUnicode_Type))) {
    SET_JIT_AOT_FUNC(call_function_ceval_no_kwisinstance3);
    PyObject* ret = call_function_ceval_no_kwisinstance3(tstate, stack, oparg);
```
instead of `call_function_ceval_no_kw`.