### PR TITLE
Produce a pyston-based docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ make script_opt
 5. update `PYSTON_MINOR` and similar inside Makefile
 6. update the include directory in pyston/pystol/CMakeLists.txt
 7. update pyston/debian/pyston.{install,links,postinst,prerm}
+8. update pyston/docker/Dockerfile and pyston/docker/build_docker.sh
 
 ## Release packaging
 We use a script which builds automatically packages for all supported distributions via docker (will take several hours):

--- a/pyston/docker/Dockerfile
+++ b/pyston/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:20.04
+
+RUN apt-get update
+RUN apt-get install -y wget
+
+RUN set -eux; \
+    wget https://github.com/pyston/pyston/releases/download/v2.3/pyston_2.3_20.04.deb; \
+    apt install -y ./pyston_2.3_20.04.deb; \
+    rm pyston_2.3_20.04.deb
+
+RUN set -eux; \
+    ln -sf /usr/bin/python3.8-pyston2.3 /usr/bin/python3.8; \
+    ln -sf /usr/bin/python3.8-pyston2.3 /usr/bin/python3; \
+    ln -sf /usr/bin/pip-pyston2.3 /usr/bin/pip
+

--- a/pyston/docker/build_docker.sh
+++ b/pyston/docker/build_docker.sh
@@ -1,0 +1,7 @@
+set -eux
+
+BUILD_NAME=2.3
+
+docker build -t pyston/pyston:latest -t pyston/pyston:${BUILD_NAME} .
+docker push pyston/pyston:latest
+docker push pyston/pyston:${BUILD_NAME}


### PR DESCRIPTION
In theory you could replace "FROM ubuntu:20.04" with "FROM pyston:pyston",
but since I don't have any docker workloads this will need some testing.

Implements #98


I already uploaded the 2.3 release to pyston:pyston
