### PR TITLE
conda packages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "pyston/bolt/bolt"]
 	path = pyston/bolt
-	url = https://github.com/facebookincubator/BOLT
+	url = https://github.com/pyston/BOLT
 [submodule "pyston/LuaJIT"]
 	path = pyston/LuaJIT
 	url = https://github.com/LuaJIT/LuaJIT.git

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,20 @@
 .SUFFIXES:
 
-CLANG:=build/Release/llvm/bin/clang
+# If PYSTON_USE_SYS_BINS=1 is set we don't build clang and bolt instead we are using supplied ones.
+ifeq ($(PYSTON_USE_SYS_BINS),1)
+BOLT:=$(shell which llvm-bolt)
+CLANG:=$(shell which clang)
+LLVM_LINK:=$(shell which llvm-link)
+MERGE_FDATA:=$(shell which merge-fdata)
+PERF2BOLT:=$(shell which perf2bolt)
+else
+BOLT:=$(abspath build/bolt/bin/llvm-bolt)
+CLANG:=$(abspath build/Release/llvm/bin/clang)
+LLVM_LINK:=$(abspath build/Release/llvm/bin/llvm-link)
+MERGE_FDATA:=$(abspath build/bolt/bin/merge-fdata)
+PERF2BOLT:=$(abspath build/bolt/bin/perf2bolt)
+endif
+
 GDB:=gdb
 .DEFAULT_GOAL:=all
 
@@ -29,15 +43,15 @@ tune_reset: build/system_env/bin/python
 build/Release/Makefile:
 	mkdir -p build/Release
 	@# Use gold linker since ld 2.32 (Ubuntu 19.04) is unable to link compiler-rt:
-	cd build/Release; CC=clang CXX=clang++ cmake ../../pyston/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_LINKER=gold -DLLVM_ENABLE_PROJECTS="clang;compiler-rt" -DLLVM_USE_PERF=ON -DCLANG_INCLUDE_TESTS=0 -DCOMPILER_RT_INCLUDE_TESTS=0 -DLLVM_INCLUDE_TESTS=0
+	cd build/Release; CC=clang CXX=clang++ cmake ../../pyston/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_LINKER=gold -DLLVM_ENABLE_PROJECTS="clang;compiler-rt" -DCLANG_INCLUDE_TESTS=0 -DCOMPILER_RT_INCLUDE_TESTS=0 -DLLVM_INCLUDE_TESTS=0
 
 build/PartialDebug/Makefile:
 	mkdir -p build/PartialDebug
-	cd build/PartialDebug; CC=clang CXX=clang++ cmake ../../pyston/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=PartialDebug -DLLVM_ENABLE_PROJECTS=clang -DLLVM_USE_PERF=ON -DCLANG_INCLUDE_TESTS=0 -DCOMPILER_RT_INCLUDE_TESTS=0 -DLLVM_INCLUDE_TESTS=0
+	cd build/PartialDebug; CC=clang CXX=clang++ cmake ../../pyston/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=PartialDebug -DLLVM_ENABLE_PROJECTS=clang -DCLANG_INCLUDE_TESTS=0 -DCOMPILER_RT_INCLUDE_TESTS=0 -DLLVM_INCLUDE_TESTS=0
 
 build/Debug/Makefile:
 	mkdir -p build/Debug
-	cd build/Debug; CC=clang CXX=clang++ cmake ../../pyston/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_PROJECTS=clang -DLLVM_USE_PERF=ON -DCLANG_INCLUDE_TESTS=0 -DCOMPILER_RT_INCLUDE_TESTS=0 -DLLVM_INCLUDE_TESTS=0
+	cd build/Debug; CC=clang CXX=clang++ cmake ../../pyston/ -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_PROJECTS=clang -DCLANG_INCLUDE_TESTS=0 -DCOMPILER_RT_INCLUDE_TESTS=0 -DLLVM_INCLUDE_TESTS=0
 
 .PHONY: build_release build_dbg build_debug
 build_dbg: build/PartialDebug/Makefile build/bc_env/bin/python
@@ -56,17 +70,22 @@ build_release:
 LLVM_TOOLS:=$(CLANG)
 .PHONY: clang
 clang $(CLANG): | build/Release/Makefile
+ifneq ($(PYSTON_USE_SYS_BINS),1)
 	cd build/Release; $(MAKE) clang llvm-dis llvm-as llvm-link opt compiler-rt llvm-profdata
+endif
 
-BOLT:=build/bolt/bin/llvm-bolt
-PERF2BOLT:=build/bolt/bin/perf2bolt
-MERGE_FDATA:=build/bolt/bin/merge-fdata
+
+bolt: $(BOLT)
+ifeq ($(PYSTON_USE_SYS_BINS),1)
+$(BOLT):
+	# nothing todo
+else
 build/bolt/Makefile:
 	mkdir -p build/bolt
 	cd build/bolt; cmake -G "Unix Makefiles" ../../pyston/bolt/llvm -DLLVM_TARGETS_TO_BUILD="X86" -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_INCLUDE_TESTS=0 -DLLVM_ENABLE_PROJECTS=bolt
-bolt: $(BOLT)
 $(BOLT): build/bolt/Makefile
 	cd build/bolt; $(MAKE) llvm-bolt merge-fdata perf2bolt
+endif
 
 # this flags are what the default debian/ubuntu cpython uses
 CPYTHON_EXTRA_CFLAGS:=-fstack-protector -specs=$(CURDIR)/pyston/tools/no-pie-compile.specs -D_FORTIFY_SOURCE=2
@@ -120,11 +139,11 @@ build/$(1)_build/Makefile: $(MAKEFILE_DEPENDENCIES)
 	cd build/$(1)_build; $(2)
 
 build/$(1)_build/pyston: build/$(1)_build/Makefile $(wildcard */*.c) $(wildcard */*.h) $(3)
-	cd build/$(1)_build; $$(MAKE)
+	cd build/$(1)_build; CLANG=$(CLANG) $$(MAKE)
 	touch $$@ # some cpython .c files don't affect the python executable
 
 build/$(1)_install/usr/bin/python3: build/$(1)_build/pyston
-	cd build/$(1)_build; $$(MAKE) install DESTDIR=$(4) $(if $(findstring so,$(5)),INSTSONAME=libpython$(PYTHON_MAJOR).$(PYTHON_MINOR)-pyston$(PYSTON_MAJOR).$(PYSTON_MINOR).so.1.0.prebolt)
+	cd build/$(1)_build; CLANG=$(CLANG) $$(MAKE) install DESTDIR=$(4) $(if $(findstring so,$(5)),INSTSONAME=libpython$(PYTHON_MAJOR).$(PYTHON_MINOR)-pyston$(PYSTON_MAJOR).$(PYSTON_MINOR).so.1.0.prebolt)
 
 $(1): build/$(1)_env/bin/python
 
@@ -211,21 +230,21 @@ endef
 SO_IFNOT_AMD := $(if $(findstring AMD,$(shell cat /proc/cpuinfo)),,so)
 
 COMMA:=,
