### PR TITLE
jit: STORE_ATTR inline cache for split dicts

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -105,10 +105,11 @@ enum _PyOpcache_StoreAttr_Types {
 
     // caching an index inside instance splitdict, guarded by the splitdict keys version (dict->ma_keys->dk_version_tag)
     SA_CACHE_IDX_SPLIT_DICT = 0,
+    SA_CACHE_IDX_SPLIT_DICT_INIT = 1, // same as the first but means we hit the dict not initialized path
 
     // caching the offset to attribute slot inside a python object.
     // used for __slots__
-    SA_CACHE_SLOT_CACHE = 1,
+    SA_CACHE_SLOT_CACHE = 2,
 };
 
 typedef struct {

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -94,6 +94,7 @@ typedef struct {
             int64_t offset; /* offset in bytes from the start of the PyObject to the slot */
         } slot_cache;
     } u;
+    short type_tp_dictoffset;  /* tp_dictoffset of type */
     char cache_type;
     char meth_found; // used by LOAD_METHOD: can we do the method descriptor optimization or not
     char guard_tp_descr_get; // do we have to guard on Py_TYPE(u.value_cache.obj)->tp_descr_get == NULL
@@ -121,6 +122,7 @@ typedef struct {
             int64_t offset; /* offset in bytes from the start of the PyObject to the slot */
         } slot_cache;
     } u;
+    short type_tp_dictoffset;  /* tp_dictoffset of type */
     char cache_type;
 } _PyOpcache_StoreAttr;
 

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -839,6 +839,21 @@ static uint64_t getSplitDictKeysVersionFromDictPtr(PyObject** dictptr) {
     return _PyDict_GetDictKeyVersionFromSplitDict((PyObject*)dict);
 }
 
+int setItemSplitDictCache(PyObject* dict, Py_ssize_t splitdict_index, PyObject* v, PyObject* name) {
+    int err = _PyDict_SetItemFromSplitDict(dict, name, splitdict_index, v);
+    if (err < 0 && PyErr_ExceptionMatches(PyExc_KeyError)) {
+        PyErr_SetObject(PyExc_AttributeError, name);
+    }
+    return err;
+}
+int setItemInitSplitDictCache(PyObject** dictptr, PyObject* obj, PyObject* v, Py_ssize_t splitdict_index,PyObject* name) {
+    int err = _PyDict_SetItemInitialFromSplitDict(Py_TYPE(obj), dictptr, name, splitdict_index, v);
+    if (err < 0 && PyErr_ExceptionMatches(PyExc_KeyError)) {
+        PyErr_SetObject(PyExc_AttributeError, name);
+    }
+    return err;
+}
+
 int __attribute__((always_inline)) __attribute__((visibility("hidden")))
 storeAttrCache(PyObject* owner, PyObject* name, PyObject* v, _PyOpcache *co_opcache, int* err) {
     _PyOpcache_StoreAttr *sa = &co_opcache->u.sa;
@@ -885,18 +900,20 @@ storeAttrCache(PyObject* owner, PyObject* name, PyObject* v, _PyOpcache *co_opca
         if (_PyDict_GetDictKeyVersionFromKeys((PyObject*)keys) != sa->u.split_dict_cache.splitdict_keys_version)
             return -1;
 
-        *err = _PyDict_SetItemInitialFromSplitDict(tp, dictptr, name, sa->u.split_dict_cache.splitdict_index, v);
+        *err = setItemInitSplitDictCache(dictptr, owner, v, sa->u.split_dict_cache.splitdict_index, name);
+
+        // mark that we hit the dict not initalized path
+        sa->cache_type = SA_CACHE_IDX_SPLIT_DICT_INIT;
     } else {
         // check if this dict has the same keys as the cached one
         if (sa->u.split_dict_cache.splitdict_keys_version != getSplitDictKeysVersionFromDictPtr(dictptr))
             return -1;
 
-        *err = _PyDict_SetItemFromSplitDict(*dictptr, name, sa->u.split_dict_cache.splitdict_index, v);
+        *err = setItemSplitDictCache(*dictptr, sa->u.split_dict_cache.splitdict_index, v, name);
+
+        // mark that we hit the dict already initalized path
+        sa->cache_type = SA_CACHE_IDX_SPLIT_DICT;
     }
-
-    if (*err < 0 && PyErr_ExceptionMatches(PyExc_KeyError))
-        PyErr_SetObject(PyExc_AttributeError, name);
-
 
 hit:
     co_opcache->num_failed = 0;


### PR DESCRIPTION
Unfortunately it's not really possible to inline all of it
because of the complexity of setting a dict entry so we still branch
out to a helper function at the end.

But it's a bit faster then not having the cache inline.
make measure perf stays the same microbenchmarks are slightly improved (e.g richards).
Cache hit rates are really really good for most benchmarks I looked at.
```
e.g. both of this couldn't use an IC for STORE_ATTR before:
raytrace: inlined 10 (of total 10) STORE_ATTR caches: 16015419 hits 0 misses (=0%)
richards: inlined 41 (of total 54) STORE_ATTR caches: 27436324 hits 629121 misses (=2%)
```

I hope that in the future with the cpython 3.11 object layout for split dicts this caches
should be faster and smaller because the pointer to the values array is directly stored
in front of the object.

I confirmed that it also works on Arm.
