### PR TITLE
Get embedding working through conda

### DIFF
--- a/pyston/conda/build_pkgs.sh
+++ b/pyston/conda/build_pkgs.sh
@@ -22,7 +22,7 @@ apt-get install -y netbase
 conda install conda-build -y
 conda build pyston_dir/pyston/conda/compiler-rt -c pyston/label/dev --skip-existing -c conda-forge --override-channels
 conda build pyston_dir/pyston/conda/bolt -c pyston/label/dev --skip-existing -c conda-forge --override-channels
-conda build pyston_dir/pyston/conda/pyston -c pyston/label/dev -c conda-forge --override-channels
+conda build pyston_dir/pyston/conda/pyston -c pyston/label/dev -c conda-forge --override-channels -m pyston_dir/pyston/conda/pyston/variants.yaml
 conda build pyston_dir/pyston/conda/python_abi -c conda-forge --override-channels
 conda build pyston_dir/pyston/conda/python -c conda-forge --override-channels
 

--- a/pyston/conda/build_pkgs.sh
+++ b/pyston/conda/build_pkgs.sh
@@ -20,13 +20,13 @@ apt-get update
 apt-get install -y netbase
 
 conda install conda-build -y
-conda build pyston_dir/pyston/conda/compiler-rt -c pyston/label/dev --skip-existing
-conda build pyston_dir/pyston/conda/bolt -c pyston/label/dev --skip-existing
-conda build pyston_dir/pyston/conda/pyston -c pyston/label/dev
-conda build pyston_dir/pyston/conda/python_abi
-conda build pyston_dir/pyston/conda/python
+conda build pyston_dir/pyston/conda/compiler-rt -c pyston/label/dev --skip-existing -c conda-forge --override-channels
+conda build pyston_dir/pyston/conda/bolt -c pyston/label/dev --skip-existing -c conda-forge --override-channels
+conda build pyston_dir/pyston/conda/pyston -c pyston/label/dev -c conda-forge --override-channels
+conda build pyston_dir/pyston/conda/python_abi -c conda-forge --override-channels
+conda build pyston_dir/pyston/conda/python -c conda-forge --override-channels
 
-conda install patch -y # required to apply the patches in some recipes
+conda install patch -y -c /conda_pkgs -c conda-forge --override-channels # required to apply the patches in some recipes
 
 # This are the arch dependent pip dependencies.
 # We set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 to prevent the implicit dependency on pip when specifying python.

--- a/pyston/conda/pyston/build_static.sh
+++ b/pyston/conda/pyston/build_static.sh
@@ -1,0 +1,11 @@
+set -eux
+
+NAME=libpython${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}.a
+
+if [ "${PYSTON_UNOPT_BUILD}" = "1" ]; then
+    BUILDNAME=unopt
+else
+    BUILDNAME=release
+fi
+
+cp $(find build/${BUILDNAME}_install/ -name $NAME | grep -v config) ${PREFIX}/lib/

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -7,37 +7,38 @@
 {% set unopt_build = environ.get('PYSTON_UNOPT_BUILD', '0') | int %}
 
 package:
-  name: pyston{{ pyston_version2 }}
+  name: pyston{{ pyston_version2 }}-split
   version: {{ pyston_version }}
   skip: True  # [not linux]
 
 source:
   path: ../../../
 
-build:
-  number: {{ build_num }}
-  string: {{ build_num }}_unopt_{{ pyston_version2.replace('.', '') }}_pyston # [unopt]
-  string: {{ build_num }}_{{ pyston_version2.replace('.', '') }}_pyston # [not unopt]
-
-  # don't compile python code for now
-  skip_compile_pyc:
-    "*.py"
-
-  script_env:
-    - PYSTON_VERSION2={{ pyston_version2 }}
-    - PYTHON_VERSION2={{ python_version2 }}
-    - PYSTON_UNOPT_BUILD={{ unopt_build }}
-
-  always_include_files:
-    # this directory is already created by our build requirement on 'python' so will not get bundled automatically
-    # but we want the pyston package to create it too so force package our README.txt.
-    - lib/python{{ python_version2 }}/site-packages/README.txt
-
-  detect_binary_files_with_prefix: true
-
 outputs:
   - name: pyston{{ pyston_version2 }}
     script: build_base.sh
+
+    build:
+      number: {{ build_num }}
+      string: {{ build_num }}_unopt_{{ pyston_version2.replace('.', '') }}_pyston # [unopt]
+      string: {{ build_num }}_{{ pyston_version2.replace('.', '') }}_pyston # [not unopt]
+
+      # don't compile python code for now
+      skip_compile_pyc:
+        "*.py"
+
+      script_env:
+        - PYSTON_VERSION2={{ pyston_version2 }}
+        - PYTHON_VERSION2={{ python_version2 }}
+        - PYSTON_UNOPT_BUILD={{ unopt_build }}
+
+      always_include_files:
+        # this directory is already created by our build requirement on 'python' so will not get bundled automatically
+        # but we want the pyston package to create it too so force package our README.txt.
+        - lib/python{{ python_version2 }}/site-packages/README.txt
+
+      detect_binary_files_with_prefix: true
+
 
     requirements:
       build:
@@ -58,6 +59,7 @@ outputs:
         - sqlite
         - luajit
         - bolt==2021.10.27 *_pyston
+        - zlib
 
         # nitrous needs 'nm'
         - binutils
@@ -88,7 +90,27 @@ outputs:
         - tzdata
 
       run_constrained:
-        python {{ python_version }} *_{{ pyston_version2.replace('.', '') }}_pyston
+        - python {{ python_version }} *_{{ pyston_version2.replace('.', '') }}_pyston
+
+  - name: libpython-static
+    script: build_static.sh
+    version: {{ python_version }}
+
+    build:
+      string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_pyston
+      script_env:
+        - PYSTON_VERSION2={{ pyston_version2 }}
+        - PYTHON_VERSION2={{ python_version2 }}
+        - PYSTON_UNOPT_BUILD={{ unopt_build }}
+
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - {{ pin_subpackage('pyston' + pyston_version2, exact=True) }}
+      run:
+        - {{ pin_subpackage('pyston' + pyston_version2, exact=True) }}
 
 test:
   commands:

--- a/pyston/conda/pyston/variants.yaml
+++ b/pyston/conda/pyston/variants.yaml
@@ -1,0 +1,55 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+libffi:
+- '3.4'
+libuuid:
+- '2'
+ncurses:
+- '6.2'
+openssl:
+- 1.1.1
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  libffi:
+    max_pin: x.x
+  libuuid:
+    max_pin: x
+  ncurses:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  readline:
+    max_pin: x
+  sqlite:
+    max_pin: x
+  tk:
+    max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+readline:
+- '8'
+sqlite:
+- '3'
+target_platform:
+- linux-64
+tk:
+- '8.6'
+xz:
+- '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'


### PR DESCRIPTION
I just copied the conda-forge approach: they have a libpython_static package that just contains the libpython.a library. I think this conflicts with the python package which also contains this file, but it seems to work?

I also made a couple other small changes. The uwsgi feedstock tests pass, and the conda package works enough to spawn a uwsgi process that exits immediately, but we'll need a bunch more packages to run our uwsgi benchmark.