### PR TITLE
jit: use PyUnicode_Append when possible

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -279,6 +279,7 @@ _PyCode_InitOpcache(PyCodeObject *co)
         if (opcode == LOAD_GLOBAL
 #if PYSTON_SPEEDUPS
                 || opcode == LOAD_METHOD || opcode == LOAD_ATTR || opcode == STORE_ATTR
+                || opcode == BINARY_ADD || opcode == INPLACE_ADD
 #endif
                 ) {
             opts++;

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -2117,6 +2117,11 @@ main_loop:
                speedup on microbenchmarks. */
             if (PyUnicode_CheckExact(left) &&
                      PyUnicode_CheckExact(right)) {
+                // Pyston change: we use the opcache to signal that we can optimize this unicode concat
+                OPCACHE_CHECK();
+                if (co_opcache)
+                    co_opcache->optimized = 1;
+
                 sum = unicode_concatenate(tstate, left, right, f, next_instr);
                 /* unicode_concatenate consumed the ref to left */
             }
@@ -2316,6 +2321,11 @@ main_loop:
             PyObject *left = TOP();
             PyObject *sum;
             if (PyUnicode_CheckExact(left) && PyUnicode_CheckExact(right)) {
+                // Pyston change: we use the opcache to signal that we can optimize this unicode concat
+                OPCACHE_CHECK();
+                if (co_opcache)
+                    co_opcache->optimized = 1;
+
                 sum = unicode_concatenate(tstate, left, right, f, next_instr);
                 /* unicode_concatenate consumed the ref to left */
             }


### PR DESCRIPTION
This allows us to modify the string inplace if the string is only stored in the fast array
and the operation is followed by a STORE_FAST which will overwrite it.

`PyUnicode_Append()` will handle cases where the reference count is 1 or more (the interpreter also always calls this
function for unicode objects without doing any reference count check first).

The interpreter was already doing it but the JIT didn't implement it.
Code like this gets about 20% faster:
```python
    a = ''
    for i in range(200):
        a = a + 'a'
```