### PR TITLE
JIT: a few small improvements I discovered while reviewing the method IC PR

### DIFF
--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -1494,7 +1494,8 @@ static int emit_inline_cache(Jit* Dst, int opcode, int oparg, _PyOpcache* co_opc
                 | jne >1
             }
             emit_mov_imm(Dst, res_idx, (unsigned long)lg->ptr);
-            emit_incref(Dst, res_idx);
+            if (!IS_IMMORTAL(lg->ptr))
+                emit_incref(Dst, res_idx);
             if (jit_stats_enabled) {
                 emit_inc_qword_ptr(Dst, &jit_stat_load_global_hit, 1 /*=can use tmp_reg*/);
             }

--- a/pyston/tools/perf_jit.py
+++ b/pyston/tools/perf_jit.py
@@ -107,7 +107,7 @@ def replaceInst(inst):
     if m:
         n = int(m.group(1), 16)
         if n and lookupAsSymbol(n):
-            return inst.replace(m.group(1), lookupAsSymbol(n))
+            return inst + " <" + lookupAsSymbol(n) + ">"
     return inst
 
 if __name__ == "__main__":
@@ -115,7 +115,7 @@ if __name__ == "__main__":
         objdump = get_objdump(sys.argv[1:])
         for l in objdump.split('\n')[7:]:
             l = replaceInst(l)
-            
+
             # check if we have opcode info string for current address
             addr = getAddressOfInst(l)
             if addr:


### PR DESCRIPTION
Only the 3 commits are new (I rebased it on your commit because I used the new `IS_IMMORTAL()` and I did not want to introduce a merge conflict:
- fix perf integration for some 'callq' instructions where we did not print the destination:
Before: 
![image](https://user-images.githubusercontent.com/7397630/150851919-7be4eb0d-e744-43af-a1df-05e188a3fa3f.png)
After:
![image](https://user-images.githubusercontent.com/7397630/150851970-e68aaac6-0144-4be0-a106-be165ebe023a.png)

- jit: special case for moving an imm to mem without using a register
- jit: LOAD_GLOBAL don't emit an incref for immortal objects