### PR TITLE
Conda: upgrade to Cython 0.29.25 and fix 'sed' cmds in feedstock script

### DIFF
--- a/pyston/conda/build_feedstock.py
+++ b/pyston/conda/build_feedstock.py
@@ -102,9 +102,15 @@ def getRecipeSedCommands(feedstock, version):
         return ("s/  sha256: {{ sha256 }}/  sha256: {{ sha256 }}\n  patches:\n    - pyston.patch/",)
 
     if feedstock == "cython":
+        if version == "latest":
+            return ()
+        assert version.startswith("0.29."), "not sure if this version requires our patch"
+        if int(version.split(".")[2]) >= 25:
+            return () # 0.29.25 contains our fix
+
         # we need to apply our memory corruption fix for cython #4200
         return (
-                "s/number: 1/number: 2\n  string: 2_pyston/g", # increment build number and add _pyston suffix so we know it's the fixed version 
+                "s/number: 1/number: 2\n  string: 2_pyston/g", # increment build number and add _pyston suffix so we know it's the fixed version
                 "s@    - patches/pypy37-eval.patch@    - patches/pypy37-eval.patch\n    - pyston.patch@",)
 
     if feedstock == "vim":

--- a/pyston/conda/build_feedstock.py
+++ b/pyston/conda/build_feedstock.py
@@ -28,10 +28,10 @@ def getCherryPicks(feedstock, version):
 
 def getRecipeSedCommands(feedstock, version):
     if feedstock == "python-rapidjson":
-        return ('s/pytest tests/pytest tests --ignore=tests\/test_memory_leaks.py --ignore=tests\/test_circular.py/g',)
+        return (r's/pytest tests/pytest tests --ignore=tests\/test_memory_leaks.py --ignore=tests\/test_circular.py/g',)
 
     if feedstock == "numpy":
-        return ('s/_not_a_real_test/test_for_reference_leak or test_api_importable/g',)
+        return (r's/_not_a_real_test/test_for_reference_leak or test_api_importable/g',)
 
     if feedstock == "implicit":
         # The build step here implicitly does a `pip install numpy scipy`.
@@ -39,26 +39,26 @@ def getRecipeSedCommands(feedstock, version):
         # for Pyston it will try to recompile both of these packages.
         # But the meta.yaml doesn't include all the dependencies of
         # building scipy, specifically a fortran compiler, so we have to add it:
-        return ("s/        - {{ compiler('cxx') }}/        - {{ compiler('cxx') }}\n        - {{ compiler('fortran') }}/",)
+        return (r"s/        - {{ compiler('cxx') }}/        - {{ compiler('cxx') }}\n        - {{ compiler('fortran') }}/",)
 
     if feedstock == "pyqt":
-        return ("s@      - patches/qt5_dll.diff@      - patches/qt5_dll.diff\n      - pyston.patch@",)
+        return (r"s@      - patches/qt5_dll.diff@      - patches/qt5_dll.diff\n      - pyston.patch@",)
 
     if feedstock == "scikit-build":
-        return ("s/not test_fortran_compiler/not test_fortran_compiler and not test_get_python_version/",)
+        return (r"s/not test_fortran_compiler/not test_fortran_compiler and not test_get_python_version/",)
 
     if feedstock == "conda-package-handling":
         # Not sure why the sha mismatches, I think they must have uploaded a new version
-        return ("s/2a7cc4dc892d3581764710e869d36088291de86c7ebe0375c830a2910ef54bb6/6c01527200c9d9de18e64d2006cc97f9813707a34f3cb55bca2852ff4b06fb8d/",)
+        return (r"s/2a7cc4dc892d3581764710e869d36088291de86c7ebe0375c830a2910ef54bb6/6c01527200c9d9de18e64d2006cc97f9813707a34f3cb55bca2852ff4b06fb8d/",)
 
     if feedstock == "python-libarchive-c":
         # Not sure why the sha mismatches, I think they must have uploaded a new version
-        return ("s/bef034fbc403feacc4d28e71520eff6a1fcc4a677f0bec5324f68ea084c8c103/1223ef47b1547a34eeaca529ef511a8593fecaf7054cb46e62775d8ccc1a6e5c/",)
+        return (r"s/bef034fbc403feacc4d28e71520eff6a1fcc4a677f0bec5324f68ea084c8c103/1223ef47b1547a34eeaca529ef511a8593fecaf7054cb46e62775d8ccc1a6e5c/",)
 
     if feedstock == "ipython":
         # ipython has a circular dependency via ipykernel,
         # but they have this flag presumably for this exact problem:
-        return ("s/set migrating = False/set migrating = True/",)
+        return (r"s/set migrating = False/set migrating = True/",)
 
     if feedstock == "gobject-introspection":
         # This feedstock lists a "downstream" test, which it will try to run
@@ -66,12 +66,12 @@ def getRecipeSedCommands(feedstock, version):
         # Installing this dependent package will fail because we haven't built it yet;
         # conda is supposed to be able to recognize this and skip the tests, but it
         # it doesn't and instead fails.
-        return ("/pygobject/d",)
+        return (r"/pygobject/d",)
 
     if feedstock == "ipykernel":
         # ipykernel depends on ipyparallel for testing, but
         # ipyparallel depends on ipykernel
-        return ("/- ipyparallel/d",)
+        return (r"/- ipyparallel/d",)
 
         # It's missing this dependency:
         # return ("/ipython_genutils/d" recipe/meta.yaml
