### PR TITLE
last few conda fixes

### DIFF
--- a/pyston/conda/build_feedstock.sh
+++ b/pyston/conda/build_feedstock.sh
@@ -211,7 +211,7 @@ if [ "$PACKAGE" == "vim" ]; then
 fi
 
 # conda-forge-ci-setup automatically sets add_pip_as_python_dependency=false
-CONDA_FORGE_DOCKER_RUN_ARGS="-e EXTRA_CB_OPTIONS" EXTRA_CB_OPTIONS="-c $CHANNEL" python3 build-locally.py $(CHANNEL=$CHANNEL python3 $MAKE_CONFIG_PY)
+CONDA_FORGE_DOCKER_RUN_ARGS="-e EXTRA_CB_OPTIONS --rm" EXTRA_CB_OPTIONS="-c $CHANNEL" python3 build-locally.py $(CHANNEL=$CHANNEL python3 $MAKE_CONFIG_PY)
 
 echo "Done! Build artifacts are:"
 find build_artifacts -name '*.tar.bz2' | xargs realpath

--- a/pyston/conda/patches/numba.patch
+++ b/pyston/conda/patches/numba.patch
@@ -1,0 +1,25 @@
+diff --git a/numba/tests/test_nrt.py b/numba/tests/test_nrt.py
+index b29f8f97c..12266abb4 100644
+--- a/numba/tests/test_nrt.py
++++ b/numba/tests/test_nrt.py
+@@ -220,6 +220,7 @@ class TestNrtMemInfo(unittest.TestCase):
+         # consumed by another thread.
+ 
+ 
++@unittest.skip("Pyston has removed tracemalloc")
+ class TestTracemalloc(unittest.TestCase):
+     """
+     Test NRT-allocated memory can be tracked by tracemalloc.
+diff --git a/numba/tests/test_pycc.py b/numba/tests/test_pycc.py
+index bf3d046ab..2e7d66164 100644
+--- a/numba/tests/test_pycc.py
++++ b/numba/tests/test_pycc.py
+@@ -210,7 +210,7 @@ class TestCC(BasePYCCTest):
+         self.assertTrue(os.path.basename(f).startswith('pycc_test_simple.'), f)
+         if sys.platform.startswith('linux'):
+             self.assertTrue(f.endswith('.so'), f)
+-            self.assertIn('.cpython', f)
++            self.assertIn('pyston', f)
+ 
+     def test_compile(self):
+         with self.check_cc_compiled(self._test_module.cc) as lib:

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 4 %}
+{% set build_num = 5 %}
 {% set llvm_version = "10.0.1" %}
 {% set pyston_version = "2.3.1" %}
 {% set python_version = "3.8.12" %}
@@ -127,6 +127,11 @@ outputs:
 
       run_constrained:
         - python {{ python_version }} *_{{ pyston_version2.replace('.', '') }}_pyston
+        # Cython <3.0.0a8 has a bug that causes memory corruption in Pyston
+        # We can work with anything >=3.0.0a8, or our special builds that have
+        # our fix backported. I don't know how to specify this OR relation, so
+        # just specify the one that we're currently using
+        - cython >=0.29 *_pyston
 
   - name: libpython-static
     script: build_static.sh


### PR DESCRIPTION
- add the numba patch I forgot to git add
- run_constrain pyston to have a version of cython that works with it

I verified that the cython constraint will correctly prevent us from installing a version of cython without our patch, but since there's currently no working version of it anything depending on cython will fail to build. once we get a pyston version made I'll update the constraint to point to it. I think it's worth checking this in for now so that I can build all the non-cython-dependent packages and make sure the cython ones fail