### PR TITLE
add PYSTON_VERSION_HEX

### DIFF
--- a/Include/patchlevel.h
+++ b/Include/patchlevel.h
@@ -38,3 +38,11 @@
                         (PY_MICRO_VERSION <<  8) | \
                         (PY_RELEASE_LEVEL <<  4) | \
                         (PY_RELEASE_SERIAL << 0))
+
+
+#define PYSTON_VERSION_HEX ((PYSTON_MAJOR_VERSION  << 24) | \
+                           (PYSTON_MINOR_VERSION   << 16) | \
+                           (PYSTON_MICRO_VERSION   <<  8) | \
+                           (0                      <<  4) | \
+                           (0                      <<  0))
+


### PR DESCRIPTION
Similar to `PY_VERSION_HEX` but for the pyston version number, should make it easier for 3rd party code to check for a specific version number.
I was worried that we run into issues with exisiting software using it to check for pyston_v1 (e.g. old cythenized code) but it looks like we defined `PYSTON_VERSION` not `PYSTON_VERSION_HEX` so should be fine (github code search found no code in any repo checking it).