### PR TITLE
misc jit speedups

### DIFF
--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -4482,13 +4482,6 @@ _PyEval_EvalFrame_AOT_JIT(PyFrameObject *f, PyThreadState * const tstate, PyObje
 {
     PyObject* retval = NULL;
 
-    // our generated code dispatches based on f_lasti so we need to adjust it
-    if (f->f_lasti < 0)
-        f->f_lasti = 0;
-    else // e.g. continuing a generator. increase by one instruction
-        f->f_lasti += 2;
-
-
 continue_jit:
     {
         JitRetVal ret = jit_code(f, tstate, stack_pointer);
@@ -4588,7 +4581,7 @@ exception_unwind:
             PUSH(val);
             PUSH(exc);
 
-            f->f_lasti = handler;
+            f->f_lasti = handler - 2;
             /* Resume normal execution */
             goto continue_jit;
         }

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -734,6 +734,10 @@ static unsigned long jit_stat_call_method_hit, jit_stat_call_method_miss, jit_st
 |.define tmp2, x6
 #define tmp2_idx 6
 
+// this is currently only used in deferred_vs_emit() which requires a temporary reg which is different from the two other we already have
+|.define tmp_pair, x8
+#define tmp_pair_idx 8
+
 |.define zero_reg, xzr  // this register is always 0 - nice for clearing memory
 #define zero_reg_idx 31
 @ARM_END
@@ -1501,33 +1505,58 @@ static void emit_update_f_lasti(Jit* Dst, long val) {
 // Deferred value stack functions
 static void deferred_vs_emit(Jit* Dst) {
     if (Dst->deferred_vs_next) {
+        int clear_vs_preserved_reg = 0;
+        // we use this to generate store pair instructions on arm
+        // if the value is not -1 at the beginning it means we have a not yet stored value which is lives in register 'prev_store_reg'
+@ARM    int prev_store_reg = -1;
         for (int i=Dst->deferred_vs_next; i>0; --i) {
+            int delayed_store = 1;
+            int tmpreg = tmp_idx;
+@ARM        if (prev_store_reg == -1)
+@ARM            tmpreg = tmp_pair_idx;
             DeferredValueStackEntry* entry = &Dst->deferred_vs[i-1];
             if (entry->loc == CONST) {
                 PyObject* obj = PyTuple_GET_ITEM(Dst->co_consts, entry->val);
-                if (IS_IMMORTAL(obj)) {
+                // don't use this path on arm because it prevents storing a pair and arm does not have a store instructions which support immediates
+                // which means it will expanded into a mov + store - we can do better in the common path which at least handles pairs.
+@ARM            if (0) {
+@X86            if (IS_IMMORTAL(obj)) {
                     emit_store64_mem_imm(Dst, (unsigned long)obj, vsp_idx, 8 * (i-1));
+                    delayed_store = 0;
                 } else {
-                    emit_mov_imm(Dst, tmp_idx, (unsigned long)obj);
-                    emit_incref(Dst, tmp_idx);
-                    emit_store64_mem(Dst, tmp_idx, vsp_idx, 8 * (i-1));
+                    emit_mov_imm(Dst, tmpreg, (unsigned long)obj);
+                    if (!IS_IMMORTAL(obj)) {
+                        emit_incref(Dst, tmpreg);
+                    }
                 }
             } else if (entry->loc == FAST) {
-                emit_load64_mem(Dst, tmp_idx, f_idx, get_fastlocal_offset(entry->val));
-                emit_incref(Dst, tmp_idx);
-                emit_store64_mem(Dst, tmp_idx, vsp_idx, 8 * (i-1));
+                emit_load64_mem(Dst, tmpreg, f_idx, get_fastlocal_offset(entry->val));
+                emit_incref(Dst, tmpreg);
             } else if (entry->loc == REGISTER) {
-                emit_store64_mem(Dst, entry->val, vsp_idx, 8 * (i-1));
+                tmpreg = entry->val;
                 if (entry->val == vs_preserved_reg_idx) {
-                    emit_mov_imm(Dst, vs_preserved_reg_idx, 0); // we have to clear it because error path will xdecref
+                    clear_vs_preserved_reg = 1;
                 }
             } else if (entry->loc == STACK) {
-                emit_load64_mem(Dst, tmp_idx, sp_reg_idx, (entry->val + NUM_MANUAL_STACK_SLOTS) * 8);
+                emit_load64_mem(Dst, tmpreg, sp_reg_idx, (entry->val + NUM_MANUAL_STACK_SLOTS) * 8);
                 emit_store64_mem_imm(Dst, 0 /* = value */, sp_reg_idx, (entry->val + NUM_MANUAL_STACK_SLOTS) * 8);
-                emit_store64_mem(Dst, tmp_idx, vsp_idx, 8 * (i-1));
             } else {
                 JIT_ASSERT(0, "entry->loc not implemented");
             }
+            if (delayed_store) {
+@ARM_START
+                if (prev_store_reg != -1) {
+                    | stp Rx(tmpreg), Rx(prev_store_reg), [vsp, #8 * (i-1)]
+                    prev_store_reg = -1;
+                } else if (i > 1) {
+                    prev_store_reg = tmpreg;
+                } else
+@ARM_END
+                emit_store64_mem(Dst, tmpreg, vsp_idx, 8 * (i-1));
+            }
+        }
+        if (clear_vs_preserved_reg) {
+            emit_mov_imm(Dst, vs_preserved_reg_idx, 0); // we have to clear it because error path will xdecref
         }
         emit_adjust_vs(Dst, Dst->deferred_vs_next);
     }

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -1330,8 +1330,9 @@ static void emit_decref2(Jit* Dst, int r_idx, int r_idx2, int preserve_res) {
 }
 
 static void emit_xdecref_arg1(Jit* Dst) {
-    emit_cmp64_imm(Dst, arg1_idx, 0);
-    | branch_eq >9
+@ARM| cbz arg1, >9 // compare and branch on zero. only allows to jump up to 126 byte but is okay here because it's much closer
+@X86emit_cmp64_imm(Dst, arg1_idx, 0);
+@X86| branch_eq >9
     emit_decref(Dst, arg1_idx, 0 /* don't preserve res */);
     |9:
 }

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -1740,10 +1740,32 @@ static void deferred_vs_peek_top_and_apply(Jit* Dst, int r_idx_top) {
 }
 
 static void deferred_vs_pop_n(Jit* Dst, int num, const int* const regs, RefStatus out_ref_status[]) {
-    for (int i=0; i<num; ++i) {
+    if (num <= 0)
+        return;
+
+    // how many values come from the deferred value stack
+    int num_deferred = Dst->deferred_vs_next < num ? Dst->deferred_vs_next : num;
+    // how many values come from the value stack
+    int num_vs = num - num_deferred;
+
+    for (int i=0; i<num_deferred; ++i) {
         out_ref_status[i] = deferred_vs_peek(Dst, regs[i], i+1);
     }
-    deferred_vs_remove(Dst, num);
+    deferred_vs_remove(Dst, num_deferred);
+
+    if (num_vs) {
+        for (int i=0, reverse_i=num-1; i<num_vs; ++i, --reverse_i) {
+            out_ref_status[reverse_i] = OWNED;
+            if (i == 0) {
+                // on arm we can adjust the value stack pointer directly
+                // in the load instruction.
+@ARM            | ldr Rx(regs[reverse_i]), [vsp, #-8*num_vs]!
+@ARM            continue;
+@X86            emit_adjust_vs(Dst, -num_vs);
+            }
+            emit_load64_mem(Dst, regs[reverse_i], vsp_idx, 8*i);
+        }
+    }
 }
 
 // returns one of BORROWED, OWNED, or IMMORTAL


### PR DESCRIPTION
- the arm64 changes not only increase speed but also reduce code size
- most "controversial" is likely the "remove signal and tracing check for STORE_FAST" change. It helps especially unpacking code. All tests pass but can't guarantee it's not breaking some 3rd party tracing code.. I'm fine with removing it if you have doubts.

Speedup is about 4% on Graviton2 and RPi4 (and less on M1) on pyperformance.
```
Geometric mean pyperformance speedup compared to ubuntu 20.04 cpython
                    #183                this patch
M1 Pro:          1.38x faster      ->  1.45x faster
Graviton2:       1.42x faster      ->  1.48x faster
RPi4:            1.46x faster      ->  1.55x faster
Intel i9-12900K: 1.50x faster                             - x86_64 just for comparison
```
