### PR TITLE
Add back recursion checking, but do it faster using the C stack pointer

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -83,45 +83,41 @@ PyAPI_FUNC(int) Py_MakePendingCalls(void);
    http://mail.python.org/pipermail/python-dev/2008-August/082106.html
    for some observations.
 */
+#if !PYSTON_SPEEDUPS
 PyAPI_FUNC(void) Py_SetRecursionLimit(int);
 PyAPI_FUNC(int) Py_GetRecursionLimit(void);
+#endif
 
 #define Py_EnterRecursiveCall(where)  \
-            (_Py_MakeRecCheck(PyThreadState_GET()->recursion_depth) &&  \
+            (_Py_MakeRecCheck(PyThreadState_GET()->stack_limit) &&  \
              _Py_CheckRecursiveCall(where))
 #define Py_LeaveRecursiveCall()                         \
-    do{ if(_Py_MakeEndRecCheck(PyThreadState_GET()->recursion_depth))  \
+    do{ if(_Py_MakeEndRecCheck((void*)(((char*)PyThreadState_GET()->stack_limit) + (1<<16))))  \
       PyThreadState_GET()->overflowed = 0;  \
     } while(0)
 PyAPI_FUNC(int) _Py_CheckRecursiveCall(const char *where);
 
+#if !PYSTON_SPEEDUPS
 /* Due to the macros in which it's used, _Py_CheckRecursionLimit is in
    the stable ABI.  It should be removed therefrom when possible.
 */
 PyAPI_DATA(int) _Py_CheckRecursionLimit;
 PyAPI_DATA(int) _Py_RecursionLimitLowerWaterMark_Precomputed;
+#endif
 
 #ifdef USE_STACKCHECK
 /* With USE_STACKCHECK, trigger stack checks in _Py_CheckRecursiveCall()
    on every 64th call to Py_EnterRecursiveCall.
 */
-#  define _Py_MakeRecCheck(x)  \
-    (++(x) > _Py_CheckRecursionLimit || \
+#  define _Py_MakeRecCheck()  \
+    (__builtin_frame_address(0) < (x) || \
      ++(PyThreadState_GET()->stackcheck_counter) > 64)
 #else
-#  define _Py_MakeRecCheck(x)  (++(x) > _Py_CheckRecursionLimit)
+#  define _Py_MakeRecCheck(x)  (__builtin_frame_address(0) < (x))
 #endif
 
-/* Compute the "lower-water mark" for a recursion limit. When
- * Py_LeaveRecursiveCall() is called with a recursion depth below this mark,
- * the overflowed flag is reset to 0. */
-#define _Py_RecursionLimitLowerWaterMark(limit) \
-    (((limit) > 200) \
-        ? ((limit) - 50) \
-        : (3 * ((limit) >> 2)))
-
 #define _Py_MakeEndRecCheck(x) \
-    (--(x) < _Py_RecursionLimitLowerWaterMark_Precomputed)
+    (__builtin_frame_address(0) > (x))
 
 #define Py_ALLOW_RECURSION \
   do { unsigned char _old = PyThreadState_GET()->recursion_critical;\

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -102,15 +102,23 @@ PyAPI_DATA(int) _Py_CheckRecursionLimit;
 PyAPI_DATA(int) _Py_RecursionLimitLowerWaterMark_Precomputed;
 #endif
 
+static inline void* _getSp() {
+    void* sp;
+    __asm( "mov %%rsp, %0" : "=rm" ( sp ));
+    return sp;
+}
+//#define frame_address() __builtin_frame_address(0)
+#define frame_address() _getSp(0)
+
 #ifdef USE_STACKCHECK
 /* With USE_STACKCHECK, trigger stack checks in _Py_CheckRecursiveCall()
    on every 64th call to Py_EnterRecursiveCall.
 */
 #  define _Py_MakeRecCheck()  \
-    (__builtin_frame_address(0) < (x) || \
+    (frame_address() < (x) || \
      ++(PyThreadState_GET()->stackcheck_counter) > 64)
 #else
-#  define _Py_MakeRecCheck(x)  (__builtin_frame_address(0) < (x))
+#  define _Py_MakeRecCheck(x)  (frame_address() < (x))
 #endif
 
 #define Py_ALLOW_RECURSION \

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -91,10 +91,7 @@ PyAPI_FUNC(int) Py_GetRecursionLimit(void);
 #define Py_EnterRecursiveCall(where)  \
             (_Py_MakeRecCheck(PyThreadState_GET()->stack_limit) &&  \
              _Py_CheckRecursiveCall(where))
-#define Py_LeaveRecursiveCall()                         \
-    do{ if(_Py_MakeEndRecCheck((void*)(((char*)PyThreadState_GET()->stack_limit) + (1<<16))))  \
-      PyThreadState_GET()->overflowed = 0;  \
-    } while(0)
+#define Py_LeaveRecursiveCall() ((void)0)
 PyAPI_FUNC(int) _Py_CheckRecursiveCall(const char *where);
 
 #if !PYSTON_SPEEDUPS
@@ -115,9 +112,6 @@ PyAPI_DATA(int) _Py_RecursionLimitLowerWaterMark_Precomputed;
 #else
 #  define _Py_MakeRecCheck(x)  (__builtin_frame_address(0) < (x))
 #endif
-
-#define _Py_MakeEndRecCheck(x) \
-    (__builtin_frame_address(0) > (x))
 
 #define Py_ALLOW_RECURSION \
   do { unsigned char _old = PyThreadState_GET()->recursion_critical;\

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -112,7 +112,7 @@ static inline void* _stack_pointer() {
 /* With USE_STACKCHECK, trigger stack checks in _Py_CheckRecursiveCall()
    on every 64th call to Py_EnterRecursiveCall.
 */
-#  define _Py_MakeRecCheck()  \
+#  define _Py_MakeRecCheck(x)  \
     (frame_address() < (x) || \
      ++(PyThreadState_GET()->stackcheck_counter) > 64)
 #else

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -86,10 +86,6 @@ PyAPI_FUNC(int) Py_MakePendingCalls(void);
 PyAPI_FUNC(void) Py_SetRecursionLimit(int);
 PyAPI_FUNC(int) Py_GetRecursionLimit(void);
 
-#if !PY_DEBUGGING_CHECKS
-#define Py_EnterRecursiveCall(where) (0)
-#define Py_LeaveRecursiveCall(where) ((void)0)
-#else
 #define Py_EnterRecursiveCall(where)  \
             (_Py_MakeRecCheck(PyThreadState_GET()->recursion_depth) &&  \
              _Py_CheckRecursiveCall(where))
@@ -97,7 +93,6 @@ PyAPI_FUNC(int) Py_GetRecursionLimit(void);
     do{ if(_Py_MakeEndRecCheck(PyThreadState_GET()->recursion_depth))  \
       PyThreadState_GET()->overflowed = 0;  \
     } while(0)
-#endif
 PyAPI_FUNC(int) _Py_CheckRecursiveCall(const char *where);
 
 /* Due to the macros in which it's used, _Py_CheckRecursionLimit is in

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -57,8 +57,8 @@ struct _ts {
 
     /* Borrowed reference to the current frame (it can be NULL) */
     struct _frame *frame;
-    int recursion_depth;
-    char overflowed; /* The stack has overflowed. Allow 50 more calls
+    void *stack_limit, *stack_limit_reset;
+    char overflowed; /* The stack has overflowed. Allow some more calls
                         to handle the runtime error. */
     char recursion_critical; /* The current calls must not cause
                                 a stack overflow. */

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -57,6 +57,7 @@ struct _ts {
 
     /* Borrowed reference to the current frame (it can be NULL) */
     struct _frame *frame;
+    int recursion_depth; // In Pyston this is no longer used, but is still available for API compatibility (ex uwsgi)
     void *stack_limit;
     char recursion_headroom; /* Allow 50 more calls to handle any errors. */
     char recursion_critical; /* The current calls must not cause

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -57,9 +57,8 @@ struct _ts {
 
     /* Borrowed reference to the current frame (it can be NULL) */
     struct _frame *frame;
-    void *stack_limit, *stack_limit_reset;
-    char overflowed; /* The stack has overflowed. Allow some more calls
-                        to handle the runtime error. */
+    void *stack_limit;
+    char recursion_headroom; /* Allow 50 more calls to handle any errors. */
     char recursion_critical; /* The current calls must not cause
                                 a stack overflow. */
     int stackcheck_counter;

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -44,11 +44,7 @@ struct _ceval_runtime_state {
     /* WARNING: the JIT assumes:
        - that tracing_possible and eval_breaker lay directly next to each other in memory
        - are together of size long */
-#if !PYSTON_SPEEDUPS
     int recursion_limit;
-#else
-    int _padding;
-#endif
     /* Records whether tracing is on for any thread.  Counts the number
        of threads for which tstate->c_tracefunc is non-NULL, so if the
        value is 0, we know we don't have to check this thread's

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -41,12 +41,14 @@ struct _pending_calls {
 };
 
 struct _ceval_runtime_state {
-#ifndef PYSTON_CLEANUP
     /* WARNING: the JIT assumes:
        - that tracing_possible and eval_breaker lay directly next to each other in memory
        - are together of size long */
-#endif
+#if !PYSTON_SPEEDUPS
     int recursion_limit;
+#else
+    int _padding;
+#endif
     /* Records whether tracing is on for any thread.  Counts the number
        of threads for which tstate->c_tracefunc is non-NULL, so if the
        value is 0, we know we don't have to check this thread's

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -516,7 +516,8 @@ def unwrap(func, *, stop=None):
     # Memoise by id to tolerate non-hashable objects, but store objects to
     # ensure they aren't destroyed, which would allow their IDs to be reused.
     memo = {id(f): f}
-    recursion_limit = sys.getrecursionlimit()
+    # recursion_limit = sys.getrecursionlimit()
+    recursion_limit = 1024
     while _is_wrapper(func):
         func = func.__wrapped__
         id_func = id(func)

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -516,8 +516,7 @@ def unwrap(func, *, stop=None):
     # Memoise by id to tolerate non-hashable objects, but store objects to
     # ensure they aren't destroyed, which would allow their IDs to be reused.
     memo = {id(f): f}
-    # recursion_limit = sys.getrecursionlimit()
-    recursion_limit = 1024
+    recursion_limit = sys.getrecursionlimit()
     while _is_wrapper(func):
         func = func.__wrapped__
         id_func = id(func)

--- a/Makefile
+++ b/Makefile
@@ -437,7 +437,7 @@ cpython_testsuite_bc: pyston/build/cpython_bc_build/pyston
 
 # Note: cpython_testsuite is itself parallel so we might need to run it not in parallel
 # with the other tests
-_runtests: pyston/test/caches_unopt pyston/test/test_rebuild_packages_unopt pyston/test/deferred_stack_decref_unopt pyston/test/getattr_caches_unopt test_django test_urllib3 test_setuptools test_six test_requests cpython_testsuite
+_runtests: pyston/test/caches_unopt pyston/test/test_rebuild_packages_unopt pyston/test/deferred_stack_decref_unopt pyston/test/getattr_caches_unopt pyston/test/test_recursion_limit_unopt test_django test_urllib3 test_setuptools test_six test_requests cpython_testsuite
 _runtestsdbg: pyston/test/caches_dbg pyston/test/test_rebuild_packages_dbg testdbg_django testdbg_urllib3 testdbg_setuptools testdbg_six testdbg_requests cpython_testsuite_dbg
 _runtestsopt: pyston/test/caches_opt pyston/test/test_rebuild_packages_opt testopt_django testopt_urllib3 testopt_setuptools testopt_six testopt_requests cpython_testsuite_opt
 

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,6 @@ perf_%_$(1): %.py pyston/build/$(1)_env/update.stamp
 
 pyperf_%_$(1): %.py ./pyston/build/$(1)_env/bin/update.stamp pyston/build/system_env/bin/python
 	LD_LIBRARY_PATH=$${LD_LIBRARY_PATH}:$(abspath pyston/build/cpython_$(1)_install/usr/lib) $$(PYPERF) pyston/build/$(1)_env/bin/python3 $$< $$(ARGS)
-)
 
 # UNSAFE build target
 # If you're making changes to cpython but don't want to rebuild the traces or anything beyond the python binary,
@@ -201,6 +200,10 @@ unsafe_$(1):
 	$(MAKE) -C pyston/build/cpython_$(1)_build
 	/bin/cp pyston/build/cpython_$(1)_build/pyston pyston/build/cpython_$(1)_install/usr/bin/python$(PYTHON_MAJOR).$(PYTHON_MINOR)
 
+cpython_testsuite_$(1): pyston/build/cpython_$(1)_build/pyston
+	OPENSSL_CONF=$(abspath pyston/test/openssl_dev.cnf) $(MAKE) -C pyston/build/cpython_$(1)_build test
+
+)
 endef
 
 SO_IFNOT_AMD := $(if $(findstring AMD,$(shell cat /proc/cpuinfo)),,so)
@@ -377,14 +380,6 @@ pyperf_%_pypy: %.py $(PYPY_BENCH_ENV) pyston/build/system_env/bin/python
 dbg_%: dbg_%_dbg
 
 
-# UNSAFE build target
-# If you're making changes to cpython but don't want to rebuild the traces or anything beyond the python binary,
-# you can call this target for a much faster build.
-# Skips cpython_bc_build, aot_gen, and cpython_unopt_install
-# If you want to run the skipped steps, you will have to touch a file before doing a (safe) rebuild
-unsafe_dbg:
-	$(MAKE) -C pyston/build/cpython_dbg_build
-	/bin/cp pyston/build/cpython_dbg_build/pyston pyston/build/cpython_dbg_install/usr/bin/python$(PYTHON_MAJOR).$(PYTHON_MINOR)
 unsafe_% unsafe_%_unopt: %.py unsafe_unopt
 	time pyston/build/unopt_env/bin/python3 $< $(ARGS)
 unsafe_dbg_%: %.py unsafe_unopt
@@ -436,14 +431,9 @@ testopt_%: pyston/test/external/test_%.expected pyston/test/external/test_%.opto
 testdbg_%: pyston/test/external/test_%.dbgexpected pyston/test/external/test_%.dbgoutput
 	pyston/build/system_env/bin/python pyston/test/external/helpers.py compare $< $(patsubst %.dbgexpected,%.dbgoutput,$<)
 
-cpython_testsuite: pyston/build/cpython_unopt_build/pyston
-	OPENSSL_CONF=$(abspath pyston/test/openssl_dev.cnf) $(MAKE) -C pyston/build/cpython_unopt_build test
-
-cpython_testsuite_opt: pyston/build/cpython_opt_build/pyston
-	OPENSSL_CONF=$(abspath pyston/test/openssl_dev.cnf) $(MAKE) -C pyston/build/cpython_opt_build test
-
-cpython_testsuite_dbg: pyston/build/cpython_dbg_build/pyston
-	OPENSSL_CONF=$(abspath pyston/test/openssl_dev.cnf) $(MAKE) -C pyston/build/cpython_dbg_build test
+cpython_testsuite: cpython_testsuite_unopt
+cpython_testsuite_bc: pyston/build/cpython_bc_build/pyston
+	OPENSSL_CONF=$(abspath pyston/test/openssl_dev.cnf) $(MAKE) -C pyston/build/cpython_bc_build test
 
 # Note: cpython_testsuite is itself parallel so we might need to run it not in parallel
 # with the other tests

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1048,6 +1048,10 @@ t_bootstrap(void *boot_raw)
     _PyThreadState_Init(&_PyRuntime, tstate);
     PyEval_AcquireThread(tstate);
     tstate->interp->num_threads++;
+
+    tstate->stack_limit = (void*)((char*)__builtin_frame_address(0) - (1024 * 1024));
+    //printf("Started thread, rsp is %p limit is %p\n", __builtin_frame_address(0), tstate->stack_limit);
+
     res = PyObject_Call(boot->func, boot->args, boot->keyw);
     if (res == NULL) {
         if (PyErr_ExceptionMatches(PyExc_SystemExit))

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1049,8 +1049,7 @@ t_bootstrap(void *boot_raw)
     PyEval_AcquireThread(tstate);
     tstate->interp->num_threads++;
 
-    tstate->stack_limit = (void*)((char*)__builtin_frame_address(0) - (1024 * 1024));
-    //printf("Started thread, rsp is %p limit is %p\n", __builtin_frame_address(0), tstate->stack_limit);
+    tstate->stack_limit = _Py_GetStackLimit(_Py_CheckRecursionLimit);
 
     res = PyObject_Call(boot->func, boot->args, boot->keyw);
     if (res == NULL) {

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -294,15 +294,15 @@ function_code_fastcall(PyCodeObject *co, PyObject *const *args, Py_ssize_t nargs
         _PyObject_GC_TRACK(f);
     }
     else {
-        ++tstate->recursion_depth;
 #if PYSTON_SPEEDUPS
         Py_REFCNT(f) = 0;
         assert(Py_TYPE(f) == &PyFrame_Type);
         frame_dealloc_notrashcan(f);
 #else
+        ++tstate->recursion_depth;
         Py_DECREF(f);
-#endif
         --tstate->recursion_depth;
+#endif
     }
     return result;
 }

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -5171,9 +5171,13 @@ fail: /* Jump here from prelude on failure */
         _PyObject_GC_TRACK(f);
     }
     else {
+#if !PYSTON_SPEEDUPS
         ++tstate->recursion_depth;
+#endif
         Py_DECREF(f);
+#if !PYSTON_SPEEDUPS
         --tstate->recursion_depth;
+#endif
     }
     return retval;
 }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -677,7 +677,7 @@ Py_SetRecursionLimit(int new_limit)
 // you request.
 #define BYTES_PER_RECURSION_LEVEL 800
 void* _Py_GetStackLimit(int levels) {
-    return (char*)__builtin_frame_address(0) - BYTES_PER_RECURSION_LEVEL * levels;
+    return (char*)frame_address() - BYTES_PER_RECURSION_LEVEL * levels;
 }
 
 void _Py_AdjustThreadStackLimits(int additional_levels) {

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -715,13 +715,13 @@ _Py_CheckRecursiveCall(const char *where)
         /* Somebody asked that we don't check for recursion. */
         return 0;
     if (tstate->recursion_headroom) {
-        if (__builtin_frame_address(0) < (void*)((char*)tstate->stack_limit - (1<<16))) {
+        if (frame_address() < (void*)((char*)tstate->stack_limit - BYTES_PER_RECURSION_LEVEL * 50)) {
             /* Overflowing while handling an overflow. Give up. */
             Py_FatalError("Cannot recover from stack overflow.");
         }
         return 0;
     }
-    if (__builtin_frame_address(0) < tstate->stack_limit) {
+    if (frame_address() < tstate->stack_limit) {
         tstate->recursion_headroom++;
         _PyErr_Format(tstate, PyExc_RecursionError,
                       "maximum recursion depth exceeded%s",

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -690,7 +690,7 @@ _Py_CheckRecursiveCall(const char *where)
     if (tstate->recursion_critical)
         /* Somebody asked that we don't check for recursion. */
         return 0;
-    if (tstate->overflowed) {
+    if (tstate->recursion_headroom) {
         if (__builtin_frame_address(0) < (void*)((char*)tstate->stack_limit - (1<<16))) {
             //printf("uh oh, rsp is %p limit is %p\n", __builtin_frame_address(0), tstate->stack_limit);
             /* Overflowing while handling an overflow. Give up. */
@@ -699,10 +699,11 @@ _Py_CheckRecursiveCall(const char *where)
         return 0;
     }
     if (__builtin_frame_address(0) < tstate->stack_limit) {
-        tstate->overflowed = 1;
+        tstate->recursion_headroom++;
         _PyErr_Format(tstate, PyExc_RecursionError,
                       "maximum recursion depth exceeded%s",
                       where);
+        tstate->recursion_headroom--;
         return -1;
     }
     return 0;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -583,6 +583,7 @@ new_threadstate(PyInterpreterState *interp, int init)
     tstate->interp = interp;
 
     tstate->frame = NULL;
+    tstate->recursion_depth = 0;
     tstate->recursion_headroom = 0;
     tstate->recursion_critical = 0;
     tstate->stackcheck_counter = 0;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -964,6 +964,9 @@ _PyThreadState_Swap(struct _gilstate_runtime_state *gilstate, PyThreadState *new
 {
     PyThreadState *oldts = _PyRuntimeGILState_GetThreadState(gilstate);
 
+    if (newts)
+        newts->stack_limit = _Py_GetStackLimit(_Py_CheckRecursionLimit);
+
     _PyRuntimeGILState_SetThreadState(gilstate, newts);
     /* It should not be possible for more than one thread state
        to be used for a thread.  Check this the best we can in debug

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -583,7 +583,6 @@ new_threadstate(PyInterpreterState *interp, int init)
     tstate->interp = interp;
 
     tstate->frame = NULL;
-    tstate->recursion_depth = 0;
     tstate->overflowed = 0;
     tstate->recursion_critical = 0;
     tstate->stackcheck_counter = 0;
@@ -625,6 +624,15 @@ new_threadstate(PyInterpreterState *interp, int init)
 
     if (init) {
         _PyThreadState_Init(runtime, tstate);
+    }
+
+    // Ideally we would always set the stack limit here, but since
+    // we don't know what the stack starting point is until we start the thread,
+    // we can only do it for the main thread, and the other threads get initialized in
+    // t_bootstrap()
+    if (init) {
+        tstate->stack_limit = (void*)((char*)__builtin_frame_address(0) - (1024 * 1024));
+        //printf("Started main thread, rsp is %p limit is %p\n", __builtin_frame_address(0), tstate->stack_limit);
     }
 
     HEAD_LOCK(runtime);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -583,7 +583,7 @@ new_threadstate(PyInterpreterState *interp, int init)
     tstate->interp = interp;
 
     tstate->frame = NULL;
-    tstate->overflowed = 0;
+    tstate->recursion_headroom = 0;
     tstate->recursion_critical = 0;
     tstate->stackcheck_counter = 0;
     tstate->tracing = 0;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -631,8 +631,7 @@ new_threadstate(PyInterpreterState *interp, int init)
     // we can only do it for the main thread, and the other threads get initialized in
     // t_bootstrap()
     if (init) {
-        tstate->stack_limit = (void*)((char*)__builtin_frame_address(0) - (1024 * 1024));
-        //printf("Started main thread, rsp is %p limit is %p\n", __builtin_frame_address(0), tstate->stack_limit);
+        tstate->stack_limit = _Py_GetStackLimit(_Py_CheckRecursionLimit);
     }
 
     HEAD_LOCK(runtime);

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -265,7 +265,9 @@ PySymtable_BuildObject(mod_ty mod, PyObject *filename, PyFutureFeatures *future)
     asdl_seq *seq;
     int i;
     PyThreadState *tstate;
+#if !PYSTON_SPEEDUPS
     int recursion_limit = Py_GetRecursionLimit();
+#endif
     int starting_recursion_depth;
 
     if (st == NULL)
@@ -284,12 +286,18 @@ PySymtable_BuildObject(mod_ty mod, PyObject *filename, PyFutureFeatures *future)
         PySymtable_Free(st);
         return NULL;
     }
+
     /* Be careful here to prevent overflow. */
+#if PYSTON_SPEEDUPS
+    st->recursion_depth = 0;
+    st->recursion_limit = 1024;
+#else
     starting_recursion_depth = (tstate->recursion_depth < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
         tstate->recursion_depth * COMPILER_STACK_FRAME_SCALE : tstate->recursion_depth;
     st->recursion_depth = starting_recursion_depth;
     st->recursion_limit = (recursion_limit < INT_MAX / COMPILER_STACK_FRAME_SCALE) ?
         recursion_limit * COMPILER_STACK_FRAME_SCALE : recursion_limit;
+#endif
 
     /* Make the initial symbol information gathering pass */
     if (!GET_IDENTIFIER(top) ||
@@ -331,6 +339,7 @@ PySymtable_BuildObject(mod_ty mod, PyObject *filename, PyFutureFeatures *future)
         PySymtable_Free(st);
         return NULL;
     }
+#if !PYSTON_SPEEDUPS
     /* Check that the recursion depth counting balanced correctly */
     if (st->recursion_depth != starting_recursion_depth) {
         PyErr_Format(PyExc_SystemError,
@@ -339,6 +348,7 @@ PySymtable_BuildObject(mod_ty mod, PyObject *filename, PyFutureFeatures *future)
         PySymtable_Free(st);
         return NULL;
     }
+#endif
     /* Make the second symbol analysis pass */
     if (symtable_analyze(st))
         return st;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1076,6 +1076,7 @@ sys_getswitchinterval_impl(PyObject *module)
     return 1e-6 * _PyEval_GetSwitchInterval();
 }
 
+#if !PYSTON_SPEEDUPS
 /*[clinic input]
 sys.setrecursionlimit
 
@@ -1124,6 +1125,7 @@ sys_setrecursionlimit_impl(PyObject *module, int new_limit)
     Py_SetRecursionLimit(new_limit);
     Py_RETURN_NONE;
 }
+#endif
 
 /*[clinic input]
 sys.set_coroutine_origin_tracking_depth
@@ -1384,6 +1386,7 @@ get_hash_info(void)
     }
     return hash_info;
 }
+
 /*[clinic input]
 sys.getrecursionlimit
 
@@ -1398,7 +1401,7 @@ static PyObject *
 sys_getrecursionlimit_impl(PyObject *module)
 /*[clinic end generated code: output=d571fb6b4549ef2e input=1c6129fd2efaeea8]*/
 {
-    return PyLong_FromLong(Py_GetRecursionLimit());
+    return PyLong_FromLong(1024);
 }
 
 #ifdef MS_WINDOWS
@@ -1997,7 +2000,9 @@ static PyMethodDef sys_methods[] = {
     SYS_SETDLOPENFLAGS_METHODDEF
     {"setprofile",      sys_setprofile, METH_O, setprofile_doc},
     SYS_GETPROFILE_METHODDEF
+#if !PYSTON_SPEEDUPS
     SYS_SETRECURSIONLIMIT_METHODDEF
+#endif
     {"settrace",        sys_settrace, METH_O, settrace_doc},
     SYS_GETTRACE_METHODDEF
     SYS_CALL_TRACING_METHODDEF

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1076,7 +1076,6 @@ sys_getswitchinterval_impl(PyObject *module)
     return 1e-6 * _PyEval_GetSwitchInterval();
 }
 
-#if !PYSTON_SPEEDUPS
 /*[clinic input]
 sys.setrecursionlimit
 
@@ -1103,6 +1102,7 @@ sys_setrecursionlimit_impl(PyObject *module, int new_limit)
         return NULL;
     }
 
+#if !PYSTON_SPEEDUPS
     /* Issue #25274: When the recursion depth hits the recursion limit in
        _Py_CheckRecursiveCall(), the overflowed flag of the thread state is
        set to 1 and a RecursionError is raised. The overflowed flag is reset
@@ -1121,11 +1121,11 @@ sys_setrecursionlimit_impl(PyObject *module, int new_limit)
                      new_limit, tstate->recursion_depth);
         return NULL;
     }
+#endif
 
     Py_SetRecursionLimit(new_limit);
     Py_RETURN_NONE;
 }
-#endif
 
 /*[clinic input]
 sys.set_coroutine_origin_tracking_depth
@@ -1386,7 +1386,6 @@ get_hash_info(void)
     }
     return hash_info;
 }
-
 /*[clinic input]
 sys.getrecursionlimit
 
@@ -1401,7 +1400,7 @@ static PyObject *
 sys_getrecursionlimit_impl(PyObject *module)
 /*[clinic end generated code: output=d571fb6b4549ef2e input=1c6129fd2efaeea8]*/
 {
-    return PyLong_FromLong(1024);
+    return PyLong_FromLong(Py_GetRecursionLimit());
 }
 
 #ifdef MS_WINDOWS
@@ -2000,9 +1999,7 @@ static PyMethodDef sys_methods[] = {
     SYS_SETDLOPENFLAGS_METHODDEF
     {"setprofile",      sys_setprofile, METH_O, setprofile_doc},
     SYS_GETPROFILE_METHODDEF
-#if !PYSTON_SPEEDUPS
     SYS_SETRECURSIONLIMIT_METHODDEF
-#endif
     {"settrace",        sys_settrace, METH_O, settrace_doc},
     SYS_GETTRACE_METHODDEF
     SYS_CALL_TRACING_METHODDEF

--- a/pyston/nitrous/CMakeLists.txt
+++ b/pyston/nitrous/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ferror-limit=5 -fcolor-diagnostics")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ferror-limit=5 -fcolor-diagnostics")
 
-set(LLVM_LIB_DEPS LLVMCore LLVMSupport  LLVMBitReader LLVMAsmParser  LLVMTransformUtils LLVMScalarOpts  LLVMOrcJIT LLVMX86CodeGen LLVMPerfJITEvents)
+set(LLVM_LIB_DEPS LLVMCore LLVMSupport  LLVMBitReader LLVMAsmParser  LLVMTransformUtils LLVMScalarOpts  LLVMOrcJIT LLVMX86CodeGen LLVMPerfJITEvents LLVMX86AsmParser)
 
 add_library(interp SHARED interp.cpp jit.cpp symbol_finder.cpp Execution.cpp Interpreter.cpp facts.cpp)
 target_include_directories(interp PRIVATE ${LLVM_INCLUDE_DIRS})

--- a/pyston/nitrous/Execution.cpp
+++ b/pyston/nitrous/Execution.cpp
@@ -1175,6 +1175,16 @@ void Interpreter::visitCallSite(CallSite CS) {
     case Intrinsic::dbg_value:
       return;
 
+    case Intrinsic::frameaddress: {
+      // We use __builtin_frame_address to see if the C stack has overflowed.
+      // So to avoid those exceptions, just return the max value here, since
+      // that's the smallest possible stack
+      GenericValue val;
+      val.PointerVal = PointerTy(0xffffffffffffffffL);
+      SetValue(CS.getInstruction(), val, SF);
+      return;
+    }
+
     default:
       // If it is an unknown intrinsic function, use the intrinsic lowering
       // class to transform it into hopefully tasty LLVM code.

--- a/pyston/nitrous/jit.cpp
+++ b/pyston/nitrous/jit.cpp
@@ -192,6 +192,7 @@ private:
 LLVMCompiler::LLVMCompiler(SymbolFinder* finder) {
     InitializeNativeTarget();
     InitializeNativeTargetAsmPrinter();
+    InitializeNativeTargetAsmParser();
     jit = std::make_unique<LLVMJitCompiler>(finder);
 }
 

--- a/pyston/pystol/passes.cpp
+++ b/pyston/pystol/passes.cpp
@@ -84,7 +84,7 @@ public:
                 // check if gep is accessing PyObject->ob_refcnt
                 if (!gep->hasAllConstantIndices())
                     continue;
-                APInt offset;
+                APInt offset(8 * sizeof(void*), 0);
                 bool success = gep->accumulateConstantOffset(DL, offset);
                 if (!success || offsetof(PyObject, ob_refcnt) != offset)
                     continue;

--- a/pyston/test/test_recursion_limit.py
+++ b/pyston/test/test_recursion_limit.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     # Test that doubling the limit roughly doubles the number of frames
     sys.setrecursionlimit(set_limit * 2)
     actual_limit2 = measure()
-    assert 2 * actual_limit - 1 <= actual_limit2 <= 2.1 * actual_limit + 2, (actual_limit, actual_limit2)
+    assert 1.9 * actual_limit - 1 <= actual_limit2 <= 2.1 * actual_limit + 2, (actual_limit, actual_limit2)
 
     # Threading test:
     # Check that 1) recursion limits are inherited by new threads, and 2) changing the

--- a/pyston/test/test_recursion_limit.py
+++ b/pyston/test/test_recursion_limit.py
@@ -1,0 +1,43 @@
+import sys
+import threading
+import time
+
+def measure():
+    "Measures the current stack limit of python frames"
+    x = [0]
+
+    def inner():
+        x[0] += 1
+        inner()
+
+    try:
+        inner()
+    except RecursionError:
+        pass
+
+    return x[0]
+
+if __name__ == "__main__":
+    set_limit = 1024
+
+    # Basic test: check that setting the limit is close
+    sys.setrecursionlimit(set_limit)
+    actual_limit = measure()
+    assert set_limit - 3 <= actual_limit < 2 * set_limit, actual_limit
+
+    # Test that doubling the limit roughly doubles the number of frames
+    sys.setrecursionlimit(set_limit * 2)
+    actual_limit2 = measure()
+    assert 2 * actual_limit - 1 <= actual_limit2 <= 2.1 * actual_limit + 2, (actual_limit, actual_limit2)
+
+    # Threading test:
+    # Check that 1) recursion limits are inherited by new threads, and 2) changing the
+    # limit on one thread changes it for other threads.
+    sys.setrecursionlimit(100)
+    def test():
+        assert measure() < 200
+        sys.setrecursionlimit(1024)
+    t = threading.Thread(target=test)
+    t.start()
+    t.join()
+    assert measure() > 1000


### PR DESCRIPTION
We removed recursion checking because it was about 0.8% of the runtime of our macrobenchmarks, and presumably more in microbenchmarks. The user experience is not very good though, because if there is an infinite recursion the result is a segfault which looks like our fault.

So this PR adds back recursion checking, but instead of explicitly counting Python frames, it just looks at the C stack pointer. This means that we don't have to do any additional writes to do this bookkeeping. This fixes issues like #77.

Additionally, backport an optimization from newer versions of CPython where they eliminated some of the ability to temporarily exceed the recursion limit, which further speeds things up.

The numbers are small enough to be hard to measure, but it looks like CPython-style recursion checking takes up roughly 0.8% of the time, whereas this rsp-based checking takes up about 0.2%.