### PR TITLE
ICs: cache tp_dictoffset

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -94,6 +94,7 @@ typedef struct {
             int64_t offset; /* offset in bytes from the start of the PyObject to the slot */
         } slot_cache;
     } u;
+    short type_tp_dictoffset;  /* tp_dictoffset of type */
     char cache_type;
     char meth_found; // used by LOAD_METHOD: can we do the method descriptor optimization or not
     char guard_tp_descr_get; // do we have to guard on Py_TYPE(u.value_cache.obj)->tp_descr_get == NULL
@@ -121,6 +122,7 @@ typedef struct {
             int64_t offset; /* offset in bytes from the start of the PyObject to the slot */
         } slot_cache;
     } u;
+    short type_tp_dictoffset;  /* tp_dictoffset of type */
     char cache_type;
 } _PyOpcache_StoreAttr;
 


### PR DESCRIPTION
If we guard on `tp->tp_version_tag` we can also assume that the `tp_dictoffset` has not changed.
This removes a load, cmp, conditional branch for most IC entries
it also allows us to identify types with negative `tp_dictoffset` at compile time which we currently don't handle in the JIT.

I choose to use a short to store the offset because it will not increase the size of our caches
and it should handle nearly all cases.

I'm measuring a small improvement on our benchmarks and pyperformance.

This PR is currently on top of `STORE_ATTR` because it also modifies this cache so it's best to review #207 before.