### PR TITLE
CI: Add github action which builds pyston and runs the cpython testsuite

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -1,0 +1,36 @@
+name: GitHub Actions CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - build: unopt
+            PYSTON_UNOPT_BUILD: 1
+          - build: opt
+            PYSTON_UNOPT_BUILD: 0
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Add conda to system path
+        run: |
+          # $CONDA is an environment variable pointing to the root of the miniconda directory
+          echo $CONDA/bin >> $GITHUB_PATH
+      - name: checkout submodules
+        run: |
+          git submodule update --init pyston/LuaJIT pyston/macrobenchmarks
+      - name: remove system includes
+        run: |
+          sudo mv -f /usr/include /usr/_include
+      - name: fix ACL to make cpython tests pass
+        run: |
+          sudo setfacl -Rb /home/ /usr/share/miniconda/
+      - name: build and test pyston
+        env:
+          PYSTON_UNOPT_BUILD: ${{ matrix.PYSTON_UNOPT_BUILD }}
+        run: |
+          conda install conda-build -y
+          conda build pyston/conda/pyston -c pyston/label/dev

--- a/pyston/conda/pyston/build_base.sh
+++ b/pyston/conda/pyston/build_base.sh
@@ -23,16 +23,24 @@ CPPFLAGS=${CPPFLAGS}" -I${PREFIX}/include"
 
 rm -rf build
 
-RELEASE_PREFIX=${PREFIX} make -j`nproc` release
+if [ "${PYSTON_UNOPT_BUILD}" = "1" ]; then
+    make -j`nproc` unopt
+    make -j`nproc` cpython_testsuite
+    OUTDIR=${SRC_DIR}/build/unopt_install/usr
+    PYSTON=${OUTDIR}/bin/python3
+else
+    RELEASE_PREFIX=${PREFIX} make -j`nproc` release
+    RELEASE_PREFIX=${PREFIX} make -j`nproc` cpython_testsuite_release
+    OUTDIR=${SRC_DIR}/build/release_install${PREFIX}
+    PYSTON=${OUTDIR}/bin/python3.bolt
+fi
 
-OUTDIR=$SRC_DIR/build/release_install
-
-cp $OUTDIR${PREFIX}/bin/python3.bolt ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}
+cp $PYSTON ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}
 ln -s ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2} ${PREFIX}/bin/pyston
 ln -s ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2} ${PREFIX}/bin/pyston3
 
-cp -r $OUTDIR${PREFIX}/include/* ${PREFIX}/include/
-cp -r $OUTDIR${PREFIX}/lib/* ${PREFIX}/lib/
+cp -r ${OUTDIR}/include/* ${PREFIX}/include/
+cp -r ${OUTDIR}/lib/* ${PREFIX}/lib/
 
 # remove pip
 rm -r ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages/pip*

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -4,6 +4,7 @@
 {% set python_version = "3.8.12" %}
 {% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}
 {% set python_version2 = ".".join(python_version.split(".")[:2]) %}
+{% set unopt_build = environ.get('PYSTON_UNOPT_BUILD', '0') | int %}
 
 package:
   name: pyston{{ pyston_version2 }}
@@ -15,6 +16,8 @@ source:
 
 build:
   number: {{ build_num }}
+  string: {{ build_num }}_unopt_{{ pyston_version2.replace('.', '') }}_pyston # [unopt]
+  string: {{ build_num }}_{{ pyston_version2.replace('.', '') }}_pyston # [not unopt]
 
   # don't compile python code for now
   skip_compile_pyc:
@@ -23,6 +26,7 @@ build:
   script_env:
     - PYSTON_VERSION2={{ pyston_version2 }}
     - PYTHON_VERSION2={{ python_version2 }}
+    - PYSTON_UNOPT_BUILD={{ unopt_build }}
 
   always_include_files:
     # this directory is already created by our build requirement on 'python' so will not get bundled automatically


### PR DESCRIPTION
- builds our unopt and the release build
- runs cpython_testsuite (we can later add more testsuites)
- I uploaded the pyston build requirements packages (`bolt` and `compiler-rt`) to our anaconda [pyston repo](https://anaconda.org/pyston/repo)  but with a label `dev` so that I can not yet get accidentally installed. In case we have to fix the packages before releasing them to the public.
- CI run takes about 25m for the unopt build and 1h for the release build (I think the max limit is 6h but not sure if there is a monthly limit)