### PR TITLE
conda: add rules of cpython recipe 

### DIFF
--- a/pyston/conda/bolt/meta.yaml
+++ b/pyston/conda/bolt/meta.yaml
@@ -1,5 +1,5 @@
 {% set build_num = 0 %}
-{% set version = "2021.10.27" %}
+{% set version = "2021.11.13" %}
 
 package:
   name: bolt

--- a/pyston/conda/build_pkgs.sh
+++ b/pyston/conda/build_pkgs.sh
@@ -17,7 +17,7 @@ set -eux
 apt-get update
 
 # some cpython tests require /etc/protocols
-apt-get install -y netbase
+apt-get install -y netbase curl
 
 conda install conda-build -y
 conda build pyston_dir/pyston/conda/compiler-rt -c pyston/label/dev --skip-existing -c conda-forge --override-channels
@@ -30,7 +30,7 @@ conda install patch -y -c conda-forge --override-channels # required to apply th
 
 # This are the arch dependent pip dependencies.
 # We set CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 to prevent the implicit dependency on pip when specifying python.
-for pkg in certifi setuptools
+for pkg in certifi setuptools uwsgi
 do
     git clone https://github.com/AnacondaRecipes/\${pkg}-feedstock.git
     CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 conda build \${pkg}-feedstock/recipe --python="${PYSTON_PKG_VER}" --override-channels -c conda-forge --use-local

--- a/pyston/conda/pyston/build_base.sh
+++ b/pyston/conda/pyston/build_base.sh
@@ -4,24 +4,63 @@ set -eux
 # pyston should not compile llvm and bolt but instead use the conda packages
 export PYSTON_USE_SYS_BINS=1
 
-# the conda compiler is named 'x86_64-conda-linux-gnu-cc' but cpython compares
-# the name to *gcc*, *clang* in the configure file - so we have to use the real name.
-# Code mostly copied from the cpython recipe.
+rm -rf build
+
+
+# BOLT seems to miscompile pyston when -fno-plt is passed - disable it
+CFLAGS=$(echo "${CFLAGS}" | sed "s/-fno-plt//g")
+
+_OPTIMIZED=yes
+VER=${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}
+VERABI=${VER}
+
+#########################################################################################
+# Following code is mostly copied from the cpython recipe with some changes
+# https://github.com/AnacondaRecipes/python-feedstock/blob/master-3.8/recipe/build_base.sh
+
+# This is the mechanism by which we fall back to default gcc, but having it defined here
+# would probably break the build by using incorrect settings and/or importing files that
+# do not yet exist.
+unset _PYTHON_SYSCONFIGDATA_NAME
+unset _CONDA_PYTHON_SYSCONFIGDATA_NAME
+
+# Remove bzip2's shared library if present,
+# as we only want to link to it statically.
+# This is important in cases where conda
+# tries to update bzip2.
+find "${PREFIX}/lib" -name "libbz2*${SHLIB_EXT}*" | xargs rm -fv {}
+
+# Prevent lib/python${VER}/_sysconfigdata_*.py from ending up with full paths to these things
+# in _build_env because _build_env will not get found during prefix replacement, only _h_env_placeh ...
 AR=$(basename "${AR}")
-CC=$(basename "${GCC}")
+
+# CC must contain the string 'gcc' or else distutils thinks it is on macOS and uses '-R' to set rpaths.
+if [[ ${target_platform} == osx-* ]]; then
+  CC=$(basename "${CC}")
+else
+  CC=$(basename "${GCC}")
+fi
 CXX=$(basename "${CXX}")
 RANLIB=$(basename "${RANLIB}")
 READELF=$(basename "${READELF}")
 
-# overwrite default conda build flags else the bolt instrumented binary will not work
-CFLAGS="-isystem ${PREFIX}/include"
-LDFLAGS="-Wl,-rpath,${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
-CPPFLAGS="-isystem ${PREFIX}/include"
+# Debian uses -O3 then resets it at the end to -O2 in _sysconfigdata.py
+if [[ ${_OPTIMIZED} = yes ]]; then
+  CPPFLAGS=$(echo "${CPPFLAGS}" | sed "s/-O2/-O3/g")
+  CFLAGS=$(echo "${CFLAGS}" | sed "s/-O2/-O3/g")
+  CXXFLAGS=$(echo "${CXXFLAGS}" | sed "s/-O2/-O3/g")
+fi
 
