### PR TITLE
docker: create multi arch images using buildx

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Extra dependencies for producing Pyston debian packages and portable directory r
 sudo apt-get install dh-make dh-exec debhelper patchelf
 ```
 
+Extra dependencies for producing Pyston docker images (on amd64 adjust for arm64):
+```
+# docker buildx
+wget https://github.com/docker/buildx/releases/download/v0.8.1/buildx-v0.8.1.linux-amd64 -O $HOME/.docker/cli-plugins/docker-buildx
+chmod +x $HOME/.docker/cli-plugins/docker-buildx
+# qemu
+docker run --privileged --rm tonistiigi/binfmt --install arm64
+```
+
 ## Building
 
 For a build with all optimizations enabled (LTO+PGO) run:

--- a/pyston/docker/Dockerfile
+++ b/pyston/docker/Dockerfile
@@ -10,9 +10,9 @@ ENV LANG C.UTF-8
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends wget; \
-    wget https://github.com/pyston/pyston/releases/download/pyston_${PYSTON_VERSION}/pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
-    apt-get install -y ./pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
-    rm pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
+    wget https://github.com/pyston/pyston/releases/download/pyston_${PYSTON_VERSION}/pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}_`dpkg --print-architecture`.deb; \
+    apt-get install -y ./pyston_*; \
+    rm pyston_*; \
     apt-get remove -y wget; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*

--- a/pyston/docker/Dockerfile.conda
+++ b/pyston/docker/Dockerfile.conda
@@ -9,9 +9,9 @@ RUN set -eux; \
             ca-certificates \
             wget \
         ; \
-    wget https://github.com/pyston/pyston/releases/download/pyston_${PYSTON_VERSION}/PystonConda-${INSTALLER_VERSION}-Linux-x86_64.sh; \
-    bash PystonConda-${INSTALLER_VERSION}-Linux-x86_64.sh -b; \
-    rm PystonConda-${INSTALLER_VERSION}-Linux-x86_64.sh; \
+    wget https://github.com/pyston/pyston/releases/download/pyston_${PYSTON_VERSION}/PystonConda-${INSTALLER_VERSION}-Linux-`uname -m`.sh; \
+    bash PystonConda* -b; \
+    rm PystonConda*; \
     /root/pystonconda/bin/conda init; \
     apt-get remove -y wget; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/pyston/docker/Dockerfile.slim-bullseye
+++ b/pyston/docker/Dockerfile.slim-bullseye
@@ -14,9 +14,9 @@ RUN set -eux; \
             netbase \
             wget \
         ; \
-    wget https://github.com/pyston/pyston/releases/download/pyston_${PYSTON_VERSION}/pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
-    apt-get install -y ./pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
-    rm pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}.deb; \
+    wget https://github.com/pyston/pyston/releases/download/pyston_${PYSTON_VERSION}/pyston_${PYSTON_VERSION}_${UBUNTU_VERSION}_`dpkg --print-architecture`.deb; \
+    apt-get install -y ./pyston_*; \
+    rm pyston_*; \
     apt-get remove -y wget; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This seems to be the recommended way to create this images. And allows via qemu user mode emulation to generate all images on the same machine.

I tested a dummy release on my private repo (with test packages so please don't use this for anything) and
could push it successfully to `undingen/pyston`.
Afterwards I docker run it fine on my x86 PC and MacOS M1 ARM.

I decided to use the debian arch names (amd64,arm64) as the suffix for the debian packages.
And the conda default ones (x86_64,aarch64) for the installers like e.g. similar to the miniconda installer.