### PR TITLE
Get embedding (ex uwsgi) working from our portable release

### DIFF
--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -565,6 +565,14 @@ def get_config_vars(*args):
             _init_non_posix(_CONFIG_VARS)
         if os.name == 'posix':
             _init_posix(_CONFIG_VARS)
+
+        # Pyston change: rewrite LIBDIR to allow for embedding from
+        # our portable (relocatable) release
+        real_location = os.path.dirname(_PROJECT_BASE)
+        configured_prefix = _CONFIG_VARS["prefix"]
+        if _CONFIG_VARS["LIBDIR"].startswith(configured_prefix):
+            _CONFIG_VARS["LIBDIR"] = _CONFIG_VARS["LIBDIR"].replace(configured_prefix, real_location, 1)
+
         # For backward compatibility, see issue19555
         SO = _CONFIG_VARS.get('EXT_SUFFIX')
         if SO is not None:


### PR DESCRIPTION
The problem is that sysconfig.get_config_var("LIBDIR") returns
the configured path, but the release is most likely extracted
somewhere else.

So at sysconfig-load time, rewrite LIBDIR to always point to
where we think we're running from.

I'm a bit nervous about this change because it changes the
semantics of LIBDIR. I think it's for the better, but there's
a chance that someone really wants to look at the configured
location, or it's possible that there's some weird situation
where we incorrectly guess where we're running from.

There are also a number of other variables that are like this,
that could be updated to point to the location we think we're
running from, but I'm doing this just for LIBDIR for now
to reduce the amount of changes.