### PR TITLE
CI: run external testsuites

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# set up locale
+RUN apt-get update
+RUN apt-get -y install locales locales-all
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# copied from https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
+ARG USERNAME=nonroot
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    #
+    # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# ********************************************************
+# * Anything else you want to do like clean up goes here *
+# ********************************************************
+
+# [Optional] Set the default user. Omit if you want to keep the default as root.
+USER $USERNAME

--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -1,7 +1,7 @@
 name: GitHub Actions CI
 on: [push, pull_request]
 jobs:
-  build:
+  conda-build:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -51,4 +51,39 @@ jobs:
           name: core-dump-${{ matrix.build }}
           path: /cores/
           if-no-files-found: ignore
+  unopt_build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: checkout submodules
+        run: |
+          git submodule update --init pyston/LuaJIT pyston/macrobenchmarks
+      - name: build pyston and test
+        run: |
+          # enable core dumps
+          ulimit -c unlimited
+          sudo mkdir -p /cores
+          sudo chmod a+rwx /cores
+          echo "/cores/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern
 
+          docker build -t ubuntu_nonroot .github/workflows/
+          docker run -iv${PWD}:/pyston_dir -iv/cores:/cores --name pyston_build ubuntu_nonroot /pyston_dir/.github/workflows/unopt_build.sh
+
+      # core dump handling steps in case of failure
+      - name: Core dump - add conda build directory
+        if: ${{ failure() }}
+        run: |
+          # if we find a core dump copy in conda build directory as archive
+          if [ "$(ls -A /cores)" ]; then
+            docker cp pyston_build:/pyston_dir /tmp/pyston_dir
+            tar -C /tmp/ -czf /cores/pyston_dir.tar.gz pyston_dir/
+          fi
+          sudo chmod -R +rwx /cores
+          sudo chown -R $USER:$USER /cores
+      - name: Core dump - upload
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: core-dump-unopt_build
+          path: /cores/
+          if-no-files-found: ignore

--- a/.github/workflows/unopt_build.sh
+++ b/.github/workflows/unopt_build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eux
+
+# workaround for setuptools 60
+export SETUPTOOLS_USE_DISTUTILS=stdlib
+
+export DEBIAN_FRONTEND=noninteractive
+
+# install dependencies
+sudo apt-get update
+sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y build-essential ninja-build git cmake clang llvm libssl-dev libsqlite3-dev luajit python3.8 zlib1g-dev virtualenv libjpeg-dev linux-tools-common linux-tools-generic
+sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y libwebp-dev libjpeg-dev python3.8-gdbm python3.8-tk python3.8-dev tk-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libbz2-dev nginx time
+sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y llvm-dev
+
+export PYSTON_USE_SYS_BINS=1 # build has to use system llvm and clang binaries
+
+sudo chown -R `whoami` /pyston_dir
+cd /pyston_dir
+
+make unopt -j$(nproc)
+
+# running the tests
+git submodule update --init "pyston/test/*"
+# have to install late because it will update llvm-10 to 13 or so
+sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y rustc
+
+make test -j$(nproc)

--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,7 @@ tests: $(patsubst %.py,%_unopt,$(TESTFILES))
 tests_dbg: $(patsubst %.py,%_dbg,$(TESTFILES))
 tests_opt: $(patsubst %.py,%_opt,$(TESTFILES))
 
-EXTERNAL_TESTSUITES:=django urllib3 setuptools six requests sqlalchemy pandas
+EXTERNAL_TESTSUITES:=django urllib3 setuptools six requests sqlalchemy pandas numpy
 testsuites: $(patsubst %,test_%,$(EXTERNAL_TESTSUITES))
 testsuites_dbg: $(patsubst %,testdbg_%,$(EXTERNAL_TESTSUITES))
 testsuites_opt: $(patsubst %,testopt_%,$(EXTERNAL_TESTSUITES))