-$(call make_cpython_build,unopt,CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/unopt_install/usr) --disable-debugging-features --enable-configure,build/aot/aot_all.bc,,)
-$(call make_cpython_build,unoptshared,CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/unoptshared_install/usr) --disable-debugging-features --enable-configure --enable-shared,build/aot_pic/aot_all.bc,,)
-$(call make_cpython_build,opt,PROFILE_TASK="$(PROFILE_TASK)" CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/opt_install/usr) --enable-optimizations --with-lto --disable-debugging-features --enable-configure,build/aot/aot_all.bc,,binary)
-$(call make_cpython_build,optshared,PROFILE_TASK="$(PROFILE_TASK)" CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/optshared_install/usr) --enable-optimizations --with-lto --disable-debugging-features --enable-shared --enable-configure,build/aot_pic/aot_all.bc,,$(SO_IFNOT_AMD))
-$(call make_cpython_build,releaseunopt,PROFILE_TASK="$(PROFILE_TASK)" CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=/usr --disable-debugging-features --enable-configure,build/aot/aot_all.bc,$(abspath build/releaseunopt_install))
-$(call make_cpython_build,releaseunoptshared,PROFILE_TASK="$(PROFILE_TASK)" CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=/usr --disable-debugging-features --enable-shared --enable-configure,build/aot_pic/aot_all.bc,$(abspath build/releaseunoptshared_install))
-$(call make_cpython_build,release,      PROFILE_TASK="$(PROFILE_TASK)" CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=/usr --enable-optimizations --with-lto --disable-debugging-features --enable-configure,build/aot/aot_all.bc,$(abspath build/release_install),binary)
-$(call make_cpython_build,releaseshared,PROFILE_TASK="$(PROFILE_TASK)" CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=/usr --enable-optimizations --with-lto --disable-debugging-features --enable-shared --enable-configure,build/aot_pic/aot_all.bc,$(abspath build/releaseshared_install),so)
+$(call make_cpython_build,unopt,CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/unopt_install/usr) --disable-debugging-features --enable-configure,build/aot/aot_all.bc,,)
+$(call make_cpython_build,unoptshared,CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/unoptshared_install/usr) --disable-debugging-features --enable-configure --enable-shared,build/aot_pic/aot_all.bc,,)
+$(call make_cpython_build,opt,PROFILE_TASK="$(PROFILE_TASK)" CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/opt_install/usr) --enable-optimizations --with-lto --disable-debugging-features --enable-configure,build/aot/aot_all.bc,,binary)
+$(call make_cpython_build,optshared,PROFILE_TASK="$(PROFILE_TASK)" CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/optshared_install/usr) --enable-optimizations --with-lto --disable-debugging-features --enable-shared --enable-configure,build/aot_pic/aot_all.bc,,$(SO_IFNOT_AMD))
+$(call make_cpython_build,releaseunopt,PROFILE_TASK="$(PROFILE_TASK)" CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=/usr --disable-debugging-features --enable-configure,build/aot/aot_all.bc,$(abspath build/releaseunopt_install))
+$(call make_cpython_build,releaseunoptshared,PROFILE_TASK="$(PROFILE_TASK)" CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=/usr --disable-debugging-features --enable-shared --enable-configure,build/aot_pic/aot_all.bc,$(abspath build/releaseunoptshared_install))
+$(call make_cpython_build,release,      PROFILE_TASK="$(PROFILE_TASK)" CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=/usr --enable-optimizations --with-lto --disable-debugging-features --enable-configure,build/aot/aot_all.bc,$(abspath build/release_install),binary)
+$(call make_cpython_build,releaseshared,PROFILE_TASK="$(PROFILE_TASK)" CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=/usr --enable-optimizations --with-lto --disable-debugging-features --enable-shared --enable-configure,build/aot_pic/aot_all.bc,$(abspath build/releaseshared_install),so)
 # We have to --disable-debugging-features for consistency with the bc build
 # If we had a separate bc-dbg build then we could change this
-$(call make_cpython_build,dbg,CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/dbg_install/usr) --with-pydebug --disable-debugging-features --enable-configure,build/aot/aot_all.bc)
-$(call make_cpython_build,dbgshared,CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/dbgshared_install/usr) --with-pydebug --disable-debugging-features --enable-shared --enable-configure,build/aot_pic/aot_all.bc)
-$(call make_cpython_build,stock,PROFILE_TASK="$(PROFILE_TASK) || true" CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS)" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS)" ../../configure --prefix=$(abspath build/stock_install/usr) --enable-optimizations --with-lto --disable-pyston --enable-configure,)
-$(call make_cpython_build,stockunopt,CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS)" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS)" ../../configure --prefix=$(abspath build/stockunopt_install/usr) --disable-pyston --enable-configure,)
-$(call make_cpython_build,stockdbg,CC=gcc CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS)" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS)" ../../configure --prefix=$(abspath build/stockdbg_install/usr) --disable-pyston --with-pydebug --enable-configure,)
+$(call make_cpython_build,dbg,CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/dbg_install/usr) --with-pydebug --disable-debugging-features --enable-configure,build/aot/aot_all.bc)
+$(call make_cpython_build,dbgshared,CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS) -fno-reorder-blocks-and-partition" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS) -Wl$(COMMA)--emit-relocs" ../../configure --prefix=$(abspath build/dbgshared_install/usr) --with-pydebug --disable-debugging-features --enable-shared --enable-configure,build/aot_pic/aot_all.bc)
+$(call make_cpython_build,stock,PROFILE_TASK="$(PROFILE_TASK) || true" CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS)" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS)" ../../configure --prefix=$(abspath build/stock_install/usr) --enable-optimizations --with-lto --disable-pyston --enable-configure,)
+$(call make_cpython_build,stockunopt,CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS)" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS)" ../../configure --prefix=$(abspath build/stockunopt_install/usr) --disable-pyston --enable-configure,)
+$(call make_cpython_build,stockdbg,CFLAGS_NODIST="$(CPYTHON_EXTRA_CFLAGS)" LDFLAGS_NODIST="$(CPYTHON_EXTRA_LDFLAGS)" ../../configure --prefix=$(abspath build/stockdbg_install/usr) --disable-pyston --with-pydebug --enable-configure,)
 
 # Usage: $(call combine_builds,NAME)
 define combine_builds
@@ -273,11 +292,11 @@ build/$(1)/aot_pre_trace.so: build/$(1)/aot_pre_trace.c build/Release/nitrous/li
 	$(CLANG) -O2 -g -fPIC -Wno-incompatible-pointer-types -Wno-int-conversion $$< -Ibuild/bc_install/usr/include/python$(PYTHON_MAJOR).$(PYTHON_MINOR)-pyston$(PYSTON_MAJOR).$(PYSTON_MINOR)/ -Ibuild/bc_install/usr/include/python$(PYTHON_MAJOR).$(PYTHON_MINOR)-pyston$(PYSTON_MAJOR).$(PYSTON_MINOR)/internal/ -Ipyston/nitrous/ -shared -Lbuild/Release/nitrous -linterp -o $$@
 
 build/$(1)/all.bc: build/bc_build/pyston $(LLVM_TOOLS) build/$(1)/aot_pre_trace.bc
-	build/Release/llvm/bin/llvm-link $$(filter-out %_testembed.o.bc %frozenmain.o.bc build/cpython_bc/Modules/%,$$(wildcard build/cpython_bc/*/*.bc)) build/cpython_bc/Modules/gcmodule.o.bc build/cpython_bc/Modules/getpath.o.bc build/cpython_bc/Modules/main.o.bc build/cpython_bc/Modules/config.o.bc build/$(1)/aot_pre_trace.bc -o=$$@
+	$(LLVM_LINK) $$(filter-out %_testembed.o.bc %frozenmain.o.bc build/cpython_bc/Modules/%,$$(wildcard build/cpython_bc/*/*.bc)) build/cpython_bc/Modules/gcmodule.o.bc build/cpython_bc/Modules/getpath.o.bc build/cpython_bc/Modules/main.o.bc build/cpython_bc/Modules/config.o.bc build/$(1)/aot_pre_trace.bc -o=$$@
 
 # Not really dependent on aot_profile.c, but aot_profile.c gets generated at the same time as the real dependencies
 build/$(1)/aot_all.bc: build/$(1)/aot_profile.c
-	cd build/$(1); ../Release/llvm/bin/llvm-link aot_module*.bc -o aot_all.bc
+	cd build/$(1); $(LLVM_LINK) aot_module*.bc -o aot_all.bc
 
 build/$(1)/aot_profile.c: build/$(1)/all.bc build/$(1)/aot_pre_trace.so build/bc_install/usr/bin/python3 pyston/aot/aot_gen.py build/Release/nitrous/libinterp.so build/Release/pystol/libpystol.so
 	cd build/$(1); rm -f aot_module*.bc

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ LLVM_LINK:=$(shell which llvm-link)
 LLVM_PROFDATA:=$(shell which llvm-profdata)
 MERGE_FDATA:=$(shell which merge-fdata)
 PERF2BOLT:=$(shell which perf2bolt)
+RELEASE:=
 else
 BOLT:=$(abspath build/bolt/bin/llvm-bolt)
 CLANG:=$(abspath build/Release/llvm/bin/clang)
@@ -15,6 +16,7 @@ LLVM_LINK:=$(abspath build/Release/llvm/bin/llvm-link)
 LLVM_PROFDATA:=$(abspath build/Release/llvm/bin/llvm-profdata)
 MERGE_FDATA:=$(abspath build/bolt/bin/merge-fdata)
 PERF2BOLT:=$(abspath build/bolt/bin/perf2bolt)