@@ -83,15 +83,15 @@ def getRecipeSedCommands(feedstock, version):
 
     if feedstock == "nose":
         # Nose uses the setuptools "use_2to3" flag, which was removed in setuptools 58.0.0:
-        return ('s/  host:/  host:\n    - setuptools <58/',)
+        return (r's/  host:/  host:\n    - setuptools <58/',)
 
     if feedstock == "jinja2-time":
         # This old package doesn't work with newer versions of arrow:
-        return ('s/- arrow$/- arrow <0.14.5/',)
+        return r('s/- arrow$/- arrow <0.14.5/',)
 
     if feedstock == "binaryornot":
         # This old package doesn't work with newer versions of hypothesis:
-        return ('s/- hypothesis$/- hypothesis <4.0/',)
+        return (r's/- hypothesis$/- hypothesis <4.0/',)
         # Though this doesn't work because apparently earlier versions of hypothesis are py27 only?
         # Though we don't actually need to build this feedstock because it became noarch
 
@@ -99,7 +99,7 @@ def getRecipeSedCommands(feedstock, version):
         # We have to disable some tests. They have some tracemalloc tests, and a test
         # that checks that shared libraries have "cpython" in the name.
         # They use unittest and I couldn't figure out how to disable them via the test runner
-        return ("s/  sha256: {{ sha256 }}/  sha256: {{ sha256 }}\n  patches:\n    - pyston.patch/",)
+        return (r"s/  sha256: {{ sha256 }}/  sha256: {{ sha256 }}\n  patches:\n    - pyston.patch/",)
 
     if feedstock == "cython":
         if version == "latest":
@@ -110,11 +110,11 @@ def getRecipeSedCommands(feedstock, version):
 
         # we need to apply our memory corruption fix for cython #4200
         return (
-                "s/number: 1/number: 2\n  string: 2_pyston/g", # increment build number and add _pyston suffix so we know it's the fixed version
-                "s@    - patches/pypy37-eval.patch@    - patches/pypy37-eval.patch\n    - pyston.patch@",)
+                r"s/number: 1/number: 2\n  string: 2_pyston/g", # increment build number and add _pyston suffix so we know it's the fixed version
+                r"s@    - patches/pypy37-eval.patch@    - patches/pypy37-eval.patch\n    - pyston.patch@",)
 
     if feedstock == "vim":
-        return ("/source:/a \  patches:\n    - pyston.patch",)
+        return (r"/source:/a \  patches:\n    - pyston.patch",)
 
     if feedstock == "torchvision":
         assert version == "0.10.1", "other versions unsupported currently"
@@ -135,16 +135,11 @@ def getSedCommands(feedstock, version):
     recipe_cmds = getRecipeSedCommands(feedstock, version)
     r = [("recipe/meta.yaml", cmd) for cmd in recipe_cmds]
 
-    if feedstock == "implicit":
-        # I don't understand exactly why, but it seems like you can't install
-        # both a fortran compiler and gcc 7. So update the configs to use gcc 9
-        r.append((".ci_support/*.yaml", "s/'7'/'9'/"))
-
     if feedstock == "ipykernel":
         # We have to remove some of the tests that would call into it:
         # master:
         # sed -i 's/pytest_args += \[$/pytest_args += \["--ignore=" + os.path.dirname(loader.path) + "\/test_pickleutil.py",/' recipe/run_test.py
-        r.append(("recipe/run_test.py", 's/print("Final pytest args:", pytest_args)/pytest_args += \["--ignore=" + os.path.dirname(loader.path) + "\/test_pickleutil.py"\]\nprint("Final pytest args:", pytest_args)/'))
+        r.append(("recipe/run_test.py", r's/print("Final pytest args:", pytest_args)/pytest_args += \["--ignore=" + os.path.dirname(loader.path) + "\/test_pickleutil.py"\]\nprint("Final pytest args:", pytest_args)/'))
 
     return r
 

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 7 %}
+{% set build_num = 8 %}
 {% set llvm_version = "10.0.1" %}
 {% set pyston_version = "2.3.1" %}
 {% set python_version = "3.8.12" %}
@@ -126,11 +126,12 @@ outputs:
 
       run_constrained:
         - python {{ python_version }} *_{{ pyston_version2.replace('.', '') }}_pyston
-        # Cython <3.0.0a8 has a bug that causes memory corruption in Pyston
-        # We can work with anything >=3.0.0a8, or our special builds that have
-        # our fix backported. I don't know how to specify this OR relation, so
-        # just specify the one that we're currently using
-        - cython >=0.29 *_pyston
+        # Cython <3.0.0a8,<0.29.25 has a bug that causes memory corruption in Pyston
+        # We can work with anything newer or our special builds that have
+        # our fix backported and the build suffix '_pyston'.
+        # It's not possible to specify a OR relation (only possible by supplying a packages for each condition),
+        # so just specify the one that we're currently using
+        - cython >=0.29.25
 
   - name: libpython-static
     script: build_static.sh


### PR DESCRIPTION
- Cython 0.29.25 contains our fix so we don't need to apply our patch anymore.
- Had to update pyston2.3 build number too because the runtime constrained changed (think this is a bit annoying but afterwards every release should just work / alternative is to always append `_pyston` to the build string).
- Figured out that many packages currently don't build if the `sed` script contains `\n`.

I build a few test packages on my undingen channel and also tried upgrading from the offical `*_7*` pyston package to the newly `*_8*` and it seemed to work fine and it also installed the new cython (but one needs to upload the pyston package before building cython because else the build fails because of the `cython >=0.29 *_pyston` constrain).