### PR TITLE
Fix most of the compiler warnings that we added

### DIFF
--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -48,9 +48,14 @@ PyAPI_FUNC(int) PyArg_ValidateKeywordArguments(PyObject *);
 PyAPI_FUNC(int) PyArg_UnpackTuple(PyObject *, const char *, Py_ssize_t, Py_ssize_t, ...);
 #ifndef PYSTON_CLEANUP
 #if PYSTON_SPEEDUPS
-PyAPI_FUNC(int) PyArg_UnpackTuple1(PyObject *, const char *, Py_ssize_t, Py_ssize_t, PyObject **);
-PyAPI_FUNC(int) PyArg_UnpackTuple2(PyObject *, const char *, Py_ssize_t, Py_ssize_t, PyObject **, PyObject **);
-PyAPI_FUNC(int) PyArg_UnpackTuple3(PyObject *, const char *, Py_ssize_t, Py_ssize_t, PyObject **, PyObject **, PyObject **);
+// Because PyArg_UnpackTuple does no C-type-checking of its arguments,
+// wrap the new UnpackTuple functions in macros that do auto-casting:
+#define PyArg_UnpackTuple1(t, name, min, max, o1) _PyArg_UnpackTuple1((t), (name), (min), (max), (PyObject **)o1)
+#define PyArg_UnpackTuple2(t, name, min, max, o1, o2) _PyArg_UnpackTuple2((t), (name), (min), (max), (PyObject **)o1, (PyObject **)o2)
+#define PyArg_UnpackTuple3(t, name, min, max, o1, o2, o3) _PyArg_UnpackTuple3((t), (name), (min), (max), (PyObject **)o1, (PyObject **)o2, (PyObject **)o3)
+PyAPI_FUNC(int) _PyArg_UnpackTuple1(PyObject *, const char *, Py_ssize_t, Py_ssize_t, PyObject **);
+PyAPI_FUNC(int) _PyArg_UnpackTuple2(PyObject *, const char *, Py_ssize_t, Py_ssize_t, PyObject **, PyObject **);
+PyAPI_FUNC(int) _PyArg_UnpackTuple3(PyObject *, const char *, Py_ssize_t, Py_ssize_t, PyObject **, PyObject **, PyObject **);
 #else
 #define PyArg_UnpackTuple1 PyArg_UnpackTuple
 #define PyArg_UnpackTuple2 PyArg_UnpackTuple

--- a/Include/tupleobject.h
+++ b/Include/tupleobject.h
@@ -42,9 +42,14 @@ PyAPI_FUNC(PyObject *) PyTuple_GetSlice(PyObject *, Py_ssize_t, Py_ssize_t);
 PyAPI_FUNC(PyObject *) PyTuple_Pack(Py_ssize_t, ...);
 #ifndef PYSTON_CLEANUP
 #if PYSTON_SPEEDUPS
-PyAPI_FUNC(PyObject *) PyTuple_Pack1(PyObject *);
-PyAPI_FUNC(PyObject *) PyTuple_Pack2(PyObject *, PyObject *);
-PyAPI_FUNC(PyObject *) PyTuple_Pack3(PyObject *, PyObject *, PyObject *);
+// Because PyTuple_Pack does no C-type-checking of its arguments,
+// wrap the new Pack functions in macros that do auto-casting:
+#define PyTuple_Pack1(o1) _PyTuple_Pack1((PyObject*)(o1))
+#define PyTuple_Pack2(o1, o2) _PyTuple_Pack2((PyObject*)(o1), (PyObject*)(o2))
+#define PyTuple_Pack3(o1, o2, o3) _PyTuple_Pack3((PyObject*)(o1), (PyObject*)(o2), (PyObject*)(o3))
+PyAPI_FUNC(PyObject *) _PyTuple_Pack1(PyObject *);
+PyAPI_FUNC(PyObject *) _PyTuple_Pack2(PyObject *, PyObject *);
+PyAPI_FUNC(PyObject *) _PyTuple_Pack3(PyObject *, PyObject *, PyObject *);
 #else
 #define PyTuple_Pack1(el0) PyTuple_Pack(1, (el0))
 #define PyTuple_Pack2(el0, el1) PyTuple_Pack(2, (el0), (el1))

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -24,12 +24,12 @@ static void* _PyMem_DebugMalloc(void *ctx, size_t size);
 static void* _PyMem_DebugCalloc(void *ctx, size_t nelem, size_t elsize);
 static void* _PyMem_DebugRealloc(void *ctx, void *ptr, size_t size);
 static void _PyMem_DebugFree(void *ctx, void *p);
