### PR TITLE
ICs: add polymorphic LOAD_ATTR/LOAD_METHOD caches

### DIFF
--- a/Python/aot_ceval_jit_helper.c
+++ b/Python/aot_ceval_jit_helper.c
@@ -168,7 +168,7 @@ PyObject* cmp_outcomePyCmp_EXC_MATCH(PyObject *v, PyObject *w) {
 int storeAttrCache(PyObject* owner, PyObject* name, PyObject* v, _PyOpcache *co_opcache, int* err);
 int setupStoreAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache);
 int loadAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache, PyObject** res, int *meth_found);
-int setupLoadAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache, PyObject* res, int is_load_method);
+int setupLoadAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache, PyObject* res, int is_load_method, int inside_interpreter);
 
 
 JIT_HELPER1(PRINT_EXPR, value) {
@@ -1249,7 +1249,7 @@ JIT_HELPER_WITH_NAME_OPCACHE_AOT1(LOAD_ATTR_CACHED, owner) {
 #endif
 
     if (res) {
-        if (setupLoadAttrCache(owner, name, co_opcache, res, 0/*= not LOAD_METHOD*/)) {
+        if (setupLoadAttrCache(owner, name, co_opcache, res, 0/*= not LOAD_METHOD*/, 0 /*not inside_interpreter */)) {
             // don't use the cache anymore
             SET_JIT_AOT_FUNC(JIT_HELPER_LOAD_ATTR);
         }
@@ -1581,7 +1581,7 @@ JIT_HELPER_WITH_NAME_OPCACHE_AOT(LOAD_METHOD_CACHED) {
         goto_error;
     }
 
-    if (setupLoadAttrCache(obj, name, co_opcache, meth, 1 /*= LOAD_METHOD*/)) {
+    if (setupLoadAttrCache(obj, name, co_opcache, meth, 1 /*= LOAD_METHOD*/, 0 /*not inside_interpreter */)) {
         // don't use the cache anymore
         SET_JIT_AOT_FUNC(JIT_HELPER_LOAD_METHOD);
     }


### PR DESCRIPTION
Add a new cache type which stores a dynamically allocated array to further opcache entries.
This are mostly useful for the JIT which can emit several entries with low overhead.

I had to come up with some heuristics to not generate too many polymorphic sites
and what seemed to work was to check if the type is the same (we us a hash because
of storage requirements in the cache entry). This seems to catch a lot of cases
where the shape is quickly changing. In addition the JIT will only emit entries
which at least once got executed which also catches some bad entries.

This improves our benchmarks but also pyperformance (especialy 'richards': 1.39x faster)

Cache entries will never be freed so will leak but I this is similar
to how JIT memory is already leaking.