### PR TITLE
jit: optimize 'is'/'is not' cmps, PyObject_IsTrue and UNARY_NOT 

### DIFF
--- a/Include/internal/aot_ceval_jit_helper.h
+++ b/Include/internal/aot_ceval_jit_helper.h
@@ -22,7 +22,6 @@ extern "C" {
 #define JIT_HELPER_WITH_NAME_OPCACHE_AOT2(name_, py1, py2) PyObject* JIT_HELPER_##name_(PyObject* name, PyObject* py1, PyObject* py2, _PyOpcache *co_opcache)
 
 
-JIT_HELPER1(UNARY_NOT, value);
 JIT_HELPER1(PRINT_EXPR, value);
 JIT_HELPER_WITH_OPARG(RAISE_VARARGS);
 JIT_HELPER1(GET_AITER, obj);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1651,7 +1651,7 @@ none_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     Py_RETURN_NONE;
 }
 
-static int
+/*static*/ int
 none_bool(PyObject *v)
 {
     return 0;

--- a/Python/aot_ceval_jit_helper.c
+++ b/Python/aot_ceval_jit_helper.c
@@ -165,21 +165,6 @@ int loadAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache, PyObj
 int setupLoadAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache, PyObject* res, int is_load_method);
 
 
-JIT_HELPER1(UNARY_NOT, value) {
-    //PyObject *value = POP();
-    int err = PyObject_IsTrue(value);
-    Py_DECREF(value);
-    if (err == 0) {
-        Py_INCREF_IMMORTAL(Py_True);
-        return Py_True;
-    }
-    else if (err > 0) {
-        Py_INCREF_IMMORTAL(Py_False);
-        return Py_False;
-    }
-    goto_error;
-}
-
 JIT_HELPER1(PRINT_EXPR, value) {
     _Py_IDENTIFIER(displayhook);
     //PyObject *value = POP();

--- a/pyston/aot/aot_gen.py
+++ b/pyston/aot/aot_gen.py
@@ -15,6 +15,7 @@ cmps = ["PyCmp_LT", "PyCmp_LE", "PyCmp_EQ", "PyCmp_NE",
 funcs_need_res_wrap = [
     "PyObject_DelItem",
     "PyObject_SetItem",
+    "PyObject_IsTrue",
 ]
 
 VERBOSITY = 0
@@ -367,7 +368,7 @@ class CallableHandler(Handler):
             pass_args = ", ".join(self._args_names())
             print(f"{self._get_func_sig(name)}", "{", file=f)
             print(f"  if (unlikely(oparg != {nargs-1}))", "{" , file=f)
-            
+
             # CALL_METHOD can call the function with a different number of args
             # depending if LOAD_METHOD returned true or false which means we need
             # to add this additional guard.
@@ -516,6 +517,8 @@ def loadCases():
               "PyNumber_Invert",
 
               "PyObject_GetIter",
+
+              "PyObject_IsTrue", # returns int
               ]
 
     funcs2 = ["PyNumber_Multiply",

--- a/pyston/pystol/pystol.cpp
+++ b/pyston/pystol/pystol.cpp
@@ -446,9 +446,10 @@ void pystolGlobalPythonSetup() {
 void pystolAddConstObj(PyObject* x) {
     int offset = offsetof(PyObject, ob_type); /* skip refcount */
     MARKNOTZERO((char*)x, offset); /* refcount is never zero but not const! */
-    if (PyLong_CheckExact(x))
-        MARKCONST(((char*)x) + offset, sizeof(PyLongObject)
-                                           + (Py_SIZE(x) - 1) * sizeof(digit)
+    if (PyLong_CheckExact(x) || PyBool_Check(x))
+        // implementation from 'int___sizeof___impl()'
+        MARKCONST(((char*)x) + offset, offsetof(PyLongObject, ob_digit)
+                                           + Py_ABS(Py_SIZE(x)) * sizeof(digit)
                                            - offset);
     else if (PyFloat_CheckExact(x))
         MARKCONST(((char*)x) + offset, sizeof(PyFloatObject) - offset);


### PR DESCRIPTION
Small optimizations which improve the performance for the following things:
- generate AOT trace for `PyObject_IsTrue`:
     used by the normal compare and jump opcodes but also now by `UNARY_NOT`
- directly emit `UNARY_NOT` and make it use the `PyObject_IsTrue` trace
- directly emit `is` and `is not` comparisons: this saves a function call and error check

Seeing about 15% speedup on nanobenchmark and very slight speedup on `make measure`.

-----
The traces for `PyObject_IsTrue` can be improved if we tell pystol that
```C
// trace of PyObject_IsTrueLong1
if (unlikely(!(o0->ob_type == &PyLong_Type))) {
   [...]
   return ret;
}
// code inlined from PyObject_IsTrue(PyObject *v) which should be removed:
if (o0 == Py_True)  // remove we know Py_TYPE(Py_True) == PyBool_Type so they can't be equal
    return 1;
if (o0 == Py_False) // remove
    return 0;
if (o0 == Py_None) // remove 
    return 0;
[...] // real code following
```
I'm not sure how to add this to the facts system :/. While not high priority I thought you may be interested in adding it because it's seems like a fun optimization which may trigger for quite a few things.

