### PR TITLE
portable release: prefer distro supplied shared objects

### DIFF
--- a/pyston/tools/make_portable_dir.py
+++ b/pyston/tools/make_portable_dir.py
@@ -114,7 +114,11 @@ def make_portable_dir(outdir):
 
     for f in filter(is_so, os.listdir(path)):
         dependencies |= recursive_get_dependencies(Dependency(f, path + f))
-        set_rpath(path + f, "$ORIGIN/../../../lib")
+        # we like to use our supplied .so's only as fallback if the dist ones are not available
+        # because ours are likely older which causes problems.
+        # best way to do it seems to put the most common dist lib paths in front of
+        # the path to our own libs.
+        set_rpath(path + f, "/lib64:/usr/lib/x86_64-linux-gnu:$ORIGIN/../../../lib")
 
     for x in dependencies:
         print(f"copy {x} into lib/")


### PR DESCRIPTION
Until now we always used our supplied 3rd party shared objects dependencies over
the distro supplied ones. But ours are likely older which causes problems.
E.g. issue #41: we load a thirdparty distro library compiled against a newer zlib but it's loading
our supplied older version which fails.

This patch changes the search order to use our supplied .so's only as fallback if the dist ones are not available.

This is noticable e.g. running `pyston -c "import sqlite3; print(sqlite3.sqlite_version)"`
will output 3.31.1 (on my ubuntu 20.04 system) instead of 3.11.0.

Why do we even supply this libraries?:
We do have to supply this libraries in case the user does not have the library installed
or it's not available in the required major version. E.g. if you use the portable release on latest fedora and ubuntu
openssl 1.0.x is not available anymore (it uses 1.1.x) so pip will fail with a SSL not available error if we don't supply 1.0.
Which means in order to have only one release which works on as much distros as possible we need to supply this
files but should make sure they are only used as fallback.

I verified that this fixes the problems in #41 and #76 on ubuntu, fedora and archlinux.

BTW: patchelf v0.10 supplied in ubuntu 20.04 contains a bug which corrupts files when modifying
already previously via patchelf modified executables. Not an issue for this script because it's not running patchelf twice on the same file but something to lookout if manually changing rpaths. Newer and older version seem to work fine.