### PR TITLE
Regenerate .pyc files after package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ make script_opt
 4. adjust `PYSTON_VERSION` inside `configure.ac` and run `autoconf`
 5. update `PYSTON_MINOR` and similar inside Makefile
 6. update the include directory in pyston/pystol/CMakeLists.txt
-7. update pyston/debian/pyston.{install,links}
+7. update pyston/debian/pyston.{install,links,postinst,prerm}
 
 ## Release packaging
 We use a script which builds automatically packages for all supported distributions via docker (will take several hours):

--- a/pyston/debian/pyston.postinst
+++ b/pyston/debian/pyston.postinst
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+PYSTONLIBPATH=/usr/lib/python3.8-pyston2.3
+
+if [ "$1" = configure ]; then
+    # regenerate the .pyc files because they include incorrect timestamps and filepaths
+    # in addition pregenerate them also for the different optimization levels.
+    for OPT in "" "-O" "-OO"
+    do
+        /usr/bin/pyston -E -S $OPT $PYSTONLIBPATH/compileall.py \
+                        $PYSTONLIBPATH/ \
+                        -j0 -f -q \
+                        -x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data'
+        /usr/bin/pyston -E -S $OPT $PYSTONLIBPATH/compileall.py \
+                        $PYSTONLIBPATH/site-packages \
+                        -j0 -f -q \
+                        -x badsyntax
+    done
+fi

--- a/pyston/debian/pyston.prerm
+++ b/pyston/debian/pyston.prerm
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+PYSTONLIBPATH=/usr/lib/python3.8-pyston2.3
+
+if [ "$1" = remove ]; then
+    # remove .pyc files else we get this warnings:
+    # dpkg: warning: while removing pyston, directory '<dir>/__pycache__' not empty so not removed
+    find $PYSTONLIBPATH -name "*.pyc" -delete
+fi
+


### PR DESCRIPTION
The files contain the full path of installation directory used during the build
e.g. /home/marius/dev/pyston_v2/pyston/build/cpython_unopt_install/usr/lib/python3.8-pyston2.3/re.py
and as pointed out in #70 also the wrong timestamp.
This means the common use-case where the package is installed by root and a different user is executing pyston
can't use the .pyc files and instead has to parse the files on every import.

The ubuntu cpython package contains a similar script but which does not use `compileall.py` but instead
manually does most of the work and is not regenerating them for all optimization levels.
```bash
files=$(dpkg -L lib@PVER@-testsuite | sed -n '/^\/usr\/lib\/@PVER@\/.*\.py$/p' | egrep -v '/lib2to3/tests/data|/test/bad')
    if [ -n "$files" ]; then
        /usr/bin/@PVER@ -E -S /usr/lib/@PVER@/py_compile.py $files
        if grep -sq '^byte-compile[^#]*optimize' /etc/python/debian_config; then
            /usr/bin/@PVER@ -E -S -O /usr/lib/@PVER@/py_compile.py $files
        fi
    else
        echo >&2 "@PVER@: can't get files for byte-compilation"
    fi
```
I decided against copying the code and instead decided to stick to what cpython does in `Makefile.pre.in`
using `compileall.py`.

This does not change things for the portable package but I think here it's not a problem
because the directory will likely be writable by the user so pyston will just update
them the first time they are imported.

In addition added a script to remove the .pyc files when removing the package because dpkg will only remove the
files included in the package and will complain that it can't remove the directories if they contain newly created .pyc files.

Note: the files to exclude (e.g bad_coding,..) is taken from `Makefile.pre.in`. This is necessary because some test files contain stuff which would error.


Fixes #70