### PR TITLE
Update to LLVM 13.0.1

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/.github/workflows/unopt_build.sh
+++ b/.github/workflows/unopt_build.sh
@@ -8,9 +8,19 @@ export DEBIAN_FRONTEND=noninteractive
 
 # install dependencies
 sudo apt-get update
-sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y build-essential ninja-build git cmake clang llvm libssl-dev libsqlite3-dev luajit python3.8 zlib1g-dev virtualenv libjpeg-dev linux-tools-common linux-tools-generic
+
+# Install llvm 13:
+sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y software-properties-common wget
+wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo add-apt-repository "deb http://apt.llvm.org/focal llvm-toolchain-focal-13 main"
+sudo apt-get update
+for name in clang clang++ llvm-link llvm-profdata; do
+    sudo ln -s /usr/bin/$name-13 /usr/bin/$name
+done
+
+sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y build-essential ninja-build git cmake clang-13 llvm-13 libssl-dev libsqlite3-dev luajit python3.8 zlib1g-dev virtualenv libjpeg-dev linux-tools-common linux-tools-generic
 sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y libwebp-dev libjpeg-dev python3.8-gdbm python3.8-tk python3.8-dev tk-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libbz2-dev nginx time
-sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y llvm-dev
+sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y llvm-13-dev
 
 export PYSTON_USE_SYS_BINS=1 # build has to use system llvm and clang binaries
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ pyston3: build/opt_env/bin/python
 
 .PHONY: clean
 clean:
