### PR TITLE
conda: fix memory corruption in cython 0.29

### DIFF
--- a/pyston/conda/build_feedstock.sh
+++ b/pyston/conda/build_feedstock.sh
@@ -195,6 +195,15 @@ if [ "$PACKAGE" == "numba" ]; then
     sed -i "s/  sha256: {{ sha256 }}/  sha256: {{ sha256 }}\n  patches:\n    - pyston.patch/" recipe/meta.yaml
 fi
 
+if [ "$PACKAGE" == "cython" ]; then
+    git checkout 1fbf105 # 0.29.24
+    # we need to apply our memory corruption fix for cython #4200
+    cp $THISDIR/patches/cython.patch recipe/pyston.patch
+    sed -i "/pyston.patch/d" recipe/meta.yaml
+    sed -i "s/number: 1/number: 2\n  string: 2_pyston/g" recipe/meta.yaml # increment build number and add _pyston suffix so we know it's the fixed version
+    sed -i "s@    - patches/pypy37-eval.patch@    - patches/pypy37-eval.patch\n    - pyston.patch@" recipe/meta.yaml
+fi
+
 if [ "$PACKAGE" == "vim" ]; then
     cp $THISDIR/patches/vim.patch recipe/pyston.patch
     sed -i "/patch/d" recipe/meta.yaml

--- a/pyston/conda/patches/cython.patch
+++ b/pyston/conda/patches/cython.patch
@@ -1,0 +1,35 @@
+From 6be740e58f85228b52744a0bc46746af6621eef4 Mon Sep 17 00:00:00 2001
+From: Marius Wachtler <undingen@gmail.com>
+Date: Thu, 25 Nov 2021 20:12:09 +0100
+Subject: [PATCH] backport memory corruption fix #4200 to v0.29 branch fixes an
+ issue which pyston triggers https://github.com/cython/cython/issues/4200
+
+---
+ Cython/Utility/ExtensionTypes.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Cython/Utility/ExtensionTypes.c b/Cython/Utility/ExtensionTypes.c
+index 1b39c9e42..0d8c41dee 100644
+--- a/Cython/Utility/ExtensionTypes.c
++++ b/Cython/Utility/ExtensionTypes.c
+@@ -54,7 +54,7 @@ static int __Pyx_PyType_Ready(PyTypeObject *t) {
+         }
+     }
+ 
+-#if PY_VERSION_HEX >= 0x03050000
++#if PY_VERSION_HEX >= 0x03050000 && !defined(PYSTON_MAJOR_VERSION)
+     {
+         // Make sure GC does not pick up our non-heap type as heap type with this hack!
+         // For details, see https://github.com/cython/cython/issues/3603
+@@ -93,7 +93,7 @@ static int __Pyx_PyType_Ready(PyTypeObject *t) {
+ 
+     r = PyType_Ready(t);
+ 
+-#if PY_VERSION_HEX >= 0x03050000
++#if PY_VERSION_HEX >= 0x03050000 && !defined(PYSTON_MAJOR_VERSION)
+         t->tp_flags &= ~Py_TPFLAGS_HEAPTYPE;
+ 
+         if (gc_was_enabled) {
+-- 
+2.25.1
+


### PR DESCRIPTION
unfortunately our fix #4200 is only in the 0.30a releases
and not in the 0.29 branch.
This backports the fix.