### PR TITLE
make sure our global builtin objects have a GC header

### DIFF
--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -125,6 +125,14 @@ PyAPI_FUNC(void) _PyCFunction_DebugMallocStats(FILE *out);
 PyAPI_FUNC(void) _PyMethod_DebugMallocStats(FILE *out);
 #endif
 
+#if !defined(Py_LIMITED_API) && PYSTON_SPEEDUPS
+#include "objimpl.h"
+typedef struct {
+    PyGC_Head gchead;
+    PyCFunctionObject obj;
+} PyCFunctionObjectWithGCHeader;
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2816,7 +2816,8 @@ PyMethodDef builtin_method_isinstance[] = { BUILTIN_ISINSTANCE_METHODDEF };
 PyMethodDef builtin_method_len[] = { BUILTIN_LEN_METHODDEF };
 PyMethodDef builtin_method_ord[] = { BUILTIN_ORD_METHODDEF };
 
-PyCFunctionObject builtin_isinstance_obj, builtin_len_obj, builtin_ord_obj;
+PyCFunctionObjectWithGCHeader builtin_isinstance_obj_gc, builtin_len_obj_gc, builtin_ord_obj_gc;
+
 #endif
 
 PyDoc_STRVAR(builtin_doc,
@@ -2909,9 +2910,9 @@ _PyBuiltin_Init(void)
     Py_DECREF(debug);
 
 #if PYSTON_SPEEDUPS
-    _PyModule_AddFunctionStatic(mod, builtin_method_isinstance, &builtin_isinstance_obj);
-    _PyModule_AddFunctionStatic(mod, builtin_method_len, &builtin_len_obj);
-    _PyModule_AddFunctionStatic(mod, builtin_method_ord, &builtin_ord_obj);
+    _PyModule_AddFunctionStatic(mod, builtin_method_isinstance, &builtin_isinstance_obj_gc.obj);
+    _PyModule_AddFunctionStatic(mod, builtin_method_len, &builtin_len_obj_gc.obj);
+    _PyModule_AddFunctionStatic(mod, builtin_method_ord, &builtin_ord_obj_gc.obj);
 #endif
 
     return mod;

--- a/pyston/aot/aot_gen.py
+++ b/pyston/aot/aot_gen.py
@@ -670,7 +670,7 @@ def loadCases():
         def createIsInstanceSignature(name, arg1, arg2):
             classes = []
             tuple1element = isinstance(arg2, tuple) and len(arg2) == 1
-            classes.append(ObjectClass("isinstanceT1" if tuple1element else "isinstance", IdentityGuard(f"(PyObject*)&builtin_isinstance_obj"), [isinstance]))
+            classes.append(ObjectClass("isinstanceT1" if tuple1element else "isinstance", IdentityGuard(f"(PyObject*)&builtin_isinstance_obj_gc.obj"), [isinstance]))
             # add examples
             isinstance_true = [arg1]
             for example in isinstance_true:
@@ -698,7 +698,7 @@ def loadCases():
 
     def createBuiltinCFunction1ArgSignature(func_name, func, arg1type_name, arg1examples):
         classes = []
-        classes.append(ObjectClass(func_name, IdentityGuard(f"(PyObject*)&builtin_{func_name}_obj"), [func]))
+        classes.append(ObjectClass(func_name, IdentityGuard(f"(PyObject*)&builtin_{func_name}_obj_gc.obj"), [func]))
         if arg1type_name: # specialize on arg->ob_type == arg1type_name
             guard = TypeGuard(f"&{getCTypeName(arg1type_name)}")
             guard_fail_fn_name = f"{func_name}2"
@@ -1030,7 +1030,7 @@ def print_includes(f):
     print('#define unlikely(x) __builtin_expect(!!(x), 0)', file=f)
     print('', file=f)
 
-    print('extern PyCFunctionObject builtin_isinstance_obj, builtin_len_obj, builtin_ord_obj;', file=f)
+    print('extern PyCFunctionObjectWithGCHeader builtin_isinstance_obj_gc, builtin_len_obj_gc, builtin_ord_obj_gc;', file=f)
 
     print('', file=f)
 

--- a/pyston/pystol/pystol.cpp
+++ b/pyston/pystol/pystol.cpp
@@ -441,7 +441,7 @@ using namespace pystol;
 
 extern "C" {
 
-PyCFunctionObject builtin_isinstance_obj, builtin_len_obj, builtin_ord_obj;
+extern PyCFunctionObjectWithGCHeader builtin_isinstance_obj_gc, builtin_len_obj_gc, builtin_ord_obj_gc;
 
 void pystolGlobalPythonSetup() {
     addMallocLikeFunc("PyObject_Malloc");
@@ -453,9 +453,9 @@ void pystolGlobalPythonSetup() {
     pystolAddConstObj(Py_None);
     pystolAddConstObj(Py_NotImplemented);
 
-    pystolAddConstObj((PyObject*)&builtin_isinstance_obj);
-    pystolAddConstObj((PyObject*)&builtin_len_obj);
-    pystolAddConstObj((PyObject*)&builtin_ord_obj);
+    pystolAddConstObj((PyObject*)&builtin_isinstance_obj_gc.obj);
+    pystolAddConstObj((PyObject*)&builtin_len_obj_gc.obj);
+    pystolAddConstObj((PyObject*)&builtin_ord_obj_gc.obj);
 
     MARKCONST((char*)_Py_SwappedOp, sizeof(_Py_SwappedOp[0]) * 6);
 


### PR DESCRIPTION
I caught this when compiling pyston via clang (caused many segfaults).
Problem is that the `PyCFunctions` have `Py_TPFLAGS_HAVE_GC` set so must have been allocated via `PyObject_GC_New()`.
I switched to allocate them as global variable because this allows our traces to be further optimized but
I didn't allocate space for the GC Header in front of the object.

This should fix it - performance and generated code seems to be fine.
I checked that `_PyObject_GC_New` -> `_PyObject_GC_Alloc` is setting the GC header to 0 so this should now be the same as we do here.