### PR TITLE
AOT: fix crash inside isinstance trace

### DIFF
--- a/pyston/conda/pyston/build_base.sh
+++ b/pyston/conda/pyston/build_base.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eux
 
+# workaround for setuptools 60
+export SETUPTOOLS_USE_DISTUTILS=stdlib
+
 # pyston should not compile llvm and bolt but instead use the conda packages
 export PYSTON_USE_SYS_BINS=1
 

--- a/pyston/test/aot_isinstance_crash.py
+++ b/pyston/test/aot_isinstance_crash.py
@@ -1,0 +1,6 @@
+I = 10000000
+f = isinstance
+for i in range(I):
+    x = f(1, int)
+    if i == I/2:
+        f = lambda x, y: 42


### PR DESCRIPTION
The problem is that right now a trace can't call another trace safely because the called trace can use `SET_JIT_AOT_FUNC` which will look at the return address to find the address to patch.
Normally this points to JITed code but in this case it will be another AOT func.
The frame looks something like this:
`JIT func -> call_functionisinstanceLong3 -> call_functionisinstance3 -> tries to modify return address...`

Clang 13 exposes `__attribute__((musttail))` which should fix the issue unfortunately it got just released.
But there is luckily a simple workaround: change the pointer to the AOT trace but call the unspecialized case.
The JITed code will call the AOT trace next time so we only end-up calling one more time the unspecialized case than strictly necessary.

The issue was really hard to trigger because it only happened when the isinstance function changed but not if only the args changed.