### PR TITLE
CALL_METHOD inline caches

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -571,12 +571,14 @@ PyAPI_DATA(PyObject) _Py_NoneStruct; /* Don't use this directly */
 // as is done by the gc module
 #define IMMORTAL_REFCOUNT (1L<<60)
 #define MAKE_IMMORTAL(obj) (((PyObject*)obj)->ob_refcnt = IMMORTAL_REFCOUNT)
+#define IS_IMMORTAL(obj) (((PyObject*)obj)->ob_refcnt > IMMORTAL_REFCOUNT / 2)
 #else
 #define Py_INCREF_IMMORTAL(obj) Py_INCREF(obj)
 #define Py_XINCREF_IMMORTAL(obj) Py_XINCREF(obj)
 #define Py_DECREF_IMMORTAL(obj) Py_DECREF(obj)
 #define Py_XDECREF_IMMORTAL(obj) Py_XDECREF(obj)
 #define MAKE_IMMORTAL(obj) ((void)obj)
+#define IS_IMMORTAL(obj) (0)
 #endif
 
 /* Macro for returning Py_None from a function */

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ perf_%_$(1): %.py build/$(1)_env/update.stamp
 	LD_LIBRARY_PATH=$${LD_LIBRARY_PATH}:$(abspath build/$(1)_install$(_PREFIX)/lib) JIT_PERF_MAP=1 perf record -g ./build/$(1)_env/bin/python3 $$< $$(ARGS)
 	$$(MAKE) perf_report
 
-pyperf_%_$(1): %.py ./build/$(1)_env/bin/update.stamp build/system_env/bin/python
+pyperf_%_$(1): %.py ./build/$(1)_env/update.stamp build/system_env/bin/python
 	LD_LIBRARY_PATH=$${LD_LIBRARY_PATH}:$(abspath build/$(1)_install$(_PREFIX)/lib) $$(PYPERF) build/$(1)_env/bin/python3 $$< $$(ARGS)
 
 # UNSAFE build target

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -906,6 +906,9 @@ PyDescr_NewMethod(PyTypeObject *type, PyMethodDef *method)
     if (descr != NULL) {
         descr->d_method = method;
         descr->vectorcall = vectorcall;
+
+        if (IS_IMMORTAL(type))
+            MAKE_IMMORTAL(descr);
     }
     return (PyObject *)descr;
 }

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -282,7 +282,7 @@ method_enter_call(PyObject *func)
 }
 
 /* Now the actual vectorcall functions */
