### PR TITLE
Fix compiler warnings

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -12,7 +12,7 @@ typedef struct {
 // This is a special value for the builtins_ver field
 // that specifies that the LOAD_GLOBAL hit came from the globals
 // and thus the builtins version doesn't matter.
-#define LOADGLOBAL_WAS_GLOBAL -1
+#define LOADGLOBAL_WAS_GLOBAL UINT64_MAX
 
 #ifndef PYSTON_CLEANUP
 #if PYSTON_SPEEDUPS

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -200,7 +200,7 @@ PyObject_GetItemLong(PyObject *o, PyLongObject *key, Py_ssize_t key_value)
 
     m = o->ob_type->tp_as_mapping;
     if (m && m->mp_subscript) {
-        PyObject *item = m->mp_subscript(o, key);
+        PyObject *item = m->mp_subscript(o, (PyObject*)key);
         assert((item != NULL) ^ (PyErr_Occurred() != NULL));
         return item;
     }
@@ -211,7 +211,7 @@ PyObject_GetItemLong(PyObject *o, PyLongObject *key, Py_ssize_t key_value)
     }
 
     if (PyType_Check(o)) {
-        PyObject *meth, *result, *stack[1] = {key};
+        PyObject *meth, *result, *stack[1] = { (PyObject*)key };
         if (_PyObject_LookupAttrId(o, &PyId___class_getitem__, &meth) < 0) {
             return NULL;
         }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2933,7 +2933,7 @@ type_vectorcall(PyObject *metatype, PyObject *const *args,
         }
         PyTypeObject* type = Py_TYPE(args[0]);
         Py_INCREF(type);
-        return type;
+        return (PyObject*)type;
     }
     /* In other (much less common) cases, fall back to
        more flexible calling conventions. */

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -1239,7 +1239,7 @@ void jit_finish();
 static long opcache_min_runs = OPCACHE_MIN_RUNS;
 static long jit_min_runs = JIT_MIN_RUNS;
 
-#define JIT_FUNC_FAILED ((JitFunc*)0x1)
+#define JIT_FUNC_FAILED ((JitFunc)0x1)
 
 static PyObject* _Py_HOT_FUNCTION
 _PyEval_EvalFrame_AOT_JIT(PyFrameObject *f, PyThreadState * const tstate, PyObject** stack_pointer, JitFunc jit_code);


### PR DESCRIPTION
This actually caught a bug where in the jit cache stats where load method misses
would get count as load attribute misses...