### PR TITLE
Regenerate .pyc files: only process files part of the package

### DIFF
--- a/pyston/debian/pyston.postinst
+++ b/pyston/debian/pyston.postinst
@@ -6,15 +6,12 @@ PYSTONLIBPATH=/usr/lib/python3.8-pyston2.3
 if [ "$1" = configure ]; then
     # regenerate the .pyc files because they include incorrect timestamps and filepaths
     # in addition pregenerate them also for the different optimization levels.
+    FILES=$(dpkg -L pyston | grep "^$PYSTONLIBPATH/" | grep ".py$")
     for OPT in "" "-O" "-OO"
     do
         /usr/bin/pyston -E -S $OPT $PYSTONLIBPATH/compileall.py \
-                        $PYSTONLIBPATH/ \
-                        -j0 -f -q \
-                        -x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data'
-        /usr/bin/pyston -E -S $OPT $PYSTONLIBPATH/compileall.py \
-                        $PYSTONLIBPATH/site-packages \
-                        -j0 -f -q \
-                        -x badsyntax
+                        $FILES \
+                        -j0 -f -q -l \
+                        -x 'bad_coding|badsyntax|lib2to3/tests/data'
     done
 fi

--- a/pyston/debian/pyston.prerm
+++ b/pyston/debian/pyston.prerm
@@ -4,8 +4,12 @@ set -eu
 PYSTONLIBPATH=/usr/lib/python3.8-pyston2.3
 
 if [ "$1" = remove ]; then
-    # remove .pyc files else we get this warnings:
+    # remove .py[co] files else we get this warnings:
     # dpkg: warning: while removing pyston, directory '<dir>/__pycache__' not empty so not removed
-    find $PYSTONLIBPATH -name "*.pyc" -delete
+    max=$(LANG=C LC_ALL=C xargs --show-limits < /dev/null 2>&1 | awk '/Maximum length/ {print int($NF / 4)}')
+    dpkg -L pyston \
+        | awk -F/ 'BEGIN {OFS="/"} /\.py$/ {$NF=sprintf("__pycache__/%s.*.py[co]", substr($NF,1,length($NF)-3)); print}' \
+        | xargs --max-chars="$max" echo \
+        | while read files; do rm -f $files; done
 fi
 


### PR DESCRIPTION
Before packages installed by a user inside the 'site-packages' directory also got processed.

The pyston.prerm: script lines are mostly copied from the ubuntu package.