### PR TITLE
JIT: fix crash in Is/Is not comparisons

### DIFF
--- a/pyston/test/is_crash.py
+++ b/pyston/test/is_crash.py
@@ -1,0 +1,3 @@
+for i in range(100000):
+    x = "lala"
+    (x + "1") is (x + "2")


### PR DESCRIPTION
My newly introduced #146 optimization contained a bug which caused crashes.
Problem was that when both sides of the comparison are owned values and the first refcount reaches 0.
The call to `_Py_Dealloc` clobbers all registers including the one where we stored the second variable to decref.
This caused us to decref random memory :/.