-# without this line we can't find zlib and co..
+declare -a LTO_CFLAGS=()
+
 CPPFLAGS=${CPPFLAGS}" -I${PREFIX}/include"
 
-rm -rf build
+re='^(.*)(-I[^ ]*)(.*)$'
+if [[ ${CFLAGS} =~ $re ]]; then
+  CFLAGS="${BASH_REMATCH[1]}${BASH_REMATCH[3]}"
+fi
+
+export CPPFLAGS CFLAGS CXXFLAGS LDFLAGS
 
 # This causes setup.py to query the sysroot directories from the compiler, something which
 # IMHO should be done by default anyway with a flag to disable it to workaround broken ones.
@@ -36,6 +75,34 @@ if [[ -n ${HOST} ]]; then
     export _PYTHON_HOST_PLATFORM=${host_os}-${host_arch}
   fi
 fi
+
+if [[ ${target_platform} == osx-64 ]]; then
+  export MACHDEP=darwin
+  export ac_sys_system=Darwin
+  export ac_sys_release=13.4.0
+  export MACOSX_DEFAULT_ARCH=x86_64
+  # TODO: check with LLVM 12 if the following hack is needed.
+  # https://reviews.llvm.org/D76461 may have fixed the need for the following hack.
+  echo '#!/bin/bash' > $BUILD_PREFIX/bin/$HOST-llvm-ar
+  echo "$BUILD_PREFIX/bin/llvm-ar --format=darwin" '"$@"' >> $BUILD_PREFIX/bin/$HOST-llvm-ar
+  chmod +x $BUILD_PREFIX/bin/$HOST-llvm-ar
+  export ARCHFLAGS="-arch x86_64"
+elif [[ ${target_platform} == osx-arm64 ]]; then
+  export MACHDEP=darwin
+  export ac_sys_system=Darwin
+  export ac_sys_release=20.0.0
+  export MACOSX_DEFAULT_ARCH=arm64
+  echo '#!/bin/bash' > $BUILD_PREFIX/bin/$HOST-llvm-ar
+  echo "$BUILD_PREFIX/bin/llvm-ar --format=darwin" '"$@"' >> $BUILD_PREFIX/bin/$HOST-llvm-ar
+  chmod +x $BUILD_PREFIX/bin/$HOST-llvm-ar
+  export ARCHFLAGS="-arch arm64"
+  export CFLAGS="$CFLAGS $ARCHFLAGS"
+elif [[ ${target_platform} == linux-* ]]; then
+  export MACHDEP=linux
+  export ac_sys_system=Linux
+  export ac_sys_release=
+fi
+
 declare -a _common_configure_args
 _common_configure_args+=(--build=${BUILD})
 _common_configure_args+=(--host=${HOST})
@@ -46,6 +113,9 @@ _common_configure_args+=(--enable-loadable-sqlite-extensions)
 _common_configure_args+=(--with-openssl="${PREFIX}")
 _common_configure_args+=(--with-tcltk-includes="-I${PREFIX}/include")
 _common_configure_args+=("--with-tcltk-libs=-L${PREFIX}/lib -ltcl8.6 -ltk8.6")
+
+#########################################################################################
+
 
 export CONFIGURE_EXTRA_FLAGS='${_common_configure_args[@]} --oldincludedir=${BUILD_PREFIX}/${HOST}/sysroot/usr/include'
 
@@ -61,19 +131,98 @@ else
     PYSTON=${OUTDIR}/bin/python3.bolt
 fi
 
