### PR TITLE
 CI: run pyston/conda/build_pkgs.sh

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -8,29 +8,21 @@ jobs:
         include:
           - build: unopt
             PYSTON_UNOPT_BUILD: 1
-          - build: opt
+          - build: release
             PYSTON_UNOPT_BUILD: 0
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Add conda to system path
-        run: |
-          # $CONDA is an environment variable pointing to the root of the miniconda directory
-          echo $CONDA/bin >> $GITHUB_PATH
       - name: checkout submodules
         run: |
           git submodule update --init pyston/LuaJIT pyston/macrobenchmarks
-      - name: remove system includes
-        run: |
-          sudo mv -f /usr/include /usr/_include
-      - name: fix ACL to make cpython tests pass
-        run: |
-          sudo setfacl -Rb /home/ /usr/share/miniconda/
       - name: build and test pyston
         env:
           PYSTON_UNOPT_BUILD: ${{ matrix.PYSTON_UNOPT_BUILD }}
         run: |
-          conda install conda-build -y
-          conda build pyston/conda/pyston -c pyston/label/dev
+          pyston/conda/build_pkgs.sh
+      - name: Archive packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: packages-${{ matrix.build }}
+          path: |
+            release/conda_pkgs/

--- a/pyston/conda/build_pkgs.sh
+++ b/pyston/conda/build_pkgs.sh
@@ -13,6 +13,12 @@ mkdir -p ${OUTPUT_DIR}
 
 docker run -iv${PWD}:/pyston_dir:ro -v${OUTPUT_DIR}:/conda_pkgs --env PYSTON_UNOPT_BUILD continuumio/miniconda3 sh -s <<EOF
 set -eux
+
+apt-get update
+
+# some cpython tests require /etc/protocols
+apt-get install -y netbase
+
 conda install conda-build -y
 conda build pyston_dir/pyston/conda/compiler-rt -c pyston/label/dev --skip-existing
 conda build pyston_dir/pyston/conda/bolt -c pyston/label/dev --skip-existing

--- a/pyston/conda/build_pkgs.sh
+++ b/pyston/conda/build_pkgs.sh
@@ -11,18 +11,18 @@ then
 fi
 mkdir -p ${OUTPUT_DIR}
 
-docker run -iv${PWD}:/pyston_dir:ro -v${OUTPUT_DIR}:/conda_pkgs continuumio/miniconda3 sh -s <<EOF
+docker run -iv${PWD}:/pyston_dir:ro -v${OUTPUT_DIR}:/conda_pkgs --env PYSTON_UNOPT_BUILD continuumio/miniconda3 sh -s <<EOF
 set -eux
 conda install conda-build -y
-conda build pyston_dir/pyston/conda/compiler-rt
-conda build pyston_dir/pyston/conda/bolt
-conda build pyston_dir/pyston/conda/pyston
+conda build pyston_dir/pyston/conda/compiler-rt -c pyston/label/dev --skip-existing
+conda build pyston_dir/pyston/conda/bolt -c pyston/label/dev --skip-existing
+conda build pyston_dir/pyston/conda/pyston -c pyston/label/dev
 conda build pyston_dir/pyston/conda/python_abi
 conda build pyston_dir/pyston/conda/python
 
 conda install patch -y # required to apply the patches in some recipes
 
-# This are the arch dependent pip dependencies. 
+# This are the arch dependent pip dependencies.
 # We set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 to prevent the implicit dependency on pip when specifying python.
 for pkg in certifi setuptools
 do


### PR DESCRIPTION
- now there is no difference between CI build and our local build_pkgs.sh
- don't build compiler-rt and bolt if available in pyston/label/dev channel
- renamed `opt` to `release` build
- uploading generated packages as github artifacts (makes it easy do download them - per default they are stored for 90days)

Not sure if I should also add the workaround for gcc-11:
```
build_base.sh:
# gcc-11 defaults to dwarf-5 which breaks bolt (Unsupported DWARFLocationEntry Kind)
CFLAGS=${CFLAGS}" -g -gdwarf-4"
```