### PR TITLE
Change Docker image source to buildpack-deps and add slim image

### DIFF
--- a/pyston/docker/Dockerfile
+++ b/pyston/docker/Dockerfile
@@ -1,14 +1,20 @@
-FROM ubuntu:20.04
+FROM buildpack-deps:20.04
 
 ENV PYSTON_VERSION='2.3.1'
 ENV UBUNTU_VERSION='20.04'
 
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG C.UTF-8
+
 RUN set -eux; \
     apt-get update; \
-    apt-get install -y wget; \
+    apt-get install -y --no-install-recommends wget; \
     wget https://github.com/pyston/pyston/releases/download/pyston_${PYSTON_VERSION}/pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
-    apt install -y ./pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
+    apt-get install -y ./pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
     rm pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
+    apt-get remove -y wget; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
@@ -18,4 +24,3 @@ RUN set -eux; \
     ln -sf /usr/bin/pip-pyston /usr/bin/pip
 
 CMD ["python3.8"]
-

--- a/pyston/docker/Dockerfile.slim-bullseye
+++ b/pyston/docker/Dockerfile.slim-bullseye
@@ -1,0 +1,30 @@
+FROM debian:bullseye-slim
+
+ENV PYSTON_VERSION='2.3.1'
+ENV UBUNTU_VERSION='20.04'
+
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG C.UTF-8
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+            ca-certificates \
+            netbase \
+            wget \
+        ; \
+    wget https://github.com/pyston/pyston/releases/download/pyston_${PYSTON_VERSION}/pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
+    apt-get install -y ./pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
+    rm pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
+    apt-get remove -y wget; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    ln -sf /usr/bin/pyston /usr/bin/python3.8; \
+    ln -sf /usr/bin/pyston /usr/bin/python3; \
+    ln -sf /usr/bin/pyston /usr/bin/python; \
+    ln -sf /usr/bin/pip-pyston /usr/bin/pip
+
+CMD ["python3.8"]

--- a/pyston/docker/build_docker.sh
+++ b/pyston/docker/build_docker.sh
@@ -1,7 +1,16 @@
+#!/bin/sh
+
 set -eux
 
 BUILD_NAME=2.3.1
+DIR=$(dirname $0)
 
-docker build -t pyston/pyston:latest -t pyston/pyston:${BUILD_NAME} $(dirname $0)
+docker build -t pyston/pyston:latest -t pyston/pyston:${BUILD_NAME} -f ${DIR}/Dockerfile ${DIR}
 docker push pyston/pyston:latest
 docker push pyston/pyston:${BUILD_NAME}
+
+docker build -t pyston/pyston:slim-bullseye -t pyston/pyston:slim -t pyston/pyston:${BUILD_NAME}-slim-bullseye -t pyston/pyston:${BUILD_NAME}-slim -f ${DIR}/Dockerfile.slim-bullseye ${DIR}
+docker push pyston/pyston:slim
+docker push pyston/pyston:slim-bullseye
+docker push pyston/pyston:${BUILD_NAME}-slim-bullseye
+docker push pyston/pyston:${BUILD_NAME}-slim


### PR DESCRIPTION
Follow-up on #109. 

Image sizes: 

* 931 MB for the buildpack-deps image (vs 909 MB for the `python:3.8` image)
* 310 MB for the bullseye-slim image (vs 122 MB for the `python:3.8-slim` image, but since the unarchived portable Pyston tarball is 261 MB already, the increase definitely stems from there; not sure how to go about reducing this or if it's even possible)

I tried adding an alpine-based image as well, but could not get the portable version of Pyston to run on it. I'd say this is a good enough start and alpine can be investigated if there is demand for it.