-cp $PYSTON ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}
-ln -s ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2} ${PREFIX}/bin/pyston
-ln -s ${PREFIX}/bin/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2} ${PREFIX}/bin/pyston3
+cp $PYSTON ${PREFIX}/bin/python${VER}
+ln -s ${PREFIX}/bin/python${VER} ${PREFIX}/bin/pyston
+ln -s ${PREFIX}/bin/python${VER} ${PREFIX}/bin/pyston3
 
 cp -r ${OUTDIR}/include/* ${PREFIX}/include/
 cp -r ${OUTDIR}/lib/* ${PREFIX}/lib/
 
 # remove pip
-rm -r ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages/pip*
+rm -r ${PREFIX}/lib/python${VER}/site-packages/pip*
 
 # remove pystons site-packages directory and replace it with a symlink to cpythons default site-packages directory
 # we copy in our site-package/README.txt and package it to make sure the directory get's created.
 mkdir -p ${PREFIX}/lib/python${PYTHON_VERSION2}/site-packages || true
-cp ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages/README.txt ${PREFIX}/lib/python${PYTHON_VERSION2}/site-packages
-rm -r ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages
-ln -s ${PREFIX}/lib/python${PYTHON_VERSION2}/site-packages/ ${PREFIX}/lib/python${PYTHON_VERSION2}-pyston${PYSTON_VERSION2}/site-packages
+cp ${PREFIX}/lib/python${VER}/site-packages/README.txt ${PREFIX}/lib/python${PYTHON_VERSION2}/site-packages
+rm -r ${PREFIX}/lib/python${VER}/site-packages
+ln -s ${PREFIX}/lib/python${PYTHON_VERSION2}/site-packages/ ${PREFIX}/lib/python${VER}/site-packages
+
+#########################################################################################
+# Following code is mostly copied from the cpython recipe with some changes
+# https://github.com/AnacondaRecipes/python-feedstock/blob/master-3.8/recipe/build_base.sh
+
+declare -a _FLAGS_REPLACE=()
+if [[ ${_OPTIMIZED} == yes ]]; then
+  _FLAGS_REPLACE+=(-O3)
+  _FLAGS_REPLACE+=(-O2)
+  _FLAGS_REPLACE+=("-fprofile-use")
+  _FLAGS_REPLACE+=("")
+  _FLAGS_REPLACE+=("-fprofile-correction")
+  _FLAGS_REPLACE+=("")
+  _FLAGS_REPLACE+=("-L.")
+  _FLAGS_REPLACE+=("")
+  for _LTO_CFLAG in "${LTO_CFLAGS[@]}"; do
+    _FLAGS_REPLACE+=(${_LTO_CFLAG})
+    _FLAGS_REPLACE+=("")
+  done
+fi
+
+SYSCONFIG=$(find ${OUTDIR} -name "_sysconfigdata*.py" -print0)
+cat ${SYSCONFIG} | ${SYS_PYTHON} "${RECIPE_DIR}"/replace-word-pairs.py \
+  "${_FLAGS_REPLACE[@]}"  \
+    > ${PREFIX}/lib/python${VER}/$(basename ${SYSCONFIG})
+MAKEFILE=$(find ${PREFIX}/lib/python${VER}/ -path "*config-*/Makefile" -print0)
+cp ${MAKEFILE} /tmp/Makefile-$$
+cat /tmp/Makefile-$$ | ${SYS_PYTHON} "${RECIPE_DIR}"/replace-word-pairs.py \
+  "${_FLAGS_REPLACE[@]}"  \
+    > ${MAKEFILE}
+# Check to see that our differences took.
+# echo diff -urN ${SYSCONFIG} ${PREFIX}/lib/python${VER}/$(basename ${SYSCONFIG})
+# diff -urN ${SYSCONFIG} ${PREFIX}/lib/python${VER}/$(basename ${SYSCONFIG})
+
+# Python installs python${VER}m and python${VER}, one as a hardlink to the other. conda-build breaks these
+# by copying. Since the executable may be static it may be very large so change one to be a symlink
+# of the other. In this case, python${VER}m will be the symlink.
+if [[ -f ${PREFIX}/bin/python${VER}m ]]; then
+  rm -f ${PREFIX}/bin/python${VER}m
+  ln -s ${PREFIX}/bin/python${VER} ${PREFIX}/bin/python${VER}m
+fi
+
+# Remove test data to save space
+# Though keep `support` as some things use that.
+# TODO :: Make a subpackage for this once we implement multi-level testing.
+pushd ${PREFIX}/lib/python${VER}
+  mkdir test_keep
+  mv test/__init__.py test/support test/test_support* test/test_script_helper* test_keep/
+  rm -rf test */test
+  mv test_keep test
+popd
+
+# Size reductions:
+pushd ${PREFIX}
+  if [[ -f lib/libpython${VERABI}.a ]]; then
+    chmod +w lib/libpython${VERABI}.a
+    ${STRIP} -S lib/libpython${VERABI}.a
+  fi
+  CONFIG_LIBPYTHON=$(find lib/python${VER}/config-${VERABI}* -name "libpython${VERABI}.a")
+  if [[ -f lib/libpython${VERABI}.a ]] && [[ -f ${CONFIG_LIBPYTHON} ]]; then
+    chmod +w ${CONFIG_LIBPYTHON}
+    rm ${CONFIG_LIBPYTHON}
+  fi
+popd
+
+if [[ ${HOST} =~ .*linux.* ]]; then
+  mkdir -p ${PREFIX}/compiler_compat
+  ln -s ${PREFIX}/bin/${HOST}-ld ${PREFIX}/compiler_compat/ld
+  echo "Files in this folder are to enhance backwards compatibility of anaconda software with older compilers."   > ${PREFIX}/compiler_compat/README
+  echo "See: https://github.com/conda/conda/issues/6030 for more information."                                   >> ${PREFIX}/compiler_compat/README
+fi
+
+# There are some strange distutils files around. Delete them
+rm -rf ${PREFIX}/lib/python${VER}/distutils/command/*.exe
+
+$PYSTON -c "import compileall,os;compileall.compile_dir(os.environ['PREFIX'])"
+rm ${PREFIX}/lib/libpython${VER}.a
+
+#########################################################################################

--- a/pyston/conda/pyston/build_static.sh
+++ b/pyston/conda/pyston/build_static.sh
@@ -9,3 +9,7 @@ else
 fi
 
 cp $(find build/${BUILDNAME}_install/ -name $NAME | grep -v config) ${PREFIX}/lib/
+
+# Size reductions:
+chmod +w ${PREFIX}/lib/${NAME}
+${STRIP} -S ${PREFIX}/lib/${NAME}

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 2 %}
+{% set build_num = 3 %}
 {% set llvm_version = "10.0.1" %}
 {% set pyston_version = "2.3.1" %}
 {% set python_version = "3.8.12" %}
@@ -58,7 +58,7 @@ outputs:
         - libtool
         - sqlite
         - luajit
-        - bolt==2021.10.27 *_pyston
+        - bolt==2021.11.13 *_pyston
         - zlib
 
         # nitrous needs 'nm'

--- a/pyston/conda/pyston/recipe-license.txt
+++ b/pyston/conda/pyston/recipe-license.txt
@@ -1,0 +1,32 @@
+The pyston recipe is based upon the python-3.8 recipe from
+https://github.com/AnacondaRecipes/python-feedstock/ which has the following license:
+
+
+This recipe is based upon the python-3.5 recipe from
+https://github.com/ContinuumIO/anaconda-recipes
+which is released under the following BSD license:
+
+(c) 2016 Continuum Analytics, Inc. / http://continuum.io
+All Rights Reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Continuum Analytics, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pyston/conda/pyston/replace-word-pairs.py
+++ b/pyston/conda/pyston/replace-word-pairs.py
@@ -1,0 +1,29 @@
+import sys
+import re
+
+# Reads from stdin line by line, writes to stdout line by line replacing
+# each odd argument with the subsequent even argument.
+
+def pairs(it):
+    it = iter(it)
+    try:
+        while True:
+            yield next(it), next(it)
+    except StopIteration:
+        return
+
+def main():
+    rep_dict = dict()
+    for fro, to in pairs(sys.argv[1:]):
+        rep_dict[fro] = to
+    if len(rep_dict):
+        regex = re.compile("(%s)" % "|".join(map(re.escape, rep_dict.keys())))
+        for line in iter(sys.stdin.readline, ''):
+            sys.stdout.write(regex.sub(lambda mo: rep_dict[mo.string[mo.start():mo.end()]], line))
+    else:
+        for line in iter(sys.stdin.readline, ''):
+            sys.stdout.write(line)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This adds a lot of code from the cpython conda recipe.
- use conda `CFLAGS` except `-fno-plt` which triggers a misscompile when running with bolt and `-pipe` (which has a fix which bolt has not yet merged)
- strip debug data from *.a
- move *.a to the libpython-static package
- don't package the tests
- patch sysconfig
- generate *.pyc files

Reduces release package artifact size to about 79MB from 152MB.

- I added some code which is not strictly necessary (e.g. code for non linux platforms) but which makes it easier to compare with the original cpython recipe.

- I did not add the the code where they copy in some preexisting sysconfigs: https://github.com/AnacondaRecipes/python-feedstock/blob/f91dedf533a5217d77dc48700e779d77820b68c7/recipe/build_base.sh#L427
I'm not sure why they need it / I guess it's for crosscompiling which we don't support. If we decide to also include we will need to patch them because they contain many cpython specific things.