-#endif
 
 static void _PyObject_DebugDumpAddress(const void *p);
 static void _PyMem_DebugCheckAddress(char api_id, const void *p);
 
 static void _PyMem_SetupDebugHooksDomain(PyMemAllocatorDomain domain);
+#endif
 
 #if defined(__has_feature)  /* Clang */
 #  if __has_feature(address_sanitizer) /* is ASAN enabled? */
@@ -2103,6 +2103,7 @@ bumpserialno(void)
 #  define PYMEM_DEBUG_EXTRA_BYTES 3 * SST
 #endif
 
+#if PY_DEBUGGING_FEATURES
 /* Read sizeof(size_t) bytes at p as a big-endian size_t. */
 static size_t
 read_size_t(const void *p)
@@ -2131,7 +2132,6 @@ write_size_t(void *p, size_t n)
     }
 }
 
-#if PY_DEBUGGING_FEATURES
 /* Let S = sizeof(size_t).  The debug malloc asks for 4 * S extra bytes and
    fills them with useful stuff, here calling the underlying malloc's result p:
 
@@ -2236,7 +2236,7 @@ _PyMem_DebugRawCalloc(void *ctx, size_t nelem, size_t elsize)
     return _PyMem_DebugRawAlloc(1, ctx, nbytes);
 }
 
-
+#if PY_DEBUGGING_FEATURES
 /* The debug free first checks the 2*SST bytes on each end for sanity (in
    particular, that the FORBIDDENBYTEs with the api ID are still intact).
    Then fills the original bytes with PYMEM_DEADBYTE.
@@ -2260,6 +2260,7 @@ _PyMem_DebugRawFree(void *ctx, void *p)
     memset(q, PYMEM_DEADBYTE, nbytes);
     api->alloc.free(api->alloc.ctx, q);
 }
+#endif
 
 
 static void *

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -259,7 +259,7 @@ PyTuple_Pack(Py_ssize_t n, ...)
 
 #if PYSTON_SPEEDUPS
 PyObject *
-PyTuple_Pack1(PyObject *el0) {
+_PyTuple_Pack1(PyObject *el0) {
     PyObject* result = PyTuple_New_Nonzeroed(1);
     if (result == NULL)
         return NULL;
@@ -272,7 +272,7 @@ PyTuple_Pack1(PyObject *el0) {
 }
 
 PyObject *
-PyTuple_Pack2(PyObject *el0, PyObject *el1) {
+_PyTuple_Pack2(PyObject *el0, PyObject *el1) {
     PyObject* result = PyTuple_New_Nonzeroed(2);
     if (result == NULL)
         return NULL;
@@ -287,7 +287,7 @@ PyTuple_Pack2(PyObject *el0, PyObject *el1) {
 }
 
 PyObject *
-PyTuple_Pack3(PyObject *el0, PyObject *el1, PyObject *el2) {
+_PyTuple_Pack3(PyObject *el0, PyObject *el1, PyObject *el2) {
     PyObject* result = PyTuple_New_Nonzeroed(3);
     if (result == NULL)
         return NULL;
@@ -339,7 +339,6 @@ done:
 /* static */ void
 tupledealloc_borrowed(PyTupleObject *op)
 {
-    Py_ssize_t i;
     Py_ssize_t len =  Py_SIZE(op);
     // Don't have to untrack, these are already untracked
     if (len > 0) {
@@ -566,7 +565,7 @@ _PyTuple_FromArray_Borrowed(PyObject *const *src, Py_ssize_t n)
 
     // Don't untrack the empty tuple
     if (n == 0)
-        return tuple;
+        return (PyObject*)tuple;
 
     _PyObject_GC_UNTRACK(tuple);
     memcpy(tuple->ob_item, src, n * sizeof(PyObject*));

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -698,7 +698,6 @@ _Py_CheckRecursiveCall(const char *where)
 {
     _PyRuntimeState *runtime = &_PyRuntime;
     PyThreadState *tstate = _PyRuntimeState_GetThreadState(runtime);
-    int recursion_limit = runtime->ceval.recursion_limit;
 
 #ifdef USE_STACKCHECK
     tstate->stackcheck_counter = 0;

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2780,7 +2780,7 @@ PyArg_UnpackTuple(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t m
 
 #if PYSTON_SPEEDUPS
 int
-PyArg_UnpackTuple1(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t max, PyObject **arg0)
+_PyArg_UnpackTuple1(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t max, PyObject **arg0)
 {
     PyObject **stack;
     Py_ssize_t nargs;
@@ -2809,7 +2809,7 @@ PyArg_UnpackTuple1(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t 
 }
 
 int
-PyArg_UnpackTuple2(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t max, PyObject **arg0, PyObject **arg1)
+_PyArg_UnpackTuple2(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t max, PyObject **arg0, PyObject **arg1)
 {
     PyObject **stack;
     Py_ssize_t nargs;
@@ -2841,7 +2841,7 @@ PyArg_UnpackTuple2(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t 
 }
 
 int
-PyArg_UnpackTuple3(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t max, PyObject **arg0, PyObject **arg1, PyObject **arg2)
+_PyArg_UnpackTuple3(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t max, PyObject **arg0, PyObject **arg1, PyObject **arg2)
 {
     PyObject **stack;
     Py_ssize_t nargs;

--- a/pyston/aot/aot_gen.py
+++ b/pyston/aot/aot_gen.py
@@ -59,7 +59,7 @@ class AssumedTypeGuard:
         return None
 
     def getAssumptions(self, variable_name):
-        return Unspecialized.getAssumptions(variable_name) + [f'{variable_name} != NULL', f'{variable_name}->ob_type == &{self.type_name}']
+        return Unspecialized.getAssumptions(variable_name) + [f'{variable_name} != NULL', f'Py_TYPE({variable_name}) == &{self.type_name}']
 
 class Tuple1ElementIdentityGuard(IdentityGuard):
     """

--- a/pyston/aot/aot_gen.py
+++ b/pyston/aot/aot_gen.py
@@ -290,8 +290,8 @@ class NormalHandler(Handler):
         return [name for (_, name) in self._args()]
 
     def _args(self):
-        oargs = [('PyObject *', o) for o in self._o_args_names()]
-        return oargs
+        types = [ac.c_type_name for ac in self.case.signatures[-1].argument_classes]
+        return list(zip(types, self._o_args_names()))
 
     def _get_func_sig(self, name):
         param = ", ".join([f"{type} {o}" for (type, o) in self._args()])
@@ -704,6 +704,7 @@ def loadCases():
 
     getitemlong_signatures = []
     unguarded_int_class = ObjectClass("", AssumedTypeGuard("PyLong_Type"), [0])
+    unguarded_int_class.c_type_name = "PyLongObject*"
     unguarded_cint_class = CLongClass([ctypes.c_long(0)])
     for name in "List", "Tuple", "Unicode", "Range":
         getitemlong_signatures += makeSignatures([type_classes[name]], [unguarded_int_class], [unguarded_cint_class])


### PR DESCRIPTION
Mostly unused variables and not casting between PyObject* and PyFooObject*