### PR TITLE
pgo: run profile tasks in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ $(BOLT): build/bolt/Makefile
 CPYTHON_EXTRA_CFLAGS:=-fstack-protector -specs=$(CURDIR)/pyston/tools/no-pie-compile.specs -D_FORTIFY_SOURCE=2
 CPYTHON_EXTRA_LDFLAGS:=-specs=$(CURDIR)/pyston/tools/no-pie-link.specs -Wl,-z,relro
 
-PROFILE_TASK:=../../Lib/test/regrtest.py -j 1 -unone,decimal -x test_posix test_asyncio test_cmd_line_script test_compiler test_concurrent_futures test_ctypes test_dbm_dumb test_dbm_ndbm test_distutils test_ensurepip test_ftplib test_gdb test_httplib test_imaplib test_ioctl test_linuxaudiodev test_multiprocessing test_nntplib test_ossaudiodev test_poplib test_pydoc test_signal test_socket test_socketserver test_ssl test_subprocess test_sundry test_thread test_threaded_import test_threadedtempfile test_threading test_threading_local test_threadsignals test_venv test_zipimport_support || true
+PROFILE_TASK:=../../Lib/test/regrtest.py -j 0 -unone,decimal -x test_posix test_asyncio test_cmd_line_script test_compiler test_concurrent_futures test_ctypes test_dbm_dumb test_dbm_ndbm test_distutils test_ensurepip test_ftplib test_gdb test_httplib test_imaplib test_ioctl test_linuxaudiodev test_multiprocessing test_nntplib test_ossaudiodev test_poplib test_pydoc test_signal test_socket test_socketserver test_ssl test_subprocess test_sundry test_thread test_threaded_import test_threadedtempfile test_threading test_threading_local test_threadsignals test_venv test_zipimport_support || true
 
 MAKEFILE_DEPENDENCIES:=Makefile.pre.in configure
 build/bc_build/Makefile: $(CLANG) $(MAKEFILE_DEPENDENCIES)


### PR DESCRIPTION
I could not measure any performance difference of the pyston executable
but the opt build takes about 10min now instead of 25min+ or so.

I could not really find any concrete sentence that says multiprocess PGO is fine but the docs mention
that the profile counters are merged on exit. Based on the benchmark result I assume it merges
them locked.