+RELEASE:=$(shell lsb_release -sr)
 endif
 
 GDB:=gdb
@@ -123,7 +125,6 @@ build/systemdbg_env/bin/python: | $(VIRTUALENV)
 build/pypy_env/bin/python: | $(VIRTUALENV)
 	$(VIRTUALENV) -p pypy3 build/pypy_env
 
-RELEASE:=$(shell lsb_release -sr)
 EXTRA_BOLT_OPTS:=
 ifeq ($(RELEASE),16.04)
 else ifeq ($(RELEASE),18.04)
@@ -499,7 +500,7 @@ dbg_test: python/test/dbg_method_call_unopt
 # llvm-bolt must be build outside of dpkg-buildpackage or it will segfault
 .PHONY: package
 package: bolt
-ifeq ($(shell lsb_release -sr),16.04)
+ifeq ($(RELEASE),16.04)
 	# 16.04 needs this file but on newer ubuntu versions it will make it fail
 	echo 10 > pyston/debian/compat
 	cd pyston; DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -b -d

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -274,8 +274,8 @@ COVERAGE_INFO=	$(abs_builddir)/coverage.info
 COVERAGE_REPORT=$(abs_builddir)/lcov-report
 COVERAGE_REPORT_OPTIONS=--no-branch-coverage --title "CPython lcov report"
 
-CLANG=		../../build/Release/llvm/bin/clang
-CLANG_RT_PROFILE=../../build/Release/llvm/lib/clang/10.0.0/lib/linux/libclang_rt.profile-x86_64.a
+# PGO instrumented build of our traces requires us to link against this library
+CLANG_RT_PROFILE=$(shell ${CLANG} --print-resource-dir)/lib/linux/libclang_rt.profile-x86_64.a
 
 # === Definitions added by makesetup ===
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1779,7 +1779,7 @@ aot_optimized.o: $(AOT_DIR)/aot_all.bc
 	elif [ -d $(AOT_DIR)/aot_prof ]; \
 	then \
 		echo "traces are using PGO"; \
