### PR TITLE
ARM64 preperations

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1776,7 +1776,7 @@ Python/aot_ceval.o: Python/aot_ceval.c $(AOT_DIR)/aot.h
 
 Python/aot_ceval_jit.o: Python/aot_ceval_jit.c
 	luajit ../../pyston/LuaJIT/dynasm/dynasm.lua  -o Python/aot_ceval_jit.gen.c $<
-	$(CC) -c $(PY_CORE_CFLAGS) -I../../pyston/LuaJIT/ -Wno-address -Wno-pointer-to-int-cast -o $@ Python/aot_ceval_jit.gen.c
+	$(CC) -c $(PY_CORE_CFLAGS) -I../../pyston/LuaJIT/ -Wno-address -Wpointer-to-int-cast -o $@ Python/aot_ceval_jit.gen.c
 
 ifneq (,$(findstring Ubuntu 7.,$(shell $(CC) --version)))
 FCF_FLAG:=

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -80,11 +80,11 @@
 
 #if JIT_DEBUG
 #define DASM_CHECKS 1
-#define JIT_ASSERT(x, m) do { if (!(x)) {                       \
-                                fprintf(stderr, "%s\n", m);     \
-                                assert(0);                      \
-                                abort();                        \
-                              }                                 \
+#define JIT_ASSERT(x, m) do { if (!(x)) {                                            \
+                                fprintf(stderr, "\nline: %d\n%s\n", __LINE__, m);    \
+                                assert(0);                                           \
+                                abort();                                             \
+                              }                                                      \
                          } while(0)
 
 #else
@@ -191,6 +191,13 @@ typedef struct Jit {
 
 #include <dynasm/dasm_proto.h>
 #include <dynasm/dasm_x86.h>
+
+#if JIT_DEBUG
+// checks after every instruction sequence emitted if a DynASM error got generated
+// helps with catching operands which are out of range for the specified instruction.
+#define dasm_put(...) do { dasm_put(__VA_ARGS__); JIT_ASSERT(Dst_REF->status == DASM_S_OK, "dasm check failed"); } while (0)
+#endif
+
 
 #include <sys/mman.h>
 #include <ctype.h>

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -3331,6 +3331,8 @@ void* jit_func(PyCodeObject* co, PyThreadState* tstate) {
         }
     }
 
+    __builtin___clear_cache((char*)mem, &((char*)mem)[size]);
+
     ++jit_num_funcs;
     success = 1;
 


### PR DESCRIPTION
This PR refactors the JIT to make it easy to add support for ARM64.
Everything except the IC code is converted to use the newly introduced helper functions (used functions where possible and a few macros for branches where we have to). The generated code is slightly different for `STORE_FAST` and `DELETE_FAST` bytecodes and I fixed a bug in `END_FINALLY`.

I still have to cleanup the real arm implementations so this does not contain any of it yet but I hope to have it ready by next week (without the ICs). And plan on fixing the IC stuff afterwards.

It's best to look at every commit individually.