### PR TITLE
jit: add ARM64 support (without ICs) 

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1774,7 +1774,10 @@ Python/dtoa.o: Python/dtoa.c
 Python/aot_ceval.o: Python/aot_ceval.c $(AOT_DIR)/aot.h
 	$(CC) -c $(PY_CORE_CFLAGS) -Wno-unused-label -o $@ $<
 
-Python/aot_ceval_jit.o: Python/aot_ceval_jit.c
+Python/aot_ceval_jit.prep.c: Python/aot_ceval_jit.c ../../pyston/tools/dynasm_preprocess.py
+	../../pyston/tools/dynasm_preprocess.py $< $@
+
+Python/aot_ceval_jit.o: Python/aot_ceval_jit.prep.c
 	luajit ../../pyston/LuaJIT/dynasm/dynasm.lua  -o Python/aot_ceval_jit.gen.c $<
 	$(CC) -c $(PY_CORE_CFLAGS) -I../../pyston/LuaJIT/ -Wno-address -Wpointer-to-int-cast -o $@ Python/aot_ceval_jit.gen.c
 

--- a/pyston/tools/dis_jit_gdb.py
+++ b/pyston/tools/dis_jit_gdb.py
@@ -17,18 +17,20 @@ def stop_handler(event):
 
     gdb.execute("frame 1")
     co = gdb.parse_and_eval("co")
-    print("Dissasembly of", gdb.parse_and_eval("PyUnicode_AsUTF8(co->co_name)"))
+    def getPythonStr(cmd):
+        return str(gdb.parse_and_eval(f"PyUnicode_AsUTF8({cmd})")).split('"')[1]
+    print(f"Dissasembly of {getPythonStr('co->co_filename')}:{int(gdb.parse_and_eval('co->co_firstlineno'))} {getPythonStr('co->co_name')}")
 
-    num_opcodes = int(gdb.parse_and_eval("num_opcodes"))
+    num_opcodes = int(gdb.parse_and_eval("jit.num_opcodes"))
     for i in range(num_opcodes):
-        codeunit = int(gdb.parse_and_eval(f"first_instr[{i}]"))
+        codeunit = int(gdb.parse_and_eval(f"jit.first_instr[{i}]"))
         opcode = codeunit & 0xFF
         oparg = codeunit >> 8
         print(f"{i*2:8} {dis.opname[opcode]:30} {oparg:10}")
 
         flags = "" # "/r" to see machine code bytes too
-        until = f"opcode_addr_begin[{i}+1]" if i+1 < num_opcodes else "labels[lbl_epilog]"
-        gdb.execute(f"disassemble {flags} opcode_addr_begin[{i}], {until}")
+        until = f"((int*)(labels[lbl_opcode_addr_begin]))[{i}+1]" if i+1 < num_opcodes else "labels[lbl_epilog]"
+        gdb.execute(f"disassemble {flags} ((int*)(labels[lbl_opcode_addr_begin]))[{i}], {until}")
 
 gdb.events.stop.connect(stop_handler)
 gdb.Breakpoint("dasm_free")

