### PR TITLE
conda: create a linux installer for our pyston packages

### DIFF
--- a/pyston/conda/installer/LICENSE.txt
+++ b/pyston/conda/installer/LICENSE.txt
@@ -1,0 +1,34 @@
+PystonConda installer code uses BSD-3-Clause license as stated below.
+
+Binary packages that come with it have their own licensing terms
+and by installing PystonConda you agree to the licensing terms of individual
+packages as well. They include different OSI-approved licenses including
+the GNU General Public License and can be found in pkgs/<pkg-name>/info/licenses
+folders.
+
+=============================================================================
+
+Copyright (c) 2021, Anaconda, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Anaconda, Inc. nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ANACONDA, INC BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pyston/conda/installer/construct.yaml
+++ b/pyston/conda/installer/construct.yaml
@@ -1,0 +1,26 @@
+# generate installer via:
+# conda install constructor -c conda-forge --override-channels
+# constructor --output-dir release/conda_pkgs pyston/conda/installer
+
+name: PystonConda
+version: 0.1
+
+channels:
+  - undingen/label/dev
+  - kmod/label/dev
+  - conda-forge
+
+write_condarc: True
+
+license_file: LICENSE.txt
+
+specs:
+  - python 3.8.* *_pyston
+
+  # I think this is technically not required (pypy installer does not do it)
+  # but I think it may prevent someone accidently installing cpython because
+  # the pyston package has a hard dependency on 'python 3.8.* *_pyston'
+  - pyston
+
+  - conda
+  - pip


### PR DESCRIPTION
only installs minimum required packages like miniconda/miniforge
- currently pointing to kmods and my channel because we don't have the packages yet the pyston channel

Install can be created by running:
$ conda install constructor -c conda-forge --override-channels
$ constructor --output-dir release/conda_pkgs pyston/conda/installer

I tested with fedora and could successful install (and import) tensorflow :)

I names it PystonConda not sure about the name... the default install location is all lowercase 'pystonconda'