-	rm -rf build/*_env build/*_build build/*_install build/aot*
+	rm -rf build/*_env build/*_build build/*_install build/aot* build/cpython_bc
 
 tune: build/system_env/bin/python
 	PYTHONPATH=pyston/tools build/system_env/bin/python -c "import tune; tune.tune()"

--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,9 @@ aot_trace_only: build/aot_dev/all.bc build/aot_dev/aot_pre_trace.so pyston/aot/a
 dbg_aot_trace_only: build/aot_dev/all.bc build/aot_dev/aot_pre_trace.so pyston/aot/aot_gen.py build/bc_install/usr/bin/python3 build_dbg
 	cd build/aot_dev; LD_LIBRARY_PATH="`pwd`/../PartialDebug/nitrous/:`pwd`/../PartialDebug/pystol/" gdb --ex run --args ../bc_install/usr/bin/python3 ../../pyston/aot/aot_gen.py --action=trace -vv --only=$(ONLY)
 
+debug_aot_trace_only: build/aot_dev/all.bc build/aot_dev/aot_pre_trace.so pyston/aot/aot_gen.py build/bc_install/usr/bin/python3 build_debug
+	cd build/aot_dev; LD_LIBRARY_PATH="`pwd`/../Debug/nitrous/:`pwd`/../Debug/pystol/" gdb --ex run --args ../bc_install/usr/bin/python3 ../../pyston/aot/aot_gen.py --action=trace -vv --only=$(ONLY)
+
 PYPERF:=build/system_env/bin/pyperf command -w 0 -l 1 -p 1 -n $(or $(N),$(N),3) -v --affinity 0
 
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ git submodule update --init pyston/llvm pyston/bolt pyston/LuaJIT pyston/macrobe
 Pyston has the following build dependencies:
 
 ```
-sudo apt-get install build-essential ninja-build git cmake clang libssl-dev libsqlite3-dev luajit python3.8 zlib1g-dev virtualenv libjpeg-dev linux-tools-common linux-tools-generic linux-tools-`uname -r`
+sudo apt-get install build-essential git cmake clang libssl-dev libsqlite3-dev luajit python3.8 zlib1g-dev virtualenv libjpeg-dev linux-tools-common linux-tools-generic linux-tools-`uname -r`
 ```
 
 Extra dependencies for running the test suite:

--- a/pyston/aot/aot_gen.py
+++ b/pyston/aot/aot_gen.py
@@ -619,6 +619,7 @@ def loadCases():
     # we try to specialice on the 2. argument and generate a special version for tuples with a single fixed type
     # this are all types where PyType_FastSubclass() checks exist except BaseException
     for name, example in {  # name: (args to isinstance)
+                            "": (1.0, float), # non type specialized isinstance case. note this needs to go first
                             "Long": (1, int),
                             "List" : ([1], list),
                             "Tuple": ((1,), tuple),
@@ -626,7 +627,6 @@ def loadCases():
                             "Unicode": ("str", str),
                             "Dict": (dict(), dict),
                             "Type": (int, type),
-                            "": (1.0, float), # non type specialized isinstance case
                             }.items():
         def createIsInstanceSignature(name, arg1, arg2):
             classes = []
@@ -670,13 +670,15 @@ def loadCases():
         return Signature(classes, always_trace=[f"builtin_{func_name}"], guard_fail_fn_name=guard_fail_fn_name)
 
     def addBuiltinCFunction1ArgSignatures(func_name, func, spec_dict):
-        # Argument type specific versions
-        for name, example in spec_dict.items():
-            call_signatures.append(createBuiltinCFunction1ArgSignature(func_name, func, name, [example]))
         # Generic non arg type specific version only assuming the function is the same.
         # Creates a trace supporting all types.
         # If a type guard inside a type specific version fails we will use this trace.
+        # Note: this needs to go before the specialized versions
         call_signatures.append(createBuiltinCFunction1ArgSignature(func_name, func, "", list(spec_dict.values())))
+
+        # Argument type specific versions
+        for name, example in spec_dict.items():
+            call_signatures.append(createBuiltinCFunction1ArgSignature(func_name, func, name, [example]))
 
     # builtin len()
     len_specs = {

--- a/pyston/aot/aot_gen.py
+++ b/pyston/aot/aot_gen.py
@@ -563,7 +563,7 @@ def loadCases():
                            ]
 
     f = 4.4584
-    types = {"Long": (0, 1, 4200, -42222),
+    types = {"Long": (0, 1, 420, -322),
              "Float": (f,),
              "Unicode": ('string', '', ' alaslas' * 20, 'a'),
              "List": ([1, 2, 3], list(range(100)),),

--- a/pyston/conda/compiler-rt/meta.yaml
+++ b/pyston/conda/compiler-rt/meta.yaml
@@ -1,9 +1,9 @@
 # this recipe is taken from the main/compiler-rt because
 # it's currently not build for linux
 {% set name = "compiler-rt-packages" %}
-{% set version = "10.0.1" %}
+{% set version = "13.0.1" %}
 {% set build_number = 0 %}
-{% set sha256 = "d90dc8e121ca0271f0fd3d639d135bfaa4b6ed41e67bd6eb77808f72629658fa" %}
+{% set sha256 = "7b33955031f9a9c5d63077dedb0f99d77e4e7c996266952c1cec55626dca5dfc" %}
 
 package:
   name: {{ name }}
@@ -13,8 +13,9 @@ source:
   url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version }}/compiler-rt-{{ version }}.src.tar.xz
   sha256: {{ sha256 }}
   patches:
-    - no_codesign.diff
-    - macosx_10_9.patch
+    - patches/0001-no-code-sign.patch
+    - patches/0002-compiler-rt-Make-7.0.0-compatible-with-10.9-SDK.patch
+    - patches/0003-set-cmake-paths.patch
 
 build:
   number: {{ build_number }}

--- a/pyston/conda/compiler-rt/patches/0001-no-code-sign.patch
+++ b/pyston/conda/compiler-rt/patches/0001-no-code-sign.patch
@@ -1,8 +1,17 @@
+From cccd04a707de150bd4326dffb083dac6da21f541 Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Mon, 22 Apr 2019 02:00:30 -0500
+Subject: [PATCH 1/3] no code sign
+
+---
+ cmake/Modules/AddCompilerRT.cmake | 8 --------
+ 1 file changed, 8 deletions(-)
+
 diff --git a/cmake/Modules/AddCompilerRT.cmake b/cmake/Modules/AddCompilerRT.cmake
-index 81b110203..ef6dbff57 100644
+index bc69ec95c419..9f100fdcec2f 100644
 --- a/cmake/Modules/AddCompilerRT.cmake
 +++ b/cmake/Modules/AddCompilerRT.cmake
-@@ -290,14 +290,6 @@ function(add_compiler_rt_runtime name type)
+@@ -366,14 +366,6 @@ function(add_compiler_rt_runtime name type)
          set_target_properties(${libname} PROPERTIES IMPORT_PREFIX "")
          set_target_properties(${libname} PROPERTIES IMPORT_SUFFIX ".lib")
        endif()
@@ -11,10 +20,12 @@ index 81b110203..ef6dbff57 100644
 -        add_custom_command(TARGET ${libname}
 -          POST_BUILD  
 -          COMMAND codesign --sign - $<TARGET_FILE:${libname}>
--          WORKING_DIRECTORY ${COMPILER_RT_LIBRARY_OUTPUT_DIR}
+-          WORKING_DIRECTORY ${COMPILER_RT_OUTPUT_LIBRARY_DIR}
 -        )
 -      endif()
      endif()
-     install(TARGETS ${libname}
-       ARCHIVE DESTINATION ${install_dir_${libname}}
+ 
+     set(parent_target_arg)
+-- 
+2.32.0.windows.2
 

--- a/pyston/conda/compiler-rt/patches/0002-compiler-rt-Make-7.0.0-compatible-with-10.9-SDK.patch
+++ b/pyston/conda/compiler-rt/patches/0002-compiler-rt-Make-7.0.0-compatible-with-10.9-SDK.patch
@@ -1,20 +1,20 @@
-From eaa09b0ac70d1ebba29c4650cb5e5c14b9049499 Mon Sep 17 00:00:00 2001
+From fab7f16f1f1b764bbbdbbb3c135802762f61a99c Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Tue, 16 Oct 2018 21:23:44 -0500
-Subject: [PATCH 3/3] compiler-rt: Make 7.0.0 compatible with 10.9 SDK
+Subject: [PATCH 2/3] compiler-rt: Make 7.0.0 compatible with 10.9 SDK
 
 ---
- lib/xray/xray_buffer_queue.h |  7 +++++++
- lib/xray/xray_utils.h        | 30 ++++++++++++++++++++++++++++++
- 2 files changed, 37 insertions(+)
+ lib/xray/xray_buffer_queue.h |  7 +++++
+ lib/xray/xray_utils.h        | 33 ++++++++++++++++++++++++
+ 2 files changed, 40 insertions(+)
 
 diff --git a/lib/xray/xray_buffer_queue.h b/lib/xray/xray_buffer_queue.h
-index e76fa79..e20a69a 100644
+index e1739d050f3d..38288e35ae62 100644
 --- a/lib/xray/xray_buffer_queue.h
 +++ b/lib/xray/xray_buffer_queue.h
-@@ -20,6 +20,13 @@
- #include "sanitizer_common/sanitizer_mutex.h"
+@@ -21,6 +21,13 @@
  #include <cstddef>
+ #include <cstdint>
  
 +#include <sys/mman.h>
 +/* MAP_ANONYMOUS is MAP_ANON on some systems,
@@ -27,18 +27,28 @@ index e76fa79..e20a69a 100644
  
  /// BufferQueue implements a circular queue of fixed sized buffers (much like a
 diff --git a/lib/xray/xray_utils.h b/lib/xray/xray_utils.h
-index eafa16e..a8dad83 100644
+index 333826168c0d..637ab17f4805 100644
 --- a/lib/xray/xray_utils.h
 +++ b/lib/xray/xray_utils.h
-@@ -20,6 +20,36 @@
- #include <sys/types.h>
- #include <utility>
+@@ -24,6 +24,39 @@
+ #include <zircon/types.h>
+ #endif
  
 +#if defined __APPLE__
 +#include <time.h>
 +#include <mach/clock.h>
 +#include <mach/mach.h>
-+int alt_clock_gettime(int clock_id, timespec *ts) {
++
++#if defined __APPLE__ && __x86_64__ && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // less than macOS 10.12
++  #define clock_gettime alt_clock_gettime
++#endif
++#if defined __APPLE__ && __MAC_OS_X_VERSION_MAX_ALLOWED < 101200
++  #define CLOCK_REALTIME CALENDAR_CLOCK
++  #define CLOCK_MONOTONIC SYSTEM_CLOCK
++  typedef int clockid_t;
++#endif
++
++int alt_clock_gettime(clockid_t clock_id, timespec *ts) {
 +  clock_serv_t cclock;
 +  mach_timespec_t mts;
 +  host_get_clock_service(mach_host_self(), clock_id, &cclock);
@@ -55,17 +65,11 @@ index eafa16e..a8dad83 100644
 +#define MAP_ANONYMOUS MAP_ANON
 +#endif
 +
-+#if defined __APPLE__ && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // less than macOS 10.12
-+  #define clock_gettime alt_clock_gettime
-+  #define CLOCK_REALTIME CALENDAR_CLOCK
-+  #define CLOCK_MONOTONIC SYSTEM_CLOCK
-+  typedef int clockid_t;
-+#endif
-+
 +#endif
 +
  namespace __xray {
  
- // Default implementation of the reporting interface for sanitizer errors.
+ class LogWriter {
 -- 
-2.5.4 (Apple Git-61)
+2.32.0.windows.2
+

--- a/pyston/conda/compiler-rt/patches/0003-set-cmake-paths.patch
+++ b/pyston/conda/compiler-rt/patches/0003-set-cmake-paths.patch
@@ -1,0 +1,31 @@
+From c875dfed5452f1ea743881188c048590b37e7fc0 Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Wed, 14 Oct 2020 20:06:05 -0500
+Subject: [PATCH 3/3] set cmake paths
+
+---
+ cmake/Modules/CompilerRTUtils.cmake | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/Modules/CompilerRTUtils.cmake b/cmake/Modules/CompilerRTUtils.cmake
+index 5543e3c6afc6..988bf2ff1e0f 100644
+--- a/cmake/Modules/CompilerRTUtils.cmake
++++ b/cmake/Modules/CompilerRTUtils.cmake
+@@ -373,11 +373,12 @@ macro(load_llvm_config)
+       OUTPUT_VARIABLE CONFIG_OUTPUT)
+     if(NOT HAD_ERROR)
+       string(STRIP "${CONFIG_OUTPUT}" LLVM_CMAKE_PATH_FROM_LLVM_CONFIG)
+-      file(TO_CMAKE_PATH ${LLVM_CMAKE_PATH_FROM_LLVM_CONFIG} LLVM_CMAKE_PATH)
++      file(TO_CMAKE_PATH ${LLVM_CMAKE_PATH_FROM_LLVM_CONFIG} LLVM_CMAKE_PATH2)
+     else()
+       file(TO_CMAKE_PATH ${LLVM_BINARY_DIR} LLVM_BINARY_DIR_CMAKE_STYLE)
+-      set(LLVM_CMAKE_PATH "${LLVM_BINARY_DIR_CMAKE_STYLE}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
++      set(LLVM_CMAKE_PATH2 "${LLVM_BINARY_DIR_CMAKE_STYLE}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
+     endif()
++    set(LLVM_CMAKE_PATH ${LLVM_CMAKE_PATH2} CACHE STRING "Path to LLVM cmake files")
+ 
+     set(LLVM_CMAKE_INCLUDE_FILE "${LLVM_CMAKE_PATH}/LLVMConfig.cmake")
+     if (EXISTS "${LLVM_CMAKE_INCLUDE_FILE}")
+-- 
+2.32.0.windows.2
+

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -1,5 +1,5 @@
-{% set build_num = 9 %}
-{% set llvm_version = "10.0.1" %}
+{% set build_num = 10 %}
+{% set llvm_version = "13.0.1" %}
 {% set pyston_version = "2.3.2" %}
 {% set python_version = "3.8.12" %}
 {% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}

--- a/pyston/nitrous/Execution.cpp
+++ b/pyston/nitrous/Execution.cpp
@@ -1189,6 +1189,12 @@ long fshl(long a, long b, long c) {
     return ((unsigned long)a >> (8 * sizeof(a) - c)) | (b << c);
 }
 
+void assertIsInt64(Type* t) {
+    IntegerType *i = dyn_cast<IntegerType>(t);
+    RELEASE_ASSERT(i, "");
+    RELEASE_ASSERT(i->getBitWidth() == 64, "");
+}
+
 void Interpreter::visitCallBase(CallBase &I) {
   ExecutionContext &SF = ECStack.back();
 
@@ -1227,17 +1233,18 @@ void Interpreter::visitCallBase(CallBase &I) {
       break;
 
     case Intrinsic::abs:
+      assertIsInt64(F->getFunctionType()->getParamType(0));
       // The extra cast is to select the right overload
       func_addr = (uint64_t)(long (*)(long))abs;
       break;
 
     case Intrinsic::smin:
-      // TODO: check for variant
+      assertIsInt64(F->getFunctionType()->getParamType(0));
       func_addr = (uint64_t)_min;
       break;
 
     case Intrinsic::fshl:
-      // TODO
+      assertIsInt64(F->getFunctionType()->getParamType(0));
       func_addr = (uint64_t)fshl;
       break;
 

--- a/pyston/nitrous/Interpreter.h
+++ b/pyston/nitrous/Interpreter.h
@@ -15,7 +15,6 @@
 
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
 #include "llvm/ExecutionEngine/GenericValue.h"
-#include "llvm/IR/CallSite.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/InstVisitor.h"
@@ -67,8 +66,8 @@ struct ExecutionContext {
   Function             *CurFunction;// The currently executing function
   BasicBlock           *CurBB;      // The currently executing BB
   BasicBlock::iterator  CurInst;    // The next instruction to execute
-  CallSite             Caller;     // Holds the call that called subframes.
-                                   // NULL if main func or debugger invoked fn
+  CallBase             *Caller;     // Holds the call that called subframes.
+                                    // NULL if main func or debugger invoked fn
   std::map<Value *, GenericValue> Values; // LLVM values used in this invocation
   std::vector<GenericValue>  VarArgs; // Values passed through an ellipsis
   AllocaHolder Allocas;            // Track memory allocated by alloca
@@ -99,6 +98,15 @@ public:
   /// atexit(3), which we intercept and store in AtExitHandlers.
   ///
   void runAtExitHandlers();
+
+  static void Register() {
+    InterpCtor = create;
+  }
+
+  /// Create an interpreter ExecutionEngine.
+  ///
+  static ExecutionEngine *create(std::unique_ptr<Module> M,
+                                 std::string *ErrorStr = nullptr);
 
   /// run - Start execution with the specified function and arguments.
   ///
@@ -153,10 +161,11 @@ public:
   void visitBitCastInst(BitCastInst &I);
   void visitSelectInst(SelectInst &I);
 
-
-  virtual void visitCallSite(CallSite CS);
-  void visitCallInst(CallInst &I) { visitCallSite (CallSite (&I)); }
-  void visitInvokeInst(InvokeInst &I) { visitCallSite (CallSite (&I)); }
+  void visitVAStartInst(VAStartInst &I);
+  void visitVAEndInst(VAEndInst &I);
+  void visitVACopyInst(VACopyInst &I);
+  void visitIntrinsicInst(IntrinsicInst &I);
+  virtual void visitCallBase(CallBase &I);
   void visitUnreachableInst(UnreachableInst &I);
 
   void visitShl(BinaryOperator &I);

--- a/pyston/nitrous/facts.cpp
+++ b/pyston/nitrous/facts.cpp
@@ -8,6 +8,7 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/Dominators.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"

--- a/pyston/nitrous/jit.cpp
+++ b/pyston/nitrous/jit.cpp
@@ -326,10 +326,8 @@ void LLVMJit::cloneFunctionIntoAndRemap(Function* new_func,
     // Uncomment this to strip debug metadata from the emitted code.
     // This makes the generated IR easier to read, and may also improve compilation
     // speed a tiny amount
-    //if (nitrous_verbosity < NITROUS_VERBOSITY_IR) {
     if (getenv("STRIP_DEBUG_INFO"))
          StripDebugInfo(*module);
-    //}
 }
 
 LLVMJit::LLVMJit(const Function* orig_function, orc::ThreadSafeContext* llvm_context,

--- a/pyston/nitrous/jit.cpp
+++ b/pyston/nitrous/jit.cpp
@@ -13,8 +13,11 @@
 #include "llvm/ExecutionEngine/JITEventListener.h"
 #include "llvm/ExecutionEngine/JITSymbol.h"
 #include "llvm/ExecutionEngine/Orc/CompileUtils.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
+#include "llvm/ExecutionEngine/Orc/ExecutorProcessControl.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
-#include "llvm/ExecutionEngine/Orc/LambdaResolver.h"
+#include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
@@ -60,135 +63,106 @@ namespace nitrous {
 // from llvm/examples/Kaleidoscope/include/KaleidoscopeJIT.h
 class LLVMJitCompiler {
 private:
+    // An ORC definition generator that uses our SymbolFinder class to look up non-dynamic
+    // symbols from the current process.
+    class SFDefGenerator : public DefinitionGenerator {
+    public:
+        SymbolFinder* finder;
+
+        SFDefGenerator(SymbolFinder *finder) : finder(finder) {}
+
+        Error tryToGenerate(LookupState &LS, LookupKind K, JITDylib &JD,
+                JITDylibLookupFlags JDLookupFlags, const SymbolLookupSet &Symbols) override {
+            // Adapted from ExecutionUtils.cpp: DynamicLibrarySearchGenerator::tryToGenerate()
+            orc::SymbolMap NewSymbols;
+
+            for (auto &KV : Symbols) {
+              StringRef Name = *KV.first;
+
+              if (Name.empty())
+                continue;
+
+              void* Addr = finder->lookupSymbol(Name);
+              //printf("Looking up symbol %s: %p\n", Name.data(), Addr);
+
+              NewSymbols[KV.first] = JITEvaluatedSymbol(
+                      static_cast<JITTargetAddress>(reinterpret_cast<uintptr_t>(Addr)),
+                      JITSymbolFlags::Exported);
+            }
+
+            if (NewSymbols.empty())
+                return Error::success();
+
+            return JD.define(absoluteSymbols(std::move(NewSymbols)));
+        }
+    };
     SymbolFinder *finder;
 
 public:
-    using ObjLayerT = LegacyRTDyldObjectLinkingLayer;
-    using CompileLayerT = LegacyIRCompileLayer<ObjLayerT, SimpleCompiler>;
-
-    LLVMJitCompiler(SymbolFinder* _finder)
-        : finder(_finder),
-          Resolver(createLegacyLookupResolver(
-              ES,
-              [this](const std::string& Name) -> JITSymbol {
-                  // Adapted from
-                  // examples/Kaleidoscope/BuildingAJIT/Chapter4/KaleidoscopeJIT.h:
-                  if (auto sym = ObjectLayer.findSymbol(Name, true))
-                      return sym;
-
-                  //if (auto SymAddr
-                      //= RTDyldMemoryManager::getSymbolAddressInProcess(Name))
-                      //return JITSymbol(SymAddr, JITSymbolFlags::Exported);
-                  //return nullptr;
-
-                  return JITSymbol((intptr_t)finder->lookupSymbol(Name),
-                                   JITSymbolFlags::Exported);
-              },
-              [](Error Err) {
-                  cantFail(std::move(Err), "lookupFlags failed");
-              })),
-          TM(EngineBuilder().selectTarget()),
-          DL(TM->createDataLayout()),
-          ObjectLayer(AcknowledgeORCv1Deprecation, ES,
-                      [this](VModuleKey) {
-                          return ObjLayerT::Resources{
-                              std::make_shared<SectionMemoryManager>(), Resolver
-                          };
-                      },
-                      ObjLayerT::NotifyLoadedFtor(),
-                      [](uint64_t K, const object::ObjectFile& Obj,
-                         const RuntimeDyld::LoadedObjectInfo& L) {
-                          /* disabled because we don't link in perfjitevents if avialable
-                          static JITEventListener* jit_event
-                              = JITEventListener::createPerfJITEventListener();
-                          if (jit_event)
-                              jit_event->notifyObjectLoaded(K, Obj, L);
-                          */
-                      }),
-          CompileLayer(AcknowledgeORCv1Deprecation, ObjectLayer, SimpleCompiler(*TM)) {
-        llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
-    }
+    LLVMJitCompiler(SymbolFinder* _finder, std::unique_ptr<ExecutionSession> ES,
+            JITTargetMachineBuilder JTMB, DataLayout DL)
+        : finder(_finder), ES(std::move(ES)), DL(std::move(DL)), Mangle(*this->ES, this->DL),
+        ObjectLayer(*this->ES,
+                []() { return std::make_unique<SectionMemoryManager>(); }),
+        CompileLayer(*this->ES, ObjectLayer,
+                std::make_unique<ConcurrentIRCompiler>(std::move(JTMB))),
+        MainJD(this->ES->createBareJITDylib("<main>")),
+        TM(EngineBuilder().selectTarget()) {
+            MainJD.addGenerator(
+                    cantFail(DynamicLibrarySearchGenerator::GetForCurrentProcess(
+                            DL.getGlobalPrefix())));
+            MainJD.addGenerator(make_unique<SFDefGenerator>(finder));
+        }
 
     TargetMachine& getTargetMachine() { return *TM; }
     SymbolFinder* getSymbolFinder() { return finder; }
 