@@ -483,19 +483,12 @@ _runtestsopt: tests_opt testsuites_opt cpython_testsuite_opt
 
 test: build/system_env/bin/python build/unopt_env/bin/python
 	rm -f $(wildcard pyston/test/external/*.output)
-	# Test mostly tests the CAPI so don't rerun it with different JIT_MIN_RUNS
-	# Note: test_numpy is internally parallel so we might have to re-separate it
-	# into a separate step
-	$(MAKE) _runtests test_numpy
+	$(MAKE) _runtests
 	JIT_MAX_MEM=50000 build/unopt_env/bin/python pyston/test/jit_limit.py
 	JIT_MAX_MEM=50000 build/unopt_env/bin/python pyston/test/jit_osr_limit.py
-	build/unopt_env/bin/python pyston/test/test_venvs.py
-	rm -f $(wildcard pyston/test/external/*.output)
-	JIT_MIN_RUNS=0 $(MAKE) _runtests
-	rm -f $(wildcard pyston/test/external/*.output)
-	JIT_MIN_RUNS=50 $(MAKE) _runtests
-	rm -f $(wildcard pyston/test/external/*.output)
-	JIT_MIN_RUNS=9999999999 $(MAKE) _runtests
+	JIT_MIN_RUNS=0 $(MAKE) tests cpython_testsuite
+	JIT_MIN_RUNS=50 $(MAKE) tests cpython_testsuite
+	JIT_MIN_RUNS=9999999999 $(MAKE) tests cpython_testsuite
 	rm -f $(wildcard pyston/test/external/*.output)
 
 stocktest: build/stockunopt_build/python

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo apt-get install build-essential ninja-build git cmake clang libssl-dev libs
 
 Extra dependencies for running the test suite:
 ```
-sudo apt-get install libwebp-dev libjpeg-dev python3.8-gdbm python3.8-tk python3.8-dev tk-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libbz2-dev nginx rustc
+sudo apt-get install libwebp-dev libjpeg-dev python3.8-gdbm python3.8-tk python3.8-dev tk-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libbz2-dev nginx rustc time
 ```
 
 Extra dependencies for producing Pyston debian packages and portable directory release:

--- a/pyston/nitrous/jit.cpp
+++ b/pyston/nitrous/jit.cpp
@@ -98,10 +98,12 @@ public:
                       ObjLayerT::NotifyLoadedFtor(),
                       [](uint64_t K, const object::ObjectFile& Obj,
                          const RuntimeDyld::LoadedObjectInfo& L) {
+                          /* disabled because we don't link in perfjitevents if avialable
                           static JITEventListener* jit_event
                               = JITEventListener::createPerfJITEventListener();
                           if (jit_event)
                               jit_event->notifyObjectLoaded(K, Obj, L);
+                          */
                       }),
           CompileLayer(AcknowledgeORCv1Deprecation, ObjectLayer, SimpleCompiler(*TM)) {
         llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);

--- a/pyston/test/external/test_django.py
+++ b/pyston/test/external/test_django.py
@@ -12,7 +12,7 @@ django_requirements.txt:
 
 if __name__ == "__main__":
     with tempfile.TemporaryDirectory() as tempdir:
-        print("PYSTONTEST: on-failure-print If you see a WebP failure, you might have to install libweb-dev, delete the cached pillow wheel, and try again")
+        print("PYSTONTEST: on-failure-print If you see a WebP failure, you might have to install libwebp-dev, delete the cached pillow wheel, and try again")
 
         def rel(path):
             return os.path.join(os.path.dirname(__file__), path)

--- a/pyston/test/external/test_django.py
+++ b/pyston/test/external/test_django.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
         print("PYSTONTEST: on-failure-print If you see a WebP failure, you might have to install libwebp-dev, delete the cached pillow wheel, and try again")
 
         def rel(path):
-            return os.path.join(os.path.dirname(__file__), path)
+            return os.path.abspath(os.path.join(os.path.dirname(__file__), path))
 
         env_dir = os.path.abspath(os.path.join(tempdir, "env"))
         subprocess.check_call([rel("../../../build/bootstrap_env/bin/virtualenv"), "-p", sys.executable, env_dir])
@@ -28,5 +28,5 @@ if __name__ == "__main__":
         print("created virtual environment (step 2)")
         subprocess.check_call([os.path.join(env_dir, "bin/pip"), "install", "-r", rel("django_requirements.txt")])
 
-        r = subprocess.call([os.path.join(env_dir, "bin/python3"), "-u", rel("django/tests/runtests.py"), "--parallel", "1"])
+        r = subprocess.call([os.path.join(env_dir, "bin/python3"), "-u", rel("django/tests/runtests.py"), "--parallel", "1"], cwd=tempdir)
         assert r in (0, 1), r

--- a/pyston/test/external/test_numpy.py
+++ b/pyston/test/external/test_numpy.py
@@ -41,12 +41,8 @@ if __name__ == "__main__":
         # One option could be to allow differences in the test counts, but for
         # now let's try forcing the numpy testsuite to think it's running on Pyston
         # even for the baseline run.
-        with open(os.path.join(env_dir, "lib/%s/site-packages/usercustomize.py" % libdir), 'w') as f:
-            f.write("""
-import sys
-if not hasattr(sys, "pyston_version_info"):
-    sys.pyston_version_info = ()
-""")
+        with open(os.path.join(env_dir, "lib/%s/site-packages/pretend_to_be_pyston.pth" % libdir), 'w') as f:
+            f.write("import sys; sys.pyston_version_info = getattr(sys, 'pyston_version_info', ())")
 
         r = subprocess.call([os.path.join(env_dir, "bin/python"), "-u", "runtests.py", "--mode=full", "-v"], cwd=numpy_dir)
         assert r in (0, 1)


### PR DESCRIPTION
This significantly enhances our CI tests. And should make it much less likely for regressions to sneak in.

- add new non conda build job which uses regular unopt non-conda build but with ubuntus llvm libs
     - needs to run inside own docker image so we can control exactly what dependencies get installed
     - could not use the conda job because of dependency issues while installing the dependencies for the external tests.
     - we are building own ubuntu 20.04 based image because some tests fail when run as root and I found this the easiest and cleanest solution
- moved `test_numpy` to the `EXTERNAL_TESTSUITES`
- only run the external testsuites with default JIT flags to reduce build time
- `test_numpy` failed for me. It seemed the `usercustomize.py` script did not get run so I switched to putting in a `.pth` file

Runtime seems to be about 2h15min - will update when all CI jobs have finished