-		../../build/Release/llvm/bin/llvm-profdata merge -output=$(AOT_DIR)/aot_prof.profdata $(AOT_DIR)/aot_prof/*.profraw || exit 1; \
+		$(LLVM_PROFDATA) merge -output=$(AOT_DIR)/aot_prof.profdata $(AOT_DIR)/aot_prof/*.profraw || exit 1; \
 		$(CLANG) -c -O2 $(CFLAGSFORSHARED) -fprofile-use=`realpath $(AOT_DIR)/aot_prof.profdata` -o $@ $(AOT_DIR)/aot_all.bc; \
 	else \
 		echo "traces are not using PGO"; \

--- a/pyston/CMakeLists.txt
+++ b/pyston/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wreturn-type -Wno-sign-compare -Wno-unused -Wno-unused-parameter")
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -fno-rtti -std=c++14")
+set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -fno-rtti -std=c++14 -D__STDC_FORMAT_MACROS")
 
 set(CLANG_FLAGS "-Qunused-arguments -fcolor-diagnostics" CACHE STRING "Clang specific C and CXX flags")
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")

--- a/pyston/CMakeLists.txt
+++ b/pyston/CMakeLists.txt
@@ -1,23 +1,27 @@
 cmake_minimum_required(VERSION 3.1)
 project(interp)
 
-set(CMAKE_C_FLAGS_PARTIALDEBUG "${CMAKE_C_FLAGS_DEBUG}")
-set(CMAKE_CXX_FLAGS_PARTIALDEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+if("$ENV{PYSTON_USE_SYS_BINS}" STREQUAL "1")
+    find_package(LLVM)
+else()
+    set(CMAKE_C_FLAGS_PARTIALDEBUG "${CMAKE_C_FLAGS_DEBUG}")
+    set(CMAKE_CXX_FLAGS_PARTIALDEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 
-set(CMAKE_BUILD_TYPE_SAVED "${CMAKE_BUILD_TYPE}")
-if(${CMAKE_BUILD_TYPE} STREQUAL "PartialDebug")
-    set(CMAKE_BUILD_TYPE Release)
+    set(CMAKE_BUILD_TYPE_SAVED "${CMAKE_BUILD_TYPE}")
+    if(${CMAKE_BUILD_TYPE} STREQUAL "PartialDebug")
+        set(CMAKE_BUILD_TYPE Release)
 
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -UNDEBUG")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -UNDEBUG")
+        set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -UNDEBUG")
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -UNDEBUG")
+    endif()
+    set(LLVM_TARGETS_TO_BUILD "host" CACHE STRING "LLVM targets")
+
+    add_subdirectory(${CMAKE_SOURCE_DIR}/llvm/llvm ${CMAKE_BINARY_DIR}/llvm EXCLUDE_FROM_ALL)
+    set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE_SAVED}")
+
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}/llvm/lib/cmake/llvm/")
+    include(LLVMConfig)
 endif()
-set(LLVM_TARGETS_TO_BUILD "host" CACHE STRING "LLVM targets")
-add_subdirectory(${CMAKE_SOURCE_DIR}/llvm/llvm ${CMAKE_BINARY_DIR}/llvm EXCLUDE_FROM_ALL)
-set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE_SAVED}")
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}/llvm/lib/cmake/llvm/")
-include(LLVMConfig)
-
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wreturn-type -Wno-sign-compare -Wno-unused -Wno-unused-parameter")
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -fno-rtti -std=c++14")

--- a/pyston/clang_wrapper.py
+++ b/pyston/clang_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import subprocess

--- a/pyston/conda/bolt/LICENSE.TXT
+++ b/pyston/conda/bolt/LICENSE.TXT
@@ -1,0 +1,279 @@
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2003-2019 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+

--- a/pyston/conda/bolt/build.sh
+++ b/pyston/conda/bolt/build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eux
+
+# we need to overwrite the conda build flags because
+# using the default flags the resulting bolt binary will not work
+CFLAGS="-isystem ${PREFIX}/include"
+CXXFLAGS="-isystem ${PREFIX}/include"
+LDFLAGS="-Wl,-rpath,${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
+CPPFLAGS="-isystem ${PREFIX}/include"
+
+# without this line we can't find zlib and co..
+CPPFLAGS=${CPPFLAGS}" -I${PREFIX}/include"
+
+mkdir build
+cd build
+cmake -G "Unix Makefiles" $SRC_DIR/llvm -DLLVM_TARGETS_TO_BUILD="X86" -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_INCLUDE_TESTS=0 -DLLVM_ENABLE_PROJECTS=bolt
+
+make -j`nproc` llvm-bolt merge-fdata perf2bolt
+cp bin/{llvm-bolt,merge-fdata,perf2bolt} ${PREFIX}/bin/
+cp lib/libbolt_* ${PREFIX}/lib/

--- a/pyston/conda/bolt/meta.yaml
+++ b/pyston/conda/bolt/meta.yaml
@@ -1,18 +1,18 @@
-{% set commit_hash  = "0c14e20238604a4c05e174e71676857d45c60a0f" %}
-{% set version_name = "2021.06.05" %}  # date of the commit 
+{% set build_num = 0 %}
+{% set version = "2.3.1" %}
 
 package:
   name: bolt
-  version: {{ version_name }}
+  version: {{ version }}
 
 source:
-  # git_url: https://github.com/facebookincubator/BOLT
-  # usig git we can only checkout HEAD or a tag
-  # but the tags are too old for us so download an archive via github
-  url: https://github.com/facebookincubator/BOLT/archive/{{ commit_hash }}/bolt.zip
+  git_url: https://github.com/pyston/BOLT
+  git_rev: pyston_{{version}}
+  git_depth: -1
 
 build:
-  number: 0
+  number: {{ build_num }}
+  string: {{ build_num }}_pyston
 
 outputs:
   - name: bolt
@@ -36,7 +36,7 @@ test:
     - merge-fdata --version
 
 about:
-  home: https://github.com/facebookincubator/BOLT/
+  home: https://github.com/pyston/BOLT/
   licence: Apache License v2.0 with LLVM Exceptions
   licence_file: LICENCE.TXT
   summary: BOLT is a post-link optimizer developed to speed up large applications.

--- a/pyston/conda/bolt/meta.yaml
+++ b/pyston/conda/bolt/meta.yaml
@@ -1,0 +1,42 @@
+{% set commit_hash  = "0c14e20238604a4c05e174e71676857d45c60a0f" %}
+{% set version_name = "2021.06.05" %}  # date of the commit 
+
+package:
+  name: bolt
+  version: {{ version_name }}
+
+source:
+  # git_url: https://github.com/facebookincubator/BOLT
+  # usig git we can only checkout HEAD or a tag
+  # but the tags are too old for us so download an archive via github
+  url: https://github.com/facebookincubator/BOLT/archive/{{ commit_hash }}/bolt.zip
+
+build:
+  number: 0
+
+outputs:
+  - name: bolt
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - make
+        - cmake
+        - zlib
+        - ncurses
+
+      run:
+        - zlib
+        - ncurses
+
+test:
+  commands:
+    - llvm-bolt --version
+    - perf2bolt --version
+    - merge-fdata --version
+
+about:
+  home: https://github.com/facebookincubator/BOLT/
+  licence: Apache License v2.0 with LLVM Exceptions
+  licence_file: LICENCE.TXT
+  summary: BOLT is a post-link optimizer developed to speed up large applications.

--- a/pyston/conda/build_pkgs.sh
+++ b/pyston/conda/build_pkgs.sh
@@ -30,6 +30,12 @@ do
     CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 conda build \${pkg}-feedstock/recipe --python="${PYSTON_PKG_VER}" --override-channels -c conda-forge --use-local
 done
 
+# build numpy 1.20.3 using openblas
+git clone https://github.com/AnacondaRecipes/numpy-feedstock.git -b pbs_1.20.3_20210520T162213
+# 'test_for_reference_leak' fails for pyston - disable it
+sed -i 's/_not_a_real_test/test_for_reference_leak/g' numpy-feedstock/recipe/meta.yaml
+conda build numpy-feedstock/ --python="${PYSTON_PKG_VER}" --override-channels -c conda-forge --use-local --extra-deps pyston --variants="{blas_impl: openblas, openblas: 0.3.3, c_compiler_version: 7.5.0, cxx_compiler_version: 7.5.0}"
+
 for arch in noarch linux-64
 do
     mkdir /conda_pkgs/\${arch}

--- a/pyston/conda/build_pkgs.sh
+++ b/pyston/conda/build_pkgs.sh
@@ -2,11 +2,16 @@
 set -eux
 
 PYSTON_PKG_VER="3.8.5 *_23_pyston"
-OUT_DIR=${PWD}/release/conda_pkgs
+OUTPUT_DIR=${PWD}/release/conda_pkgs
 
-mkdir -p ${OUT_DIR}
+if [ -d $OUTPUT_DIR ]
+then
+    echo "Directory $OUTPUT_DIR already exists";
+    exit 1
+fi
+mkdir -p ${OUTPUT_DIR}
 
-docker run -iv${PWD}:/pyston_dir:ro -v${OUT_DIR}:/conda_pkgs continuumio/miniconda3 sh -s <<EOF
+docker run -iv${PWD}:/pyston_dir:ro -v${OUTPUT_DIR}:/conda_pkgs continuumio/miniconda3 sh -s <<EOF
 set -eux
 conda install conda-build -y
 conda build pyston_dir/pyston/conda/compiler-rt
@@ -30,5 +35,6 @@ do
     mkdir /conda_pkgs/\${arch}
     cp /opt/conda/conda-bld/\${arch}/*.tar.bz2 /conda_pkgs/\${arch}
 done
+chown -R $(id -u):$(id -g) /conda_pkgs/
 
 EOF

--- a/pyston/conda/build_pkgs.sh
+++ b/pyston/conda/build_pkgs.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eux
+
+PYSTON_PKG_VER="3.8.5 *_23_pyston"
+OUT_DIR=${PWD}/release/conda_pkgs
+
+mkdir -p ${OUT_DIR}
+
+docker run -iv${PWD}:/pyston_dir:ro -v${OUT_DIR}:/conda_pkgs continuumio/miniconda3 sh -s <<EOF
+set -eux
+conda install conda-build -y
+conda build pyston_dir/pyston/conda/compiler-rt
+conda build pyston_dir/pyston/conda/bolt
+conda build pyston_dir/pyston/conda/pyston
+conda build pyston_dir/pyston/conda/python_abi
+conda build pyston_dir/pyston/conda/python
+
+conda install patch -y # required to apply the patches in some recipes
+
+# This are the arch dependent pip dependencies. 
+# We set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 to prevent the implicit dependency on pip when specifying python.
+for pkg in certifi setuptools
+do
+    git clone https://github.com/AnacondaRecipes/\${pkg}-feedstock.git
+    CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 conda build \${pkg}-feedstock/recipe --python="${PYSTON_PKG_VER}" --override-channels -c conda-forge --use-local
+done
+
+for arch in noarch linux-64
+do
+    mkdir /conda_pkgs/\${arch}
+    cp /opt/conda/conda-bld/\${arch}/*.tar.bz2 /conda_pkgs/\${arch}
+done
+
+EOF

--- a/pyston/conda/compiler-rt/bld.bat
+++ b/pyston/conda/compiler-rt/bld.bat
@@ -1,0 +1,34 @@
+mkdir build
+if errorlevel 1 exit 1
+
+cd build
+if errorlevel 1 exit 1
+
+set BUILD_CONFIG=Release
+if errorlevel 1 exit 1
+
+set "CC=clang-cl.exe"
+set "CXX=clang-cl.exe"
+
+set "INSTALL_PREFIX=%LIBRARY_PREFIX%\lib\clang\%PKG_VERSION%"
+
+cmake ^
+    -G "NMake Makefiles" ^
+    -DCMAKE_BUILD_TYPE="Release" ^
+    -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_INSTALL_PREFIX:PATH="%INSTALL_PREFIX%" ^
+    -DCMAKE_MODULE_PATH:PATH="%LIBRARY_LIB%\cmake" ^
+    -DLLVM_CONFIG_PATH:PATH="%LIBRARY_BIN%\llvm-config.exe" ^
+    "%SRC_DIR%"
+if errorlevel 1 exit 1
+
+:: Build step
+nmake
+if errorlevel 1 exit 1
+
+:: Install step
+nmake install
+if errorlevel 1 exit 1
+
+mkdir %PREFIX%\lib\clang\%PKG_VERSION%\lib\windows
+copy %INSTALL_PREFIX%\lib\windows\* %PREFIX%\lib\clang\%PKG_VERSION%\lib\windows\

--- a/pyston/conda/compiler-rt/build.sh
+++ b/pyston/conda/compiler-rt/build.sh
@@ -1,0 +1,35 @@
+if [[ "$target_platform" == "osx-64" ]]; then
+    EXTRA_CMAKE_ARGS="-DDARWIN_osx_ARCHS=x86_64 -DCOMPILER_RT_ENABLE_IOS=Off"
+    EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DDARWIN_macosx_CACHED_SYSROOT=${CONDA_BUILD_SYSROOT} -DCMAKE_LIBTOOL=$LIBTOOL"
+fi
+
+# Prep build
+cp -R "${PREFIX}/lib/cmake/llvm" "${PREFIX}/lib/cmake/modules/"
+
+mkdir build
+cd build
+
+INSTALL_PREFIX=${PREFIX}/lib/clang/${PKG_VERSION}
+
+cmake \
+    -G "Unix Makefiles" \
+    -DCMAKE_BUILD_TYPE="Release" \
+    -DCMAKE_PREFIX_PATH:PATH="${PREFIX}" \
+    -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_PREFIX}" \
+    -DCMAKE_RUNTIME_OUTPUT_DIRECTORY:PATH="${INSTALL_PREFIX}/lib" \
+    -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:PATH="${INSTALL_PREFIX}/lib" \
+    -DCMAKE_MODULE_PATH:PATH="${PREFIX}/lib/cmake" \
+    -DLLVM_CONFIG_PATH:PATH="${PREFIX}/bin/llvm-config" \
+    -DPYTHON_EXECUTABLE:PATH="${BUILD_PREFIX}/bin/python" \
+    -DCMAKE_LINKER="$LD" \
+    ${EXTRA_CMAKE_ARGS} \
+    "${SRC_DIR}"
+
+# Build step
+make -j$CPU_COUNT VERBOSE=1
+
+# Install step
+make install -j$CPU_COUNT
+
+# Clean up after build
+rm -rf "${PREFIX}/lib/cmake/modules"

--- a/pyston/conda/compiler-rt/conda_build_config.yaml
+++ b/pyston/conda/compiler-rt/conda_build_config.yaml
@@ -1,0 +1,16 @@
+cxx_compiler:
+  - clang_bootstrap  # [osx]
+  - gxx              # [linux]
+  - vs2017           # [win]
+c_compiler:
+  - clang_bootstrap  # [osx]
+  - gcc              # [linux]
+  - vs2017           # [win]
+vc:
+  - 14
+python:
+  - 3.7
+c_compiler_version:     # [osx]
+  - "9.0.1"             # [osx]
+cxx_compiler_version:   # [osx]
+  - "9.0.1"             # [osx]

--- a/pyston/conda/compiler-rt/macosx_10_9.patch
+++ b/pyston/conda/compiler-rt/macosx_10_9.patch
@@ -1,0 +1,71 @@
+From eaa09b0ac70d1ebba29c4650cb5e5c14b9049499 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Tue, 16 Oct 2018 21:23:44 -0500
+Subject: [PATCH 3/3] compiler-rt: Make 7.0.0 compatible with 10.9 SDK
+
+---
+ lib/xray/xray_buffer_queue.h |  7 +++++++
+ lib/xray/xray_utils.h        | 30 ++++++++++++++++++++++++++++++
+ 2 files changed, 37 insertions(+)
+
+diff --git a/lib/xray/xray_buffer_queue.h b/lib/xray/xray_buffer_queue.h
+index e76fa79..e20a69a 100644
+--- a/lib/xray/xray_buffer_queue.h
++++ b/lib/xray/xray_buffer_queue.h
+@@ -20,6 +20,13 @@
+ #include "sanitizer_common/sanitizer_mutex.h"
+ #include <cstddef>
+ 
++#include <sys/mman.h>
++/* MAP_ANONYMOUS is MAP_ANON on some systems,
++   e.g. OS X (before Sierra), OpenBSD etc */
++#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
++#define MAP_ANONYMOUS MAP_ANON
++#endif
++
+ namespace __xray {
+ 
+ /// BufferQueue implements a circular queue of fixed sized buffers (much like a
+diff --git a/lib/xray/xray_utils.h b/lib/xray/xray_utils.h
+index eafa16e..a8dad83 100644
+--- a/lib/xray/xray_utils.h
++++ b/lib/xray/xray_utils.h
+@@ -20,6 +20,36 @@
+ #include <sys/types.h>
+ #include <utility>
+ 
++#if defined __APPLE__
++#include <time.h>
++#include <mach/clock.h>
++#include <mach/mach.h>
++int alt_clock_gettime(int clock_id, timespec *ts) {
++  clock_serv_t cclock;
++  mach_timespec_t mts;
++  host_get_clock_service(mach_host_self(), clock_id, &cclock);
++  clock_get_time(cclock, &mts);
++  mach_port_deallocate(mach_task_self(), cclock);
++  ts->tv_sec = mts.tv_sec;
++  ts->tv_nsec = mts.tv_nsec;
++  return 0;
++}
++#include <sys/mman.h>
++/* MAP_ANONYMOUS is MAP_ANON on some systems,
++   e.g. OS X (before Sierra), OpenBSD etc */
++#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
++#define MAP_ANONYMOUS MAP_ANON
++#endif
++
++#if defined __APPLE__ && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // less than macOS 10.12
++  #define clock_gettime alt_clock_gettime
++  #define CLOCK_REALTIME CALENDAR_CLOCK
++  #define CLOCK_MONOTONIC SYSTEM_CLOCK
++  typedef int clockid_t;
++#endif
++
++#endif
++
+ namespace __xray {
+ 
+ // Default implementation of the reporting interface for sanitizer errors.
+-- 
+2.5.4 (Apple Git-61)

--- a/pyston/conda/compiler-rt/meta.yaml
+++ b/pyston/conda/compiler-rt/meta.yaml
@@ -1,0 +1,100 @@
+# this recipe is taken from the main/compiler-rt because
+# it's currently not build for linux
+{% set name = "compiler-rt-packages" %}
+{% set version = "10.0.1" %}
+{% set build_number = 0 %}
+{% set sha256 = "d90dc8e121ca0271f0fd3d639d135bfaa4b6ed41e67bd6eb77808f72629658fa" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version }}/compiler-rt-{{ version }}.src.tar.xz
+  sha256: {{ sha256 }}
+  patches:
+    - no_codesign.diff
+    - macosx_10_9.patch
+
+build:
+  number: {{ build_number }}
+
+requirements:
+  build:
+    - cmake >=3.4.3
+    - {{ compiler('cxx') }}
+    - python
+    - make  # [unix]
+  host:
+    - clangdev {{ version }}
+    - llvmdev {{ version }}
+    - libcxx {{ cxx_compiler_version }}  # [osx]
+    - git
+    - patch
+
+test:
+  files:
+    - test.c.in
+  commands:
+  {% set NEW_TARGET="10." ~ (((MACOSX_DEPLOYMENT_TARGET|default("10.13")).split(".")[1])|int + 1) %}
+    - sed "s/@MACOSX_DEPLOYMENT_TARGET@/{{ NEW_TARGET }}/g" test.c.in > test.c
+    - clang -mmacosx-version-min={{ MACOSX_DEPLOYMENT_TARGET }} test.c  # [osx]
+    - test -f $PREFIX/lib/clang/{{ version }}/include/sanitizer/asan_interface.h  # [unix]
+
+outputs:
+  - name: compiler-rt_{{ target_platform }}
+    build:
+      noarch: generic
+      ignore_run_exports:
+        - vc
+        - libcxx
+        - libgcc-ng
+        - libstdcxx-ng
+      detect_binary_files_with_prefix: false  # [win]
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+      run:
+        - libcxx >={{ cxx_compiler_version }}  # [osx]
+        - clang {{ version }}
+        - clangxx {{ version }}
+      run_constrained:
+        - compiler-rt {{ version }}
+    files:
+      - lib/clang/{{ version }}/lib
+
+  - name: compiler-rt
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+      run:
+        - clang {{ version }}
+        - clangxx {{ version }}
+        - compiler-rt_{{ target_platform }} {{ version }}
+    files:
+      - lib/clang/{{ version }}/share             # [unix]
+      - lib/clang/{{ version }}/include           # [unix]
+      - Library/lib/clang/{{ version }}/share     # [win]
+      - Library/lib/clang/{{ version }}/include   # [win]
+      - Library/lib/clang/{{ version }}/lib       # [win]
+
+about:
+  home: http://llvm.org/
+  license: NCSA
+  license_file: LICENSE.TXT
+  summary: compiler-rt runtime libraries
+  description: |
+    builtins - low-level target-specific hooks required by code generation and other
+      runtime components
+    sanitizer runtimes - AddressSanitizer, ThreadSanitizer, UndefinedBehaviorSanitizer,
+      MemorySanitizer, LeakSanitizer, DataFlowSanitizer
+    profile - library which is used to collect coverage information
+    BlocksRuntime - target-independent implementation of Apple "Blocks" runtime
+      interfaces
+
+extra:
+  recipe-maintainers:
+    - SylvainCorlay
+    - inducer
+    - jakirkham
+    - isuruf

--- a/pyston/conda/compiler-rt/no_codesign.diff
+++ b/pyston/conda/compiler-rt/no_codesign.diff
@@ -1,0 +1,20 @@
+diff --git a/cmake/Modules/AddCompilerRT.cmake b/cmake/Modules/AddCompilerRT.cmake
+index 81b110203..ef6dbff57 100644
+--- a/cmake/Modules/AddCompilerRT.cmake
++++ b/cmake/Modules/AddCompilerRT.cmake
+@@ -290,14 +290,6 @@ function(add_compiler_rt_runtime name type)
+         set_target_properties(${libname} PROPERTIES IMPORT_PREFIX "")
+         set_target_properties(${libname} PROPERTIES IMPORT_SUFFIX ".lib")
+       endif()
+-      if(APPLE)
+-        # Ad-hoc sign the dylibs
+-        add_custom_command(TARGET ${libname}
+-          POST_BUILD  
+-          COMMAND codesign --sign - $<TARGET_FILE:${libname}>
+-          WORKING_DIRECTORY ${COMPILER_RT_LIBRARY_OUTPUT_DIR}
+-        )
+-      endif()
+     endif()
+     install(TARGETS ${libname}
+       ARCHIVE DESTINATION ${install_dir_${libname}}
+

--- a/pyston/conda/compiler-rt/test.c.in
+++ b/pyston/conda/compiler-rt/test.c.in
@@ -1,0 +1,4 @@
+int main() {
+  if(__builtin_available(macOS @MACOSX_DEPLOYMENT_TARGET@, *)) return 1;
+  return 0;
+}

--- a/pyston/conda/pyston/build_base.sh
+++ b/pyston/conda/pyston/build_base.sh
@@ -35,7 +35,9 @@ cp -r $OUTDIR/usr/lib/* ${PREFIX}/lib/
 # remove pip
 rm -r ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages/pip*
 
-# remove pystons site-packages directory and replace it with a symlink to cpythons default site-package directory
-rm -r ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages
+# remove pystons site-packages directory and replace it with a symlink to cpythons default site-packages directory
+# we copy in our site-package/README.txt and package it to make sure the directory get's created.
 mkdir -p ${PREFIX}/lib/python${PYTHON_VERSION2}/site-packages || true
+cp ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages/README.txt ${PREFIX}/lib/python${PYTHON_VERSION2}/site-packages
+rm -r ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages
 ln -s ${PREFIX}/lib/python${PYTHON_VERSION2}/site-packages/ ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages

--- a/pyston/conda/pyston/build_base.sh
+++ b/pyston/conda/pyston/build_base.sh
@@ -35,6 +35,7 @@ cp -r $OUTDIR/usr/lib/* ${PREFIX}/lib/
 # remove pip
 rm -r ${PREFIX}/lib/python3.8-pyston2.3/site-packages/pip*
 
-# replace python
-#ln -sf ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/python
-#ln -sf ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/python3
+# move site-packages directory to cpythons default site-package directory and create a symlink from pyston location
+mkdir ${PREFIX}/lib/python3.8/
+mv ${PREFIX}/lib/python3.8-pyston2.3/site-packages ${PREFIX}/lib/python3.8/
+ln -s ${PREFIX}/lib/python3.8/site-packages/ ${PREFIX}/lib/python3.8-pyston2.3/site-packages

--- a/pyston/conda/pyston/build_base.sh
+++ b/pyston/conda/pyston/build_base.sh
@@ -25,17 +25,17 @@ make -j`nproc` pyston3
 
 OUTDIR=$SRC_DIR/build/opt_install
 
-cp $OUTDIR/usr/bin/python3.bolt ${PREFIX}/bin/python3.8-pyston2.3
-ln -s ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/pyston
-ln -s ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/pyston3
+cp $OUTDIR/usr/bin/python3.bolt ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}
+ln -s ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2} ${PREFIX}/bin/pyston
+ln -s ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2} ${PREFIX}/bin/pyston3
 
 cp -r $OUTDIR/usr/include/* ${PREFIX}/include/
 cp -r $OUTDIR/usr/lib/* ${PREFIX}/lib/
 
 # remove pip
-rm -r ${PREFIX}/lib/python3.8-pyston2.3/site-packages/pip*
+rm -r ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages/pip*
 
 # move site-packages directory to cpythons default site-package directory and create a symlink from pyston location
-mkdir ${PREFIX}/lib/python3.8/
-mv ${PREFIX}/lib/python3.8-pyston2.3/site-packages ${PREFIX}/lib/python3.8/
-ln -s ${PREFIX}/lib/python3.8/site-packages/ ${PREFIX}/lib/python3.8-pyston2.3/site-packages
+mkdir ${PREFIX}/lib/python${PYTHON_VERSION2}/
+mv ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages ${PREFIX}/lib/python${PYTHON_VERSION2}/
+ln -s ${PREFIX}/lib/python${PYTHON_VERSION2}/site-packages/ ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages

--- a/pyston/conda/pyston/build_base.sh
+++ b/pyston/conda/pyston/build_base.sh
@@ -35,7 +35,7 @@ cp -r $OUTDIR/usr/lib/* ${PREFIX}/lib/
 # remove pip
 rm -r ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages/pip*
 
-# move site-packages directory to cpythons default site-package directory and create a symlink from pyston location
-mkdir ${PREFIX}/lib/python${PYTHON_VERSION2}/
-mv ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages ${PREFIX}/lib/python${PYTHON_VERSION2}/
+# remove pystons site-packages directory and replace it with a symlink to cpythons default site-package directory
+rm -r ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages
+mkdir -p ${PREFIX}/lib/python${PYTHON_VERSION2}/site-packages || true
 ln -s ${PREFIX}/lib/python${PYTHON_VERSION2}/site-packages/ ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages

--- a/pyston/conda/pyston/build_base.sh
+++ b/pyston/conda/pyston/build_base.sh
@@ -4,6 +4,15 @@ set -eux
 # pyston should not compile llvm and bolt but instead use the conda packages
 export PYSTON_USE_SYS_BINS=1
 
+# the conda compiler is named 'x86_64-conda-linux-gnu-cc' but cpython compares 
+# the name to *gcc*, *clang* in the configure file - so we have to use the real name. 
+# Code mostly copied from the cpython recipe.
+AR=$(basename "${AR}")
+CC=$(basename "${GCC}")
+CXX=$(basename "${CXX}")
+RANLIB=$(basename "${RANLIB}")
+READELF=$(basename "${READELF}")
+
 # overwrite default conda build flags else the bolt instrumented binary will not work
 CFLAGS="-isystem ${PREFIX}/include"
 LDFLAGS="-Wl,-rpath,${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"

--- a/pyston/conda/pyston/build_base.sh
+++ b/pyston/conda/pyston/build_base.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eux
+
+# pyston should not compile llvm and bolt but instead use the conda packages
+export PYSTON_USE_SYS_BINS=1
+
+# overwrite default conda build flags else the bolt instrumented binary will not work
+CFLAGS="-isystem ${PREFIX}/include"
+LDFLAGS="-Wl,-rpath,${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
+CPPFLAGS="-isystem ${PREFIX}/include"
+
+# without this line we can't find zlib and co..
+CPPFLAGS=${CPPFLAGS}" -I${PREFIX}/include"
+
+make -j`nproc` pyston3
+
+OUTDIR=$SRC_DIR/build/opt_install
+
+cp $OUTDIR/usr/bin/python3.bolt ${PREFIX}/bin/python3.8-pyston2.3
+cp $OUTDIR/usr/bin/pip3.8 ${PREFIX}/bin/pip-pyston2.3
+ln -s ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/pyston
+ln -s ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/pyston3
+ln -s ${PREFIX}/bin/pip-pyston2.3 ${PREFIX}/bin/pip-pyston
+
+cp -r $OUTDIR/usr/include/* ${PREFIX}/include/
+cp -r $OUTDIR/usr/lib/* ${PREFIX}/lib/
+
+# replace python
+#ln -sf ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/python
+#ln -sf ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/python3

--- a/pyston/conda/pyston/build_base.sh
+++ b/pyston/conda/pyston/build_base.sh
@@ -17,13 +17,14 @@ make -j`nproc` pyston3
 OUTDIR=$SRC_DIR/build/opt_install
 
 cp $OUTDIR/usr/bin/python3.bolt ${PREFIX}/bin/python3.8-pyston2.3
-cp $OUTDIR/usr/bin/pip3.8 ${PREFIX}/bin/pip-pyston2.3
 ln -s ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/pyston
 ln -s ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/pyston3
-ln -s ${PREFIX}/bin/pip-pyston2.3 ${PREFIX}/bin/pip-pyston
 
 cp -r $OUTDIR/usr/include/* ${PREFIX}/include/
 cp -r $OUTDIR/usr/lib/* ${PREFIX}/lib/
+
+# remove pip
+rm -r ${PREFIX}/lib/python3.8-pyston2.3/site-packages/pip*
 
 # replace python
 #ln -sf ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/python

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -1,3 +1,4 @@
+{% set build_num = 4 %}
 {% set llvm_version = "10.0.1" %}
 {% set pyston_version = "2.3.1" %}
 {% set python_version = "3.8.5" %}
@@ -5,7 +6,7 @@
 {% set python_version2 = ".".join(python_version.split(".")[:2]) %}
 
 package:
-  name: pyston
+  name: pyston{{ pyston_version2 }}
   version: {{ pyston_version }}
   skip: True  # [not linux]
 
@@ -13,14 +14,14 @@ source:
   path: ../../../
 
 build:
-  number: 1
+  number: {{ build_num }}
 
   # don't compile python code for now
   skip_compile_pyc:
     "*.py"
 
 outputs:
-  - name: pyston
+  - name: pyston{{ pyston_version2 }}
     script: build_base.sh
 
     requirements:

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -1,15 +1,19 @@
 {% set llvm_version = "10.0.1" %}
+{% set pyston_version = "2.3.1" %}
+{% set python_version = "3.8.5" %}
+{% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}
+{% set python_version2 = ".".join(python_version.split(".")[:2]) %}
 
 package:
   name: pyston
-  version: "2.3.1a"
+  version: {{ pyston_version }}
   skip: True  # [not linux]
 
 source:
   path: ../../../
 
 build:
-  number: 2
+  number: 1
 
   # don't compile python code for now
   skip_compile_pyc:
@@ -63,6 +67,9 @@ outputs:
         - readline
         - ncurses
         - libffi
+      
+      run_constrained:
+        python {{ python_version }} *_{{ pyston_version2.replace('.', '') }}_pyston
 
 test:
   commands:

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -20,6 +20,10 @@ build:
   skip_compile_pyc:
     "*.py"
 
+  script_env:
+   - PYSTON_VERSION2={{ pyston_version2 }}
+   - PYTHON_VERSION2={{ python_version2 }}
+
 outputs:
   - name: pyston{{ pyston_version2 }}
     script: build_base.sh

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -9,7 +9,7 @@ source:
   path: ../../../
 
 build:
-  number: 0
+  number: 1
 
   # don't compile python code for now
   skip_compile_pyc:
@@ -67,8 +67,6 @@ outputs:
 test:
   commands:
     - pyston -c "print('works')"
-    - pyston -mpip list
-    - pyston -mpip install attrs
 
 about:
   home: https://github.com/pyston/pyston

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 7 %}
+{% set build_num = 0 %}
 {% set llvm_version = "10.0.1" %}
 {% set pyston_version = "2.3.1" %}
 {% set python_version = "3.8.5" %}
@@ -89,3 +89,4 @@ about:
   home: https://github.com/pyston/pyston
   license: PSF
   license_file: ../../../LICENSE
+  summary: Pyston Python implementation

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 5 %}
+{% set build_num = 7 %}
 {% set llvm_version = "10.0.1" %}
 {% set pyston_version = "2.3.1" %}
 {% set python_version = "3.8.5" %}
@@ -21,8 +21,13 @@ build:
     "*.py"
 
   script_env:
-   - PYSTON_VERSION2={{ pyston_version2 }}
-   - PYTHON_VERSION2={{ python_version2 }}
+    - PYSTON_VERSION2={{ pyston_version2 }}
+    - PYTHON_VERSION2={{ python_version2 }}
+
+  always_include_files:
+    # this directory is already created by our build requirement on 'python' so will not get bundled automatically
+    # but we want the pyston package to create it too so force package our README.txt.
+    - lib/python{{ python_version2 }}/site-packages/README.txt
 
 outputs:
   - name: pyston{{ pyston_version2 }}

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -1,0 +1,76 @@
+{% set llvm_version = "10.0.1" %}
+
+package:
+  name: pyston
+  version: "2.3.1a"
+  skip: True  # [not linux]
+
+source:
+  path: ../../../
+
+build:
+  number: 0
+
+  # don't compile python code for now
+  skip_compile_pyc:
+    "*.py"
+
+outputs:
+  - name: pyston
+    script: build_base.sh
+
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - python
+        - make
+        - cmake
+        - virtualenv
+        - pkg-config
+        - clang={{ llvm_version }}
+        - llvmdev={{ llvm_version }}
+        - llvm-tools={{ llvm_version }}
+        - compiler-rt={{ llvm_version }}
+        - libtool
+        - sqlite
+        - luajit
+        - bolt==2021.06.05
+
+        - zlib
+        - bzip2
+        - openssl
+        - xz
+        - readline
+        - ncurses
+        - libffi
+
+        # nitrous needs 'nm'
+        - binutils 
+
+        # pillow dependencies
+        - freetype
+        - jpeg
+        - libtiff
+        - libwebp
+
+
+      run:
+        - zlib
+        - bzip2
+        - openssl
+        - xz
+        - readline
+        - ncurses
+        - libffi
+
+test:
+  commands:
+    - pyston -c "print('works')"
+    - pyston -mpip list
+    - pyston -mpip install attrs
+
+about:
+  home: https://github.com/pyston/pyston
+  license: PSF
+  license_file: ../../../LICENSE

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -9,7 +9,7 @@ source:
   path: ../../../
 
 build:
-  number: 1
+  number: 2
 
   # don't compile python code for now
   skip_compile_pyc:
@@ -35,7 +35,7 @@ outputs:
         - libtool
         - sqlite
         - luajit
-        - bolt==2021.06.05
+        - bolt==2.3.1 *_pyston
 
         - zlib
         - bzip2

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 4 %}
+{% set build_num = 5 %}
 {% set llvm_version = "10.0.1" %}
 {% set pyston_version = "2.3.1" %}
 {% set python_version = "3.8.5" %}

--- a/pyston/conda/python/build_base.sh
+++ b/pyston/conda/python/build_base.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eux
+
+# replace python
+ln -sf ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/python
+ln -sf ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/python3

--- a/pyston/conda/python/build_base.sh
+++ b/pyston/conda/python/build_base.sh
@@ -2,5 +2,5 @@
 set -eux
 
 # replace python
-ln -sf ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/python
-ln -sf ${PREFIX}/bin/python3.8-pyston2.3 ${PREFIX}/bin/python3
+ln -sf ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2} ${PREFIX}/bin/python
+ln -sf ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2} ${PREFIX}/bin/python3

--- a/pyston/conda/python/build_base.sh
+++ b/pyston/conda/python/build_base.sh
@@ -4,3 +4,4 @@ set -eux
 # replace python
 ln -sf ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2} ${PREFIX}/bin/python
 ln -sf ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2} ${PREFIX}/bin/python3
+ln -sf ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2} ${PREFIX}/bin/python${PYTHON_VERSION2}

--- a/pyston/conda/python/meta.yaml
+++ b/pyston/conda/python/meta.yaml
@@ -19,6 +19,9 @@ outputs:
       string: {{ build_num }}_{{ pyston_version2.replace('.', '') }}_pyston
       track_features:
         - pyston
+      script_env:
+        - PYSTON_VERSION2={{ pyston_version2 }}
+        - PYTHON_VERSION2={{ python_version2 }}
 
     run_exports:
       weak:

--- a/pyston/conda/python/meta.yaml
+++ b/pyston/conda/python/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 3 %}
+{% set build_num = 4 %}
 {% set pyston_version = "2.3.1" %}
 {% set python_version = "3.8.5" %}
 {% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}

--- a/pyston/conda/python/meta.yaml
+++ b/pyston/conda/python/meta.yaml
@@ -1,44 +1,58 @@
-{% set build_num = 1 %}
+{% set build_num = 3 %}
 {% set pyston_version = "2.3.1" %}
 {% set python_version = "3.8.5" %}
 {% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}
 {% set python_version2 = ".".join(python_version.split(".")[:2]) %}
 
 package:
-  name: python
+  name: python-meta
   version: {{ python_version }}
   skip: True  # [not linux]
-
-build:
-  number: {{ build_num }}
-  string: {{ build_num }}_{{ pyston_version2.replace('.', '') }}_pyston
-  #noarch: generic
-  track_features:
-    - pyston
 
 outputs:
   - name: python
     script: build_base.sh
     version: {{ python_version }}
 
+    build:
+      number: {{ build_num }}
+      string: {{ build_num }}_{{ pyston_version2.replace('.', '') }}_pyston
+      track_features:
+        - pyston
+
     run_exports:
       weak:
-        - pyston >={{ pyston_version }}
+        - pyston{{ pyston_version2 }} >={{ pyston_version }}
         - python_abi {{ python_version2 }} *_{{ pyston_version2.replace('.', '') }}_pyston
       noarch:
         - {{ pin_subpackage("python", max_pin="x.x", min_pin="x.x") }}
 
     requirements:
       build:
-        - pyston {{ pyston_version }}
+        - pyston{{ pyston_version2 }} {{ pyston_version }}
 
       run:
-        - pyston {{ pyston_version }}
+        - pyston{{ pyston_version2 }} {{ pyston_version }}
         - python_abi {{ python_version2 }} *_{{ pyston_version2.replace('.', '') }}_pyston
 
-test:
-  commands:
-    - python --version | grep Pyston
+    test:
+      commands:
+        - python --version | grep Pyston
+
+  - name: pyston
+    version: {{ pyston_version }}
+
+    build:
+      number: {{ build_num }}
+      noarch: generic
+
+    requirements:
+      run:
+        - python {{ python_version }} {{ build_num }}_{{ pyston_version2.replace('.', '') }}_pyston
+
+    test:
+      commands:
+        - python --version | grep Pyston
 
 about:
   home: https://github.com/pyston/pyston

--- a/pyston/conda/python/meta.yaml
+++ b/pyston/conda/python/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: python
+  version: "3.8.5"
+  skip: True  # [not linux]
+
+build:
+  number: 0
+  string: pyston
+  noarch: generic
+
+outputs:
+  - name: python
+    script: build_base.sh
+    requirements:
+      build:
+        - pyston
+      run:
+        - pyston
+
+test:
+  commands:
+    - python --version | grep Pyston
+
+about:
+  home: https://github.com/pyston/pyston
+  license: PSF

--- a/pyston/conda/python/meta.yaml
+++ b/pyston/conda/python/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 4 %}
+{% set build_num = 0 %}
 {% set pyston_version = "2.3.1" %}
 {% set python_version = "3.8.5" %}
 {% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}
@@ -60,3 +60,5 @@ outputs:
 about:
   home: https://github.com/pyston/pyston
   license: PSF
+  license_file: ../../../LICENSE
+  summary: Pyston Python implementation Metapackage

--- a/pyston/conda/python/meta.yaml
+++ b/pyston/conda/python/meta.yaml
@@ -1,21 +1,40 @@
+{% set build_num = 1 %}
+{% set pyston_version = "2.3.1" %}
+{% set python_version = "3.8.5" %}
+{% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}
+{% set python_version2 = ".".join(python_version.split(".")[:2]) %}
+
 package:
   name: python
-  version: "3.8.5"
+  version: {{ python_version }}
   skip: True  # [not linux]
 
 build:
-  number: 0
-  string: pyston
-  noarch: generic
+  number: {{ build_num }}
+  string: {{ build_num }}_{{ pyston_version2.replace('.', '') }}_pyston
+  #noarch: generic
+  track_features:
+    - pyston
 
 outputs:
   - name: python
     script: build_base.sh
+    version: {{ python_version }}
+
+    run_exports:
+      weak:
+        - pyston >={{ pyston_version }}
+        - python_abi {{ python_version2 }} *_{{ pyston_version2.replace('.', '') }}_pyston
+      noarch:
+        - {{ pin_subpackage("python", max_pin="x.x", min_pin="x.x") }}
+
     requirements:
       build:
-        - pyston
+        - pyston {{ pyston_version }}
+
       run:
-        - pyston
+        - pyston {{ pyston_version }}
+        - python_abi {{ python_version2 }} *_{{ pyston_version2.replace('.', '') }}_pyston
 
 test:
   commands:

--- a/pyston/conda/python_abi/meta.yaml
+++ b/pyston/conda/python_abi/meta.yaml
@@ -1,0 +1,30 @@
+{% set build_num = 0 %}
+{% set pyston_version = "2.3.1" %}
+{% set python_version = "3.8.5" %}
+{% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}
+{% set python_version2 = ".".join(python_version.split(".")[:2]) %}
+
+package:
+  name: python_abi
+  version: {{ python_version2 }}
+
+build:
+  number: {{ build_num }}
+  string: {{ build_num }}_{{ pyston_version2.replace('.', '') }}_pyston
+  track_features:
+    - pyston
+
+requirements:
+  run:
+    - pyston{{ pyston_version2 }} {{ pyston_version }}
+  run_constrained:
+    - python {{ python_version2 }}.* *_{{ pyston_version2.replace('.', '') }}_pyston
+
+test:
+  commands:
+    - pyston --version
+
+about:
+  home: https://github.com/pyston/pyston
+  license: PSF
+  license_file: ../../../LICENSE

--- a/pyston/nitrous/CMakeLists.txt
+++ b/pyston/nitrous/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ferror-limit=5 -fcolor-diagnostics")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ferror-limit=5 -fcolor-diagnostics")
 
-set(LLVM_LIB_DEPS LLVMCore LLVMSupport  LLVMBitReader LLVMAsmParser  LLVMTransformUtils LLVMScalarOpts  LLVMOrcJIT LLVMX86CodeGen LLVMPerfJITEvents LLVMX86AsmParser)
+set(LLVM_LIB_DEPS LLVMCore LLVMSupport  LLVMBitReader LLVMAsmParser  LLVMTransformUtils LLVMScalarOpts  LLVMOrcJIT LLVMX86CodeGen LLVMX86AsmParser)
 
 add_library(interp SHARED interp.cpp jit.cpp symbol_finder.cpp Execution.cpp Interpreter.cpp facts.cpp)
 target_include_directories(interp PRIVATE ${LLVM_INCLUDE_DIRS})

--- a/pyston/nitrous/jit.cpp
+++ b/pyston/nitrous/jit.cpp
@@ -100,7 +100,8 @@ public:
                          const RuntimeDyld::LoadedObjectInfo& L) {
                           static JITEventListener* jit_event
                               = JITEventListener::createPerfJITEventListener();
-                          jit_event->notifyObjectLoaded(K, Obj, L);
+                          if (jit_event)
+                              jit_event->notifyObjectLoaded(K, Obj, L);
                       }),
           CompileLayer(AcknowledgeORCv1Deprecation, ObjectLayer, SimpleCompiler(*TM)) {
         llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);


### PR DESCRIPTION
__Needs changes:__
- [x] replace 'python'
- [x] remove pip (should be own package)
- [x] figure out how to package all the 3rd party libraries (python abi string)
- [ ] fix package dependencies - are they correct? compare with cpython dependencies
- [ ] do all the builtin modules get build? compare with cpython conda package
- [ ] check if sysconfig is correct
- [ ] run tests during build - maybe we need to remove the tests from the final package
- [ ] strip binaries - I think they are not stripped now that we don't use dpkg to build
- [ ] generate correct .pyc files
- [ ] switch to 'release' from 'opt' build - maybe blocked by instrumentation problems in bolt
- [x] fix test failures during profiling ("file was modified... default.profraw")

__May need changes:__
- [ ] we internally pip install packages into a temporary environment for the bolt profiling task. I think this is okay because this package will not end up in the final conda package and we install them via exact version string but may still be preferred to supply the source packages locally instead.
- [x] ~bolt pkg directly loads source archive from github because we can only checkout tags. Maybe we should fork it and create tags ourselves instead. I named the bolt release we are using after the date of the last commit~ Forked bolt into the pyston org and created a tag which we point to.
 
__How to try it out:__
run the following script to build our packages in a docker miniconda image which outputs the finished packages into `release/conda_pkgs/`
```
$ pyston/conda/build_pkgs.sh
```
Afterwards index the directory and create a activate new enviroment called pyston_env
```
$ conda index -c pyston release/conda_pkgs/
$ conda create -n pyston_env pyston -c `pwd`/release/conda_pkgs/ -c conda-forge --override-channels
$ conda activate pyston_env
```
Now one can e.g install attrs package:
```
(pyston_env)$ conda install --override-channels -c conda-forge -c `pwd`/release/conda_pkgs/ attrs
(pyston_env)$ python -c "import attr"
```
Numpy:
```
(pyston_env)$ conda install --override-channels -c conda-forge -c `pwd`/release/conda_pkgs/ numpy
(pyston_env)$ python -c "import numpy as np; print(np.identity(5))"
```
__Note:__
I used conda-forge instead of the default anaconda channel because conda-forge packages have the python_abi tag set -
on the main channel it will happily let you install cpython extensions compiled against cpython.


__Note:__
The `compiler-rt` recipe is from anaconda but they currently don't build a linux_64 version thats why we also have compile it for now and I included it. 