### PR TITLE
make_release: use rsync with --exclude build

### DIFF
--- a/pyston/make_release_files/Dockerfile.18.04
+++ b/pyston/make_release_files/Dockerfile.18.04
@@ -16,6 +16,7 @@ RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -y build-essential ninja-build git cmake clang libssl-dev libsqlite3-dev luajit python3.8 zlib1g-dev virtualenv libjpeg-dev linux-tools-common linux-tools-generic
 RUN apt-get install -y dh-make dh-exec debhelper patchelf
+RUN apt-get install -y rsync # used by the release script
 
 # we have to set a local else it will use ascii
 RUN apt-get install -y locales

--- a/pyston/make_release_files/Dockerfile.20.04
+++ b/pyston/make_release_files/Dockerfile.20.04
@@ -9,6 +9,7 @@ RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -y build-essential ninja-build git cmake clang libssl-dev libsqlite3-dev luajit python3.8 zlib1g-dev virtualenv libjpeg-dev linux-tools-common linux-tools-generic
 RUN apt-get install -y dh-make dh-exec debhelper patchelf
+RUN apt-get install -y rsync # used by the release script
 
 # we have to set a local else it will use ascii
 RUN apt-get install -y locales

--- a/pyston/tools/make_release.sh
+++ b/pyston/tools/make_release.sh
@@ -63,7 +63,7 @@ function make_release {
 set -ex
 
 # make a copy of the source because it's mounted read only and we want to modify it
-cp -r /src/src_dir_host /src/build
+rsync -r /src/src_dir_host/ /src/build/ --exclude build
 cd /src/build
 rm -rf build
 git clean -fdx


### PR DESCRIPTION
this way we don't have to copy this large directory just to erase it immediately afterwards.
Fixes review comment in #206