### PR TITLE
export SETUPTOOLS_USE_DISTUTILS=stdlib as a workaround for setuptools 60

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -702,6 +702,11 @@ class ProcessTestCase(BaseTestCase):
 
         def is_env_var_to_ignore(n):
             """Determine if an environment variable is under our control."""
+
+            # Pyston change: we set this variable on purpose
+            if 'SETUPTOOLS_USE_DISTUTILS' in n:
+                return True
+
             # This excludes some __CF_* and VERSIONER_* keys MacOS insists
             # on adding even when the environment in exec is empty.
             # Gentoo sandboxes also force LD_PRELOAD and SANDBOX_* to exist.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -86,6 +86,11 @@ _PyRuntime_Initialize(void)
     }
     runtime_initialized = 1;
 
+// workaround an incompatibility with setuptools 60 until we have a better solution
+#if PYSTON_SPEEDUPS
+    setenv("SETUPTOOLS_USE_DISTUTILS", "stdlib", 0 /* don't overwrite existing var */);
+#endif
+
     return _PyRuntimeState_Init(&_PyRuntime);
 }
 


### PR DESCRIPTION
We are working on a permanent solution but in the meantime I thought we may want to workaround
it this way.
What do you think?