-static PyObject *
+/* static */ PyObject *
 method_vectorcall_VARARGS(
     PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames)
 {
@@ -305,7 +305,7 @@ method_vectorcall_VARARGS(
     return result;
 }
 
-static PyObject *
+/* static */ PyObject *
 method_vectorcall_VARARGS_KEYWORDS(
     PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames)
 {
@@ -339,7 +339,7 @@ exit:
     return result;
 }
 
-static PyObject *
+/* static */ PyObject *
 method_vectorcall_FASTCALL(
     PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames)
 {
@@ -357,7 +357,7 @@ method_vectorcall_FASTCALL(
     return result;
 }
 
-static PyObject *
+/* static */ PyObject *
 method_vectorcall_FASTCALL_KEYWORDS(
     PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames)
 {

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1841,10 +1841,10 @@ _PyTypes_Init(void)
 #if PYSTON_SPEEDUPS
 #define INIT_TYPE(TYPE, NAME) \
     do { \
+        MAKE_IMMORTAL((PyObject*)TYPE); \
         if (PyType_Ready(TYPE) < 0) { \
             return _PyStatus_ERR("Can't initialize " NAME " type"); \
         } \
-        MAKE_IMMORTAL((PyObject*)TYPE); \
     } while (0)
 #else
 #define INIT_TYPE(TYPE, NAME) \

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -2342,12 +2342,10 @@ void* jit_func(PyCodeObject* co, PyThreadState* tstate) {
                             // entering this python frame.
 
                             JIT_ASSERT(sizeof(tstate->use_tracing) == 4, "");
-                            | mov eax, [tstate + offsetof(PyThreadState, use_tracing)]
-                            | test eax, eax
+                            | cmp dword [tstate + offsetof(PyThreadState, use_tracing)], 0
                             | jne >1
 
-                            | mov arg1, [vsp - 8 * num_vs_args] // callable
-                            | test arg1, arg1
+                            | cmp qword [vsp - 8 * num_vs_args], 0 // callable
                             | je >1
 
                             | mov arg1, [vsp - 8 * num_args] // self

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -2328,6 +2328,9 @@ void* jit_func(PyCodeObject* co, PyThreadState* tstate) {
 
                             // Strategy:
                             // First guard on tstate->use_tracing == 0
+                            // It looks like we have to guard on this variable, even though we already
+                            // guarded on ceval->tracing_possible, because it looks like a profile
+                            // function will set use_tracing but not tracing_possible
                             //
                             // Then guard that meth != NULL.
                             // We need this to verify that the object in the "self" stack slot

--- a/pyston/aot/aot_gen.py
+++ b/pyston/aot/aot_gen.py
@@ -588,7 +588,7 @@ def loadCases():
                                (len, (([1, 2, 3], )), ((1, 2), ), ("test string", )), # one arg
                                (isinstance, (5, int), (42, str)), # two arg
                                (getattr, (5, "does not exist", 42))],  # three arg
-             "MethodDescr": [(str.join, (" ", ("a", "b", "c"))), (str.upper, ("hello world",))],
+             "MethodDescr": [(str.upper, ("hello world",)), (str.join, (" ", ("a", "b", "c"))), (str.ljust, ("", 5, "x")), (str.replace, ("hello world", "hello", "HELLO", 1))],
              "Method": _method_cases,
              "Function": _function_cases,
 

--- a/pyston/nitrous/interp.cpp
+++ b/pyston/nitrous/interp.cpp
@@ -378,6 +378,12 @@ public:
         if (function_name == "unicode_upper")
             return false;
 
+        if (function_name == "unicode_ljust")
+            return false;
+
+        if (function_name == "unicode_replace")
+            return false;
+
         if (function_name == "builtin_globals")
             return false;
 

--- a/pyston/test/method_ics.py
+++ b/pyston/test/method_ics.py
@@ -1,0 +1,31 @@
+def f():
+    """A particularly challenging case for the CALL_METHOD ics:
+    The LOAD_METHOD does not hit its IC, but it still puts
+    a list at the place that CALL_METHOD expects a list."""
+    l = []
+
+    for i in range(10000000):
+        # These three different methods use different variants of the method ic:
+        try:
+            l.clear()
+        except TypeError:
+            pass
+        try:
+            l.append(0)
+        except TypeError:
+            pass
+        try:
+            l.insert(0, 0)
+        except TypeError:
+            pass
+
+        if i == 100000:
+            class C:
+                clear = []
+                append = []
+                insert = []
+            l = C()
+        elif i > 100000:
+            break
+
+f()


### PR DESCRIPTION
I was thinking about the second line of the following code snippet:
```
l = []
l.append(x)
```

Ideally we would emit code that looks something like
```
if (PyList_CheckExact(l))
  PyList_Append(l, x);
else
  slowpath();
```

However here's what we do currently:

```
LOAD_FAST:

LOAD_METHOD:
set lasti
test for tracing
jump if tracing
load l from frame
incref l
move l onto the value stack
adjust the value stack pointer
load the type
check the version tag
not-taken jump to guard failure
load the dict offset
test the dict offset
take jump to dict check success
load the constant attribute value into rax
incref it
put it onto the stack
copy l from rdi to rax

CALL_METHOD:
set lasti
test for tracing
jump if tracing
copy rax (l) onto the value stack
adjust the value stack
copy tstate to rdi [arg1]
copy value stack pointer to rsi [arg2]
set rdx [arg3] to zero (using an xor)
cmpq + sbb (adjust arg3 by one if a method is found)
call aot function

call_functionMethodDescr2
[this is abbreviated, it's quite a few assembly instructions]
push 5 regs
guard on oparg
fetch f->ob_type
cmp it to PyMethodDescr_Type
jne if failed
check tstate->tracing
load the vectorcall
check if its null (for tpcall style)
load method_vectorcall_noargs
check if its that
call _PyObject_RealIsSubclass
check for recursion limit being exceeded
load func->d_method->ml_meth
test if its null
call it
decref something
decref something else
return

adjust vsp back by 16
test if rax is null (exception)
je if exception (not taken)

POP_TOP
mov rax to rdi
decref rdi
je if deallocated
```

The basis of this PR is that we have an extremely good guess of the exact object that will be called in the CALL_METHOD bytecode, since it is stored in the inline cache for the corresponding LOAD_METHOD bytecode.

This PR specifically targets calling "method descriptors" (methods that are builtin fuctions) of builtin classes.

So with this PR the above simplifies to

```
LOAD_FAST

LOAD_METHOD
set lasti
test for tracing
jump if tracing
load l
incref l
store l to the value stack
adjust value stack pointer
check if this is list
jump for guard failure
mov list.append to rax
store rax to the value stack
mov l back to rax

LOAD_FAST

CALL_METHOD
set lasti
test for tracing
jump for tracing
load x
incref x
move x to the value stack
move rax (l) to the value stack
adjust the value stack
load tstate->use_tracing
check if tstate->use_tracing is nonzero
jump if it's nonzero
load the method object from the value stack
check if its null
jump if its null
load self (l) from the value stack
check if its type is list
jump if its not a list
load x from the value stack into rsi (arg2)
call list_append
load x from the value stack
decref it
jump if dealloc
load al from the value stack
decref it
jump if dealloc
adjust the value stack
check for an exception
jump for exception

POP_TOP
move the result from rax to rdi
decref it
jump if deallocd        
```

Which includes the following optimizations:
- no more incref+decref of list.append (it's immortal now)
- Instead of checking the version tag and then the dictoffset, we just check if the type is list
- inline call_functionMethodDescr2
- skip all the guards inside call_functionMethodDescr2 once we know the exact value of the callable

This results in a pretty large reduction in the overhead of these calls. Here are some timings of these kinds of functions -- this is the total time to call the function, including all the bookkeeping overhead and the actual work of the function itself:

```
list.clear: 6.8ns before, 3.6ns now
list.append: 12ns before, 10ns now
list.insert: 20ns before, 15ns now
dict.pop: 8ns before, 6ns now
str.startswith: 17ns before, 14ns now
```

Unfortunately the behavior of this PR seems pretty different on my two machines, which I presume is due to one being an AMD cpu and the other being an Intel CPU. This PR is not a ton of help on the AMD cpu, and sometimes seems to hurt it (seems to be due to extra icache pressure from the additional code). On my intel cpu it speeds up the macrobenchmarks by about 1%:

```
  system 31.98+-0.21              net +0.0%
b704af68 25.39+-0.03              net -20.6% Add some more trace examples
44c2a121 25.32+-0.04  -0.3%+-0.2% net -20.8% Add a new loadattr cache type
8b2b8964 25.30+-0.02  -0.1%+-0.1% net -20.9% Implement CALL_METHOD "hinting"
5e89aee4 25.17+-0.03  -0.5%+-0.1% net -21.3% Specialize for 1-arg calls as well
b38929d1 25.20+-0.02  +0.1%+-0.1% net -21.2% Add fastcall support to the method hints
709c8bac 25.21+-0.03  +0.0%+-0.1% net -21.2% Small makefile bug
c6ef5680 25.18+-0.03  -0.1%+-0.1% net -21.3% Cap how many decrefs we'll inline
8a644ce9 25.13+-0.02  -0.2%+-0.1% net -21.4% Create specialized versions of decref_array
6fe7c029 25.24+-0.02  +0.4%+-0.1% net -21.1% Test that exposes a segfault
0ab3d9bd 25.12+-0.04  -0.5%+-0.1% net -21.5% Add an additional guard to fix this bug
7711c177 25.11+-0.03  -0.1%+-0.1% net -21.5% Make builtin methods immortal to avoid inc/decrefs
c4b1b2a9 25.19+-0.02  +0.3%+-0.1% net -21.2% Handle VARARGS methods
daeb0440 25.10+-0.04  -0.4%+-0.1% net -21.5% Support method_call ics for methods that take keyw
2b07f84b 25.08+-0.05  -0.1%+-0.2% net -21.6% Now that we handle all method types, clean this up
51105afe 25.11+-0.01  +0.1%+-0.2% net -21.5% Add in a check for tracing
```

I checked one of the benchmarks and all the remaining calls to call_functionMethodDescr* are due to calling method descriptors of subclasses of builtin classes (such as OrderedDict), which I think is possible to handle but seems to be a pretty minor case.


Future work:
- We could do this same optimization with LOAD_GLOBAL + CALL_FUNCTION pairs
- I'm not sure how to do this, but if we were able to fuse the LOAD_METHOD and CALL_METHOD bytecodes together, then we could remove the duplicate guards, and get rid of a bunch of stack manipulations and refcounting operations. Unfortunately those two bytecodes are not next to each other except for 0-arg calls.
- There's still a lot of value-stack manipulation in the inline cache which I think could be deferred to the slowpath
- We know that list_append always returns None (or NULL), so we could skip decreffing it.