### PR TITLE
aot: merge function and method and trace bound methods

### DIFF
--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -43,7 +43,7 @@ PyMethod_Self(PyObject *im)
 }
 
 
-static PyObject *
+/*static*/ PyObject *
 method_vectorcall(PyObject *method, PyObject *const *args,
                   size_t nargsf, PyObject *kwnames)
 {

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -305,7 +305,7 @@ static void* __attribute__ ((const)) get_addr_of_aot_func(int opcode, int oparg,
     OPCODE_PROFILE(INPLACE_POWER, PyNumber_InPlacePowerNone);
 
     OPCODE_PROFILE(CALL_FUNCTION, call_function_ceval_no_kw);
-    OPCODE_PROFILE(CALL_METHOD, call_method_ceval_no_kw);
+    OPCODE_PROFILE(CALL_METHOD, call_function_ceval_no_kw);
     OPCODE_PROFILE(CALL_FUNCTION_KW, call_function_ceval_kw);
 
     OPCODE_PROFILE(STORE_SUBSCR, PyObject_SetItem);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5058,10 +5058,6 @@ call_function_ceval_no_kw(PyThreadState *tstate, PyObject **stack, Py_ssize_t op
     return call_function_ceval(tstate, &stack, oparg, NULL /*kwnames*/);
 }
 PyObject * _Py_HOT_FUNCTION
-call_method_ceval_no_kw(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg) {
-    return call_function_ceval(tstate, &stack, oparg, NULL /*kwnames*/);
-}
-PyObject * _Py_HOT_FUNCTION
 call_function_ceval_kw(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg, PyObject *kwnames) {
     if (kwnames == NULL)
         __builtin_unreachable();

--- a/pyston/aot/aot_gen.py
+++ b/pyston/aot/aot_gen.py
@@ -367,22 +367,18 @@ class CallableHandler(Handler):
             pass_args = ", ".join(self._args_names())
             print(f"{self._get_func_sig(name)}", "{", file=f)
             print(f"  if (unlikely(oparg != {nargs-1}))", "{" , file=f)
-            if name.startswith("call_method"):
-                # CALL_METHOD can call the function with a different number of args
-                # depending if LOAD_METHOD returned true or false which means we need
-                # to add this additional guard.
-                # we don't use getGuardFailFuncName() here because if the number of args is different
-                # it's likely faster to just go to the untraced case.
-                print(f"    SET_JIT_AOT_FUNC({self.case.unspecialized_name});", file=f)
-                print(f"    PyObject* ret = {self.case.unspecialized_name}({pass_args});", file=f)
-                # this makes sure the compiler is not merging the calls into a single one
-                print(f"    __builtin_assume(ret != (PyObject*)0x1);", file=f)
-                print(f"    return ret;", file=f)
-            elif name.startswith("call_function"):
-                # CALL_FUNCTION always passes the same number of arguments
-                print(f"    __builtin_unreachable();", file=f)
-            else:
-                assert 0, name
+            
+            # CALL_METHOD can call the function with a different number of args
+            # depending if LOAD_METHOD returned true or false which means we need
+            # to add this additional guard.
+            # we don't use getGuardFailFuncName() here because if the number of args is different
+            # it's likely faster to just go to the untraced case.
+            print(f"    SET_JIT_AOT_FUNC({self.case.unspecialized_name});", file=f)
+            print(f"    PyObject* ret = {self.case.unspecialized_name}({pass_args});", file=f)
+            # this makes sure the compiler is not merging the calls into a single one
+            print(f"    __builtin_assume(ret != (PyObject*)0x1);", file=f)
+            print(f"    return ret;", file=f)
+
             print("  }", file=f)
             guard_fail_fn_name = self.getGuardFailFuncName(signature)
             print(f"  PyObject* f = stack[-oparg - 1];", file=f)
@@ -702,7 +698,6 @@ def loadCases():
         call_signatures.append(Signature([ctor_class] + [ObjectClass("", Unspecialized, [None])] * nargs))
 
     cases.append(CallableHandler(FunctionCases("call_function_ceval_no_kw", call_signatures)))
-    cases.append(CallableHandler(FunctionCases("call_method_ceval_no_kw", call_signatures)))
 
     #### call_function_kw
     call_signatures = []
@@ -974,8 +969,7 @@ def print_helper_funcs(f):
     for cmp in cmps:
         print(f"PyObject* cmp_outcome{cmp}(PyObject *v, PyObject *w);", file=f)
 
-    for func in ("call_function_ceval_no_kw", "call_method_ceval_no_kw"):
-        print(f"PyObject* {func}(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg);", file=f)
+    print(f"PyObject* call_function_ceval_no_kw(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg);", file=f)
     print(f"PyObject* call_function_ceval_kw(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg, PyObject* kwnames);", file=f)
 
     print("/* this directly modifies the destination of the jit generated call instruction */\\", file=f)

--- a/pyston/aot/aot_gen.py
+++ b/pyston/aot/aot_gen.py
@@ -480,10 +480,29 @@ def foo7(y, z, w, v, u, a, last_arg):
     return 42
 def foo8(y, z, w, v, u, a, b, last_arg):
     return 42
+class Foo:
+    def foo1(self):
+        return 42
+    def foo2(self, last_arg):
+        return 42
+    def foo3(self, z, last_arg):
+        return 42
+    def foo4(self, z, w, last_arg):
+        return 42
+    def foo5(self, z, w, v, last_arg):
+        return 42
+    def foo6(self, z, w, v, u, last_arg):
+        return 42
+    def foo7(self, z, w, v, u, a, last_arg):
+        return 42
+    def foo8(self, z, w, v, u, a, b, last_arg):
+        return 42
 _function_cases = []
 for i in range(0, 9):
     _function_cases.append((globals()[f"foo{i}"], tuple(range(i))))
-
+_method_cases = []
+for i in range(1, 9):
+    _method_cases.append((getattr(Foo(), f"foo{i}"), tuple(range(i-1))))
 for i in range(0, 10):
     exec(f"""
 class ExampleClass{i}:
@@ -561,7 +580,7 @@ def loadCases():
                                (isinstance, (5, int), (42, str)), # two arg
                                (getattr, (5, "does not exist", 42))],  # three arg
              "MethodDescr": [(str.join, (" ", ("a", "b", "c"))), (str.upper, ("hello world",))],
-             # "Method": [("aaa".lower, ())], #[].append),
+             "Method": _method_cases,
              "Function": _function_cases,
 
              # Types
@@ -703,6 +722,7 @@ def loadCases():
     call_signatures = []
     callables = {
         "Function": _function_cases[1:],
+        "Method": _method_cases[1:],
     }
     for name, l in callables.items():
         signatures = {}


### PR DESCRIPTION
The only difference was that function traces assumed that the oparg argument
stays the same while for CALL_METHOD they can change.

This will add one if check which will always be false in exchange
for a reduction in then number of traces.
I think this is a good trade-off. When I added the differentiation between
call_function and call_method I did not realize that e.g. calling a function inside another module will use the CALL_METHOD
that's why I thought it would be useful to have different traces.

Measuring a small speedup on 'make measure'