-    VModuleKey addModule(std::unique_ptr<Module> M) {
-        auto K = ES.allocateVModule();
-        cantFail(CompileLayer.addModule(K, std::move(M)));
-        ModuleKeys.push_back(K);
-        return K;
+    ~LLVMJitCompiler() {
+        if (auto Err = ES->endSession())
+            ES->reportError(std::move(Err));
     }
 
-    void removeModule(VModuleKey K) {
-        ModuleKeys.erase(find(ModuleKeys, K));
-        cantFail(CompileLayer.removeModule(K));
+    static Expected<std::unique_ptr<LLVMJitCompiler>> Create(SymbolFinder* finder) {
+        auto EPC = SelfExecutorProcessControl::Create();
+        if (!EPC)
+            return EPC.takeError();
+
+        auto ES = std::make_unique<ExecutionSession>(std::move(*EPC));
+
+        JITTargetMachineBuilder JTMB(
+                ES->getExecutorProcessControl().getTargetTriple());
+
+        auto DL = JTMB.getDefaultDataLayoutForTarget();
+        if (!DL)
+            return DL.takeError();
+
+        return std::make_unique<LLVMJitCompiler>(finder, std::move(ES), std::move(JTMB),
+                std::move(*DL));
     }
 
-    JITSymbol findSymbol(const std::string Name) {
-        return findMangledSymbol(mangle(Name));
+    Error addModule(ThreadSafeModule TSM, ResourceTrackerSP RT = nullptr) {
+        if (!RT)
+            RT = MainJD.getDefaultResourceTracker();
+        return CompileLayer.add(RT, std::move(TSM));
+    }
+
+    Expected<JITEvaluatedSymbol> lookup(const string& Name) {
+        return ES->lookup({&MainJD}, Mangle(Name));
     }
 
 private:
-    std::string mangle(const std::string& Name) {
-        std::string MangledName;
-        {
-            raw_string_ostream MangledNameStream(MangledName);
-            Mangler::getNameWithPrefix(MangledNameStream, Name, DL);
-        }
-        return MangledName;
-    }
+    //std::shared_ptr<SymbolResolver> Resolver;
+    std::unique_ptr<ExecutionSession> ES;
 
-    JITSymbol findMangledSymbol(const std::string& Name) {
-#ifdef _WIN32
-        // The symbol lookup of ObjectLinkingLayer uses the
-        // SymbolRef::SF_Exported
-        // flag to decide whether a symbol will be visible or not, when we call
-        // IRCompileLayer::findSymbolIn with ExportedSymbolsOnly set to true.
-        //
-        // But for Windows COFF objects, this flag is currently never set.
-        // For a potential solution see: https://reviews.llvm.org/rL258665
-        // For now, we allow non-exported symbols on Windows as a workaround.
-        const bool ExportedSymbolsOnly = false;
-#else
-        const bool ExportedSymbolsOnly = true;
-#endif
-
-        // Search modules in reverse order: from last added to first added.
-        // This is the opposite of the usual search order for dlsym, but makes
-        // more
-        // sense in a REPL where we want to bind to the newest available
-        // definition.
-        for (auto H : make_range(ModuleKeys.rbegin(), ModuleKeys.rend()))
-            if (auto Sym
-                = CompileLayer.findSymbolIn(H, Name, ExportedSymbolsOnly))
-                return Sym;
-
-        // If we can't find the symbol in the JIT, try looking in the host
-        // process.
-        if (auto SymAddr = RTDyldMemoryManager::getSymbolAddressInProcess(Name))
-            return JITSymbol(SymAddr, JITSymbolFlags::Exported);
-
-#ifdef _WIN32
-        // For Windows retry without "_" at beginning, as RTDyldMemoryManager
-        // uses
-        // GetProcAddress and standard libraries like msvcrt.dll use names
-        // with and without "_" (for example "_itoa" but "sin").
-        if (Name.length() > 2 && Name[0] == '_')
-            if (auto SymAddr = RTDyldMemoryManager::getSymbolAddressInProcess(
-                    Name.substr(1)))
-                return JITSymbol(SymAddr, JITSymbolFlags::Exported);
-#endif
-
-        return nullptr;
-    }
-
-    ExecutionSession ES;
-    std::shared_ptr<SymbolResolver> Resolver;
-    std::unique_ptr<TargetMachine> TM;
     const DataLayout DL;
-    ObjLayerT ObjectLayer;
-    CompileLayerT CompileLayer;
-    std::vector<VModuleKey> ModuleKeys;
+    MangleAndInterner Mangle;
+
+    RTDyldObjectLinkingLayer ObjectLayer;
+    IRCompileLayer CompileLayer;
+
+    JITDylib &MainJD;
+
+    TargetMachine* TM;
 };
 
 
@@ -196,7 +170,7 @@ LLVMCompiler::LLVMCompiler(SymbolFinder* finder) {
     InitializeNativeTarget();
     InitializeNativeTargetAsmPrinter();
     InitializeNativeTargetAsmParser();
-    jit = std::make_unique<LLVMJitCompiler>(finder);
+    jit = ExitOnError()(LLVMJitCompiler::Create(finder));
 }
 
 LLVMCompiler::~LLVMCompiler() {
@@ -211,14 +185,17 @@ TargetMachine& LLVMCompiler::getTargetMachine() {
     return jit->getTargetMachine();
 }
 
-void* LLVMCompiler::compile(unique_ptr<Module> module, string funcname) {
-    jit->addModule(move(module));
-
-    auto r = jit->findSymbol(funcname);
-    RELEASE_ASSERT(r, "uh oh");
+void* LLVMCompiler::compile(unique_ptr<Module> module, ThreadSafeContext context, const string& funcname) {
     ExitOnError ExitOnErr;
-    return (void*)ExitOnErr(r.getAddress());
+
+    auto TSM = ThreadSafeModule(std::move(module), move(context));
+    ExitOnErr(jit->addModule(move(TSM)));
+
+    auto Sym = ExitOnErr(jit->lookup(funcname));
+    RELEASE_ASSERT(Sym, "uh oh");
+    return (void*)Sym.getAddress();
 }
+
 
 int JitConsts::getFlags(char* ptr, int load_size) {
     const int not_found_value = 0;
@@ -327,8 +304,8 @@ void LLVMJit::cloneFunctionIntoAndRemap(Function* new_func,
 
     SmallVector<ReturnInst*, 4> returns;
     GVMaterializer materializer(module.get());
-    CloneFunctionInto(new_func, orig_func, vmap, true, returns, "", nullptr,
-                      nullptr, &materializer);
+    CloneFunctionInto(new_func, orig_func, vmap, CloneFunctionChangeType::DifferentModule, returns,
+            "", nullptr, nullptr, &materializer);
 
     // Uncomment this to strip debug metadata from the emitted code.
     // This makes the generated IR easier to read, and may also improve compilation
@@ -338,11 +315,11 @@ void LLVMJit::cloneFunctionIntoAndRemap(Function* new_func,
     //}
 }
 
-LLVMJit::LLVMJit(const Function* orig_function, LLVMContext* llvm_context,
+LLVMJit::LLVMJit(const Function* orig_function, orc::ThreadSafeContext* llvm_context,
                  LLVMCompiler* compiler, JitConsts& consts)
     : llvm_context(llvm_context),
       compiler(compiler),
-      module(new llvm::Module("module", *llvm_context)),
+      module(new llvm::Module("module", *llvm_context->getContext())),
       consts(consts) {
     module->setDataLayout(orig_function->getParent()->getDataLayout());
     module->setTargetTriple(orig_function->getParent()->getTargetTriple());
@@ -374,7 +351,7 @@ LLVMJit::InlineInfo LLVMJit::inlineFunction(CallInst* call,
     //outs() << "before inlining:\n";
     //outs() << *module << '\n';
     auto orig_ft = cast<FunctionType>(
-        cast<PointerType>(call->getCalledValue()->getType())->getElementType());
+        cast<PointerType>(call->getCalledOperand()->getType())->getElementType());
 
     auto new_ft = new_func->getFunctionType();
 
@@ -412,8 +389,8 @@ LLVMJit::InlineInfo LLVMJit::inlineFunction(CallInst* call,
     }
 
     InlineFunctionInfo ifi;
-    auto inline_result = InlineFunction(call, ifi);
-    RELEASE_ASSERT((bool)inline_result, "%s", inline_result.message);
+    auto inline_result = InlineFunction(*call, ifi);
+    RELEASE_ASSERT(inline_result.isSuccess(), "%s", inline_result.getFailureReason());
 
     new_func->eraseFromParent();
 
@@ -438,7 +415,7 @@ public:
                       AAQueryInfo& AAQI) {
         AliasResult base = AAResultBase::alias(LocA, LocB, AAQI);
 
-        if (base != MayAlias)
+        if (base != AliasResult::MayAlias)
             return base;
 
         auto&& extractAddrFromIntToPtr = [](const MemoryLocation& Loc, uint64_t& addr, uint64_t& size) {
@@ -458,16 +435,16 @@ public:
         uint64_t sizeA = 0, sizeB = 0;
         if (extractAddrFromIntToPtr(LocA, addrA, sizeA) && extractAddrFromIntToPtr(LocB, addrB, sizeB)) {
             if (addrA == addrB && sizeA == sizeB)
-                return MustAlias;
+                return AliasResult::MustAlias;
             else if (addrA < addrB && addrA + sizeA <= addrB)
-                return NoAlias;
+                return AliasResult::NoAlias;
             else if (addrB < addrA && addrB + sizeB <= addrA)
-                return NoAlias;
+                return AliasResult::NoAlias;
             else
-                return PartialAlias;
+                return AliasResult::PartialAlias;
         }
 
-        return MayAlias;
+        return AliasResult::MayAlias;
     }
 };
 
@@ -754,7 +731,10 @@ void LLVMJit::optimizeFunc(LLVMEvaluator& eval) {
             fpm.add(llvm::createInstructionCombiningPass());
         }
 
-        fpm.add(llvm::createLoopRerollPass());
+        // This pass seems to be buggy as of LLVM 13:
+        // https://github.com/llvm/llvm-project/issues/53736
+        //fpm.add(llvm::createLoopRerollPass());
+
         // fpm.add(llvm::createSLPVectorizerPass());   // Vectorize parallel scalar chains.
 
 
@@ -1120,7 +1100,7 @@ void* LLVMJit::finish(LLVMEvaluator& eval) {
     func->setName(func->getName().slice(0, func->getName().find("_traced")));
     std::error_code EC;
     std::string file_name = ("aot_module." + func->getName() + ".bc").str();
-    llvm::raw_fd_ostream OS(file_name, EC, llvm::sys::fs::F_None);
+    llvm::raw_fd_ostream OS(file_name, EC, llvm::sys::fs::OF_None);
     llvm::Module* mod = func->getParent();
     for (auto&& f : mod->globals()) {
         if (nitrous_pic)
@@ -1152,7 +1132,7 @@ void* LLVMJit::finish(LLVMEvaluator& eval) {
     struct timespec start, end;
     if (nitrous_verbosity >= NITROUS_VERBOSITY_STATS)
         clock_gettime(CLOCK_REALTIME, &start);
-    auto r = compiler->compile(move(module), func->getName());
+    auto r = compiler->compile(move(module), *llvm_context, func->getName().str());
 
     if (nitrous_verbosity >= NITROUS_VERBOSITY_STATS) {
         clock_gettime(CLOCK_REALTIME, &end);

--- a/pyston/nitrous/jit.cpp
+++ b/pyston/nitrous/jit.cpp
@@ -311,7 +311,8 @@ void LLVMJit::cloneFunctionIntoAndRemap(Function* new_func,
     // This makes the generated IR easier to read, and may also improve compilation
     // speed a tiny amount
     //if (nitrous_verbosity < NITROUS_VERBOSITY_IR) {
-        //StripDebugInfo(*module);
+    if (getenv("STRIP_DEBUG_INFO"))
+         StripDebugInfo(*module);
     //}
 }
 

--- a/pyston/nitrous/jit.h
+++ b/pyston/nitrous/jit.h
@@ -34,6 +34,9 @@ class Module;
 class Value;
 class TargetMachine;
 class Type;
+namespace orc {
+class ThreadSafeContext;
+}
 }
 
 namespace nitrous {
@@ -52,7 +55,7 @@ public:
     SymbolFinder* getSymbolFinder();
     llvm::TargetMachine& getTargetMachine();
 
-    void* compile(std::unique_ptr<llvm::Module> module, std::string funcname);
+    void* compile(std::unique_ptr<llvm::Module> module, llvm::orc::ThreadSafeContext context, const std::string& funcname);
 };
 
 class JitConsts {
@@ -81,7 +84,7 @@ public:
 
 class LLVMJit {
 private:
-    llvm::LLVMContext* llvm_context;
+    llvm::orc::ThreadSafeContext* llvm_context;
     LLVMCompiler* compiler;
 
     std::unique_ptr<llvm::Module> module;
@@ -109,7 +112,7 @@ private:
 
 public:
     LLVMJit(const llvm::Function* orig_function,
-            llvm::LLVMContext* llvm_context, LLVMCompiler* compiler,
+            llvm::orc::ThreadSafeContext* llvm_context, LLVMCompiler* compiler,
             JitConsts& consts);
 
     llvm::Function* getFunction() { return func; }

--- a/pyston/nitrous/symbol_finder.cpp
+++ b/pyston/nitrous/symbol_finder.cpp
@@ -123,7 +123,7 @@ void SymbolFinder::addSymbolsFromFile(StringRef filename,
             if (address_symbols.count(addr))
                 address_symbols[addr] = MULTIPLY_DEFINED_STR;
             else
-                address_symbols[addr] = p.first();
+                address_symbols[addr] = p.first().str();
         }
     }
 }

--- a/pyston/pystol/pystol.cpp
+++ b/pyston/pystol/pystol.cpp
@@ -262,8 +262,7 @@ bool PystolFactDeriver::deriveFacts(Value* v, FactSet& facts, LLVMEvaluator& eva
             } else if (name == "PyTuple_New" || name == "PyTuple_New_Nonzeroed") {
                 RELEASE_ASSERT(isPyObjectPtr(call->getType()), "");
 
-                Type* t = call->getType();
-                t = call->getParent()->getParent()->getParent()->getTypeByName("struct._typeobject")->getPointerTo();
+                Type* t = StructType::getTypeByName(getContext(), "struct._typeobject");
 
                 if (auto cint = dyn_cast<ConstantInt>(call->getOperand(0))) {
                     long val = cint->getSExtValue();


### PR DESCRIPTION
I was running into an optimization problem with one of our traces, and tracked it down to something that was fixed in newer versions of LLVM. So I decided to update our LLVM from 10.0 to 13.0.1 (latest release). The main issues:
- ORC v1 was removed, so I had to migrate to ORC v2
- We had some bugs that were not triggered by the IR that LLVM 10.0 generates, but are triggered by LLVM 13