--- a/pyston/tools/dynasm_preprocess.py
+++ b/pyston/tools/dynasm_preprocess.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+#
+# Preprocesses the DynASM file to remove architecture specific code depending on local architecture.
+# Non matching architecture code is replaced with empty lines so that line numbers match.
+# Usage:
+#   python3 dynasm_preprocess.py <input_file> <output_file>
+#
+# Currently supported architectures:
+#   ARM -> aarch64
+#   X86 -> x86_64
+#
+# Supported directives:
+#  Directives must be first nonwhite space characters on the line.
+#  @<ARCH><CODE> # removes <CODE> depending on arch
+#  @<ARCH>_START # removes all lines to the next @<ARCH>_END depending on arch
+#  @<ARCH>_END
+#
+# Example single line directive:
+#  @ARM| .define name, reg_arm64
+#  @ARM|| #define name_idx reg_arm64_idx
+#  @X86| .define name, reg_amd64
+#  @X86|| #define name_idx reg_amd64_idx
+#
+# Example multi line directive:
+#   @X86_START
+#       if (val == 0) {
+#           | test Rd(r_idx), Rd(r_idx)
+#       } else if (IS_32BIT_VAL(val)) {
+#           | cmp Rd(r_idx), (unsigned int)val
+#       } else {
+#           JIT_ASSERT(0, "should not reach this");
+#       }
+#   @X86_END
+#
+# Without this tool the code in the single line example would look like:
+#  |.if ARCH=aarch64
+#  #ifdef __aarch64__
+#   | .define name, reg_arm64
+#   #define name_idx reg_arm64_idx
+#  #endif
+#  |.else
+#  #ifndef __aarch64__
+#   | .define name, reg_amd64
+#   #define name_idx reg_amd64_idx
+#  #endif
+#  |.endif
+#
+# Because the DynASM |.if/|.endif directives only remove DynASM code and not C code
+# so we also always have to wrap it an additional #ifdef/#endif pair to remove the C code
+# (e.g. calls to emit_mov_imm() would not get removed by |.if/|.endif).
+# And just using the preprocessor would not work because DynASM runs before the C preprocessor
+# and will complain about the different achitecture assembler instructions.
+
+import platform
+import sys
+
+ARCHS = {
+    "aarch64": "ARM",
+    "x86_64": "X86",
+}
+
+
+def preprocess(filename_in, filename_out):
+    def raise_exc(msg):
+        raise Exception("Error on line %s: %s" % (lineno, msg))
+
+    local_arch = ARCHS[platform.machine()]
+    with open(filename_out, "w") as file:
+        # this is set to the directive name if we are inside a multi line directive to catch
+        # unmatched pairs
+        inside_multiline_directive = None
+        # should we skip the next lines?
+        skip = False
+        for lineno, line in enumerate(open(filename_in, "r").readlines(), 1):
+            line_stripped = line.strip()
+            if line_stripped.startswith("@"):
+                # we go over all supported archs because it makes it easier to catch errors
+                for arch in ARCHS.values():
+                    directive = "@" + arch
+                    if line_stripped.startswith(directive):
+                        directive_start = directive + "_START"
+                        directive_end = directive + "_END"
+
+                        if line_stripped.startswith(directive_start):
+                            if inside_multiline_directive:
+                                raise_exc(
+                                    "Found %s inside %s"
+                                    % (directive_start, inside_multiline_directive)
+                                )
+                            inside_multiline_directive = directive_start
+                            skip = local_arch != arch
+                            file.write("\n")
+                        elif line_stripped.startswith(directive_end):
+                            if inside_multiline_directive != directive_start:
+                                raise_exc(
+                                    "Mixed %s with %s"
+                                    % (inside_multiline_directive, directive_end)
+                                )
+                            inside_multiline_directive = None
+                            skip = False
+                            file.write("\n")
+                        else:
+                            if inside_multiline_directive:
+                                raise_exc(
+                                    "Found %s inside %s"
+                                    % (directive, inside_multiline_directive)
+                                )
+                            if arch == local_arch:
+                                file.write(
+                                    line.replace(directive, " " * len(directive))
+                                )
+                            else:
+                                file.write("\n")
+                        break
+                else:
+                    raise_exc("Unknown architecture: " + line_stripped)
+            else:
+                file.write("\n" if skip else line)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: %s <input.c> <output.c>" % (sys.argv[0],))
+        sys.exit(1)
+    preprocess(filename_in=sys.argv[1], filename_out=sys.argv[2])


### PR DESCRIPTION
Passes all tests and testsuites but does not implement Inline caches yet which will follow next week.
Also codegen is not optimized yet for ARM.

Most of the work has already been factored out in the previous pull requests now we just
have to actually implement the ARM codegen.
Luckily it's not that much code and most of it is related to the fixed 32bit instructions size
which is much more strict about the size of immediates.

I guess the most controversial thing will be my decision to implement everything in the same file and use a custom
preprocessor. I decided on this route because we can reuse most of the functions and often the arch specific code is only a few lines and most stuff is shared.
So to me it makes not much sense to split the archs into different files / I actually even prefer to see what the other arch is doing.
Unfortunately this would be really verbose because it always requires us to wrap everything into a C ifdef and a DynASM ifdef.
More infos regarding this are found in the preprocessor source.

__There a some notable gotchas:__
- inline caches and `Py_REF_DEBUG` are not yet implemented
- on ARM64 the return value of a function is the same reg as the first argument. This causes a bunch of issues for us.
I worked around it by assigning reg 'res' to new register and making sure that we generate a extra mov after
every call/return instruction which moves the value from 'real_res' to 'res'.
This means we generate a few unnecessary `mov reg, reg`s but this should be super cheap and we can fix it later if we want.
- we can't compile functions with more than 16383 bytecodes (this limit will double when we upgrade to cpython 3.11)
This makes the `f_lasti` update code easier and I don't think this is a problem we will just abort compilation for this specific function.
- `mmap()` does not support `MAP_32BIT`. I worked around it by trying to allocate fixed addresses which seems to work fine even to it's a bit of hack.

**Performance:**
I run a quick pyperformance comparison between Ubuntu 20.04 CPython and Pyston.
For the Intel run I disabled ICs and BOLT to make the comparison fairer.
All are using the optimized build.
```
Geometric mean speedup of Pyston with disabled Inline Caches vs CPython 3.8.10:
M1 Pro:          1.28x faster
Graviton2:       1.33x faster
RPi4:            1.36x faster
Intel i9-12900K: 1.41x faster - x86_64 just for comparison
```
The M1 was the only machine where a few tests performed significantly slower than CPython not sure if this is just a fluke -
will investigate it later.