### PR TITLE
OSR: track all backward jumps

### DIFF
--- a/pyston/conda/pyston/build_base.sh
+++ b/pyston/conda/pyston/build_base.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eux
 
+# workaround for setuptools 60
+export SETUPTOOLS_USE_DISTUTILS=stdlib
+
 # pyston should not compile llvm and bolt but instead use the conda packages
 export PYSTON_USE_SYS_BINS=1
 


### PR DESCRIPTION
before we missed a few cases because we only handled JUMP_ABSOLUTE.

The percentage of compiled functions increased by about 2-3% on flaskblogging which looks fine to me.
Make measure stays about the same. Have not tried if it speeds up microbenchmarks but definitely nice to have more predictable OSR behavior.

This fixes #153