### PR TITLE
arm64: run PGO tasks single processed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,12 @@ endif
 CPYTHON_EXTRA_CFLAGS:=-fstack-protector -specs=$(CURDIR)/pyston/tools/no-pie-compile.specs -D_FORTIFY_SOURCE=2
 CPYTHON_EXTRA_LDFLAGS:=-specs=$(CURDIR)/pyston/tools/no-pie-link.specs -Wl,-z,relro
 
-PROFILE_TASK:=../../Lib/test/regrtest.py -j 0 -unone,decimal -x test_posix test_asyncio test_cmd_line_script test_compiler test_concurrent_futures test_ctypes test_dbm_dumb test_dbm_ndbm test_distutils test_ensurepip test_ftplib test_gdb test_httplib test_imaplib test_ioctl test_linuxaudiodev test_multiprocessing test_nntplib test_ossaudiodev test_poplib test_pydoc test_signal test_socket test_socketserver test_ssl test_subprocess test_sundry test_thread test_threaded_import test_threadedtempfile test_threading test_threading_local test_threadsignals test_venv test_zipimport_support || true
+PROFILE_TASK_MULTIPROCESS:=-j 0
+ifeq ($(ARCH),aarch64)
+# multiprocessed PGO run is failing for optshared on ARM64
+PROFILE_TASK_MULTIPROCESS:=-j 1
+endif
+PROFILE_TASK:=../../Lib/test/regrtest.py $(PROFILE_TASK_MULTIPROCESS) -unone,decimal -x test_posix test_asyncio test_cmd_line_script test_compiler test_concurrent_futures test_ctypes test_dbm_dumb test_dbm_ndbm test_distutils test_ensurepip test_ftplib test_gdb test_httplib test_imaplib test_ioctl test_linuxaudiodev test_multiprocessing test_nntplib test_ossaudiodev test_poplib test_pydoc test_signal test_socket test_socketserver test_ssl test_subprocess test_sundry test_thread test_threaded_import test_threadedtempfile test_threading test_threading_local test_threadsignals test_venv test_zipimport_support || true
 
 MAKEFILE_DEPENDENCIES:=Makefile.pre.in configure
 build/bc_build/Makefile: $(CLANG) $(MAKEFILE_DEPENDENCIES)


### PR DESCRIPTION
I'm seeing a lot of this errors on the `aot_pic` profiles of the `optshared` build on ARM (`opt` seems to work):
```
LLVM Profile Error: Invalid profile data to merge
LLVM Profile Error: Profile Merging of file pyston/build/aot_pic/aot_prof/default_16542605575556428325_0.profraw failed: File exists
```
When running manually `llvm-profdata` on it I'm seeing a lot of truncation and invalid header errors.

I tried adding the process ID into the filename of the profile file and merge it only afterwards but this does not fix the problem.
Also looked at the bugtracker but could only find a similar sounding issue for windows which got already fixed a long time ago.
In general multiprocessed PGO runs should work - I also creating a testcase and it worked fine.
Not sure whats going on here - it works fine on x86 and I think it's new since llvm 13.

I think we should just run it single processed on ARM for now.