### PR TITLE
Improve PyObject_IsTrue traces

### DIFF
--- a/pyston/nitrous/jit.cpp
+++ b/pyston/nitrous/jit.cpp
@@ -743,7 +743,7 @@ void LLVMJit::optimizeFunc(LLVMEvaluator& eval) {
         fpm.add(llvm::createCorrelatedValuePropagationPass());
         fpm.add(llvm::createDeadStoreEliminationPass()); // Delete dead stores
 
-        fpm.add(createFactPass(eval));
+        fpm.add(createFactPass(eval, consts));
         fpm.add(llvm::createInstructionCombiningPass());
         //fpm.add(new RemoveICmpPtrPass(eval));
 

--- a/pyston/nitrous/jit.h
+++ b/pyston/nitrous/jit.h
@@ -128,7 +128,7 @@ public:
     void* finish(LLVMEvaluator& eval);
 };
 
-FunctionPass* createFactPass(LLVMEvaluator& eval);
+FunctionPass* createFactPass(LLVMEvaluator& eval, JitConsts& consts);
 
 }
 


### PR DESCRIPTION
Remove most of the comparisons with True/False/None
Teach it that all objects of type PyNone_Type are the None object