### PR TITLE
CI: upload core dumps

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -19,10 +19,36 @@ jobs:
         env:
           PYSTON_UNOPT_BUILD: ${{ matrix.PYSTON_UNOPT_BUILD }}
         run: |
-          pyston/conda/build_pkgs.sh
+          # enable core dumps
+          ulimit -c unlimited
+          sudo mkdir -p /cores
+          sudo chmod a+rwx /cores
+          echo "/cores/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern
+
+          pyston/conda/build_pkgs.sh --ci-mode
       - name: Archive packages
         uses: actions/upload-artifact@v2
         with:
           name: packages-${{ matrix.build }}
           path: |
             release/conda_pkgs/
+
+      # core dump handling steps in case of failure
+      - name: Core dump - add conda build directory
+        if: ${{ failure() }}
+        run: |
+          # if we find a core dump copy in conda build directory as archive
+          if [ "$(ls -A /cores)" ]; then
+            docker cp pyston_build:/opt/conda/conda-bld /tmp/conda-bld
+            tar -C /tmp/ -czf /cores/conda-bld.tar.gz conda-bld/
+          fi
+          sudo chmod -R a+rwx /cores
+          sudo chown -R $USER:$USER /cores
+      - name: Core dump - upload
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: core-dump-${{ matrix.build }}
+          path: /cores/
+          if-no-files-found: ignore
+

--- a/pyston/conda/build_pkgs.sh
+++ b/pyston/conda/build_pkgs.sh
@@ -11,7 +11,14 @@ then
 fi
 mkdir -p ${OUTPUT_DIR}
 
-docker run -iv${PWD}:/pyston_dir:ro -v${OUTPUT_DIR}:/conda_pkgs --env PYSTON_UNOPT_BUILD continuumio/miniconda3 sh -s <<EOF
+OPTIONAL_ARGS=
+if [ "${1:-}" = "--ci-mode" ]
+then
+    # CI is setup to write core dumps into /cores also give the container a name for easy access
+    OPTIONAL_ARGS="-iv/cores:/cores --name pyston_build"
+fi
+
+docker run -iv${PWD}:/pyston_dir:ro -v${OUTPUT_DIR}:/conda_pkgs ${OPTIONAL_ARGS} --env PYSTON_UNOPT_BUILD continuumio/miniconda3 sh -s <<EOF
 set -eux
 
 apt-get update


### PR DESCRIPTION
If the build crashes we will now generate a core dump and upload
it together with the conda build directory.

I tested it with a small artificial segfault and it worked fine: https://github.com/undingen/pyston_v2/actions/runs/1537123679