### PR TITLE
opt build: set -vp-counters-per-site

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1796,7 +1796,7 @@ aot_optimized.o: $(AOT_DIR)/aot_all.bc
 	then \
 		echo "traces are compiled with instrumentation"; \
 		rm -rf $(AOT_DIR)/aot_prof; \
-		$(CLANG) -c -O2 $(CFLAGSFORSHARED) -fprofile-generate=`realpath $(AOT_DIR)/aot_prof` -o $@ $(AOT_DIR)/aot_all.bc; \
+		$(CLANG) -c -O2 $(CFLAGSFORSHARED) -fprofile-generate=`realpath $(AOT_DIR)/aot_prof` -mllvm -vp-counters-per-site=2 -o $@ $(AOT_DIR)/aot_all.bc; \
 	elif [ -d $(AOT_DIR)/aot_prof ]; \
 	then \
 		echo "traces are using PGO"; \


### PR DESCRIPTION
I'm seeing a lot of:

>LLVM Profile Warning: Unable to track new values: Running out of static counters.  Consider using option -mllvm -vp-counters-per-site=<n> to allocate more value profile counters at compile time.

Also seeing it in the CI logs.
Increasing it to 2 seems to fix the issue.

clang itself is also increasing it so should be fine: https://reviews.llvm.org/D92669