### PR TITLE
 Take over _PyEval_EvalFrameDefault instead of using PEP523

### DIFF
--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -4801,7 +4801,7 @@ exit_yielding:
 // Entry point when executing a python function.
 // We check if we can use a JIT compiled version or have to use the Interpreter
 PyObject* _Py_HOT_FUNCTION
-_PyEval_EvalFrame_AOT(PyFrameObject *f, int throwflag)
+_PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
 {
     PyObject* retval = NULL;
     _PyRuntimeState * const runtime = &_PyRuntime;
@@ -6783,8 +6783,6 @@ PyInit_aot_ceval(void)
         return NULL;
 
     jit_start();
-
-    PyThreadState_Get()->interp->eval_frame = _PyEval_EvalFrame_AOT;
 
 
 #if PROFILE_OPCODES

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -766,11 +766,8 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
     return interp->eval_frame(f, throwflag);
 }
 
+#ifndef ENABLE_AOT
 PyObject* _Py_HOT_FUNCTION
-// unfortunately bolt fails instrumenting this function when it's compiled with standard O level.
-#if PYSTON_SPEEDUPS
-__attribute__((optimize("-Os")))
-#endif
 _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
 {
 #ifdef DXPAIRS
@@ -905,6 +902,9 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
 #define FAST_DISPATCH() goto fast_next_opcode
 #define DISPATCH() continue
 #endif
+
+// Hacky: close this ifdef early here so that we can get the macros for the other functions
+#endif // ifndef ENABLE_AOT
 
 
 /* Tuple access macros */
@@ -1102,6 +1102,8 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
 #define OPCACHE_STAT_GLOBAL_OPT()
 
 #endif
+
+#ifndef ENABLE_AOT
 
 /* Start of code */
 
@@ -3848,6 +3850,7 @@ exit_eval_frame:
 
     return _Py_CheckFunctionResult(NULL, retval, "PyEval_EvalFrameEx");
 }
+#endif // ifndef ENABLE_AOT
 
 static void
 format_missing(PyThreadState *tstate, const char *kind,

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -605,12 +605,6 @@ pycore_init_types(void)
 #ifdef ENABLE_AOT
 void PyInit_aot_ceval();
 void aot_exit();
-#else
-// Define this function so that we can resolve it during trace-optimization,
-// but it doesn't need to be functional.
-PyObject* _PyEval_EvalFrame_AOT(PyFrameObject *f, int throwflag) {
-    Py_FatalError("AOT called but not enabled");
-}
 #endif
 
 static PyStatus

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -101,7 +101,7 @@ ENCODING = locale.getpreferredencoding()
 
 FRAME_INFO_OPTIMIZED_OUT = '(frame information optimized out)'
 UNABLE_READ_INFO_PYTHON_FRAME = 'Unable to read information on python frame'
-EVALFRAME = ('_PyEval_EvalFrameDefault', '_PyEval_EvalFrame_AOT')
+EVALFRAME = '_PyEval_EvalFrameDefault'
 
 class NullPyObjectPtr(RuntimeError):
     pass
@@ -1540,7 +1540,7 @@ class Frame(object):
 
     def is_evalframe(self):
         '''Is this a _PyEval_EvalFrameDefault frame?'''
-        if self._gdbframe.name() in EVALFRAME:
+        if self._gdbframe.name() == EVALFRAME:
             '''
             I believe we also need to filter on the inline
             struct frame_id.inline_depth, only regarding frames with

--- a/pyston/pystol/pystol.cpp
+++ b/pyston/pystol/pystol.cpp
@@ -116,7 +116,7 @@ static Knowledge* getTypeFact(Value* v, FactSet& facts) {
 }
 
 extern "C" {
-PyObject* _PyEval_EvalFrame_AOT(PyFrameObject*, int);
+PyObject* _PyEval_EvalFrameDefault(PyFrameObject*, int);
 PyObject *method_vectorcall(PyObject *method, PyObject *const *args, size_t nargsf, PyObject *kwnames);
 }
 
@@ -204,13 +204,13 @@ bool PystolFactDeriver::deriveFacts(Value* v, FactSet& facts, LLVMEvaluator& eva
         // _is::eval_frame
         typedef struct _is _is;
         Knowledge& k = facts[LOCFOR(_is, eval_frame)];
-        // We fix eval_frame to _PyEval_EvalFrame_AOT since we know we are running with that to get to this trace.
+        // We fix eval_frame to _PyEval_EvalFrameDefault since we know we are running with that to get to this trace.
         // This means that it becomes more difficult to change the frame evaluation function a second time,
         // but I think it's ok if we don't support that.
         if (!k.known_value || k.known_at) {
             // Hack, we just need a pointer type
             Type* t = v->getType()->getPointerTo();
-            k.known_value = eval.GVToConst(GenericValue((void*)_PyEval_EvalFrame_AOT), t);
+            k.known_value = eval.GVToConst(GenericValue((void*)_PyEval_EvalFrameDefault), t);
             k.known_at = NULL;
             changed = true;
         }


### PR DESCRIPTION
_PyEval_EvalFrameDefault is not safe to call once Pyston is
enabled, due at least to the opcaches being different.

This function isn't part of the public API, but it's still somewhat
exposed, and in general it feels like an unnecessary risk to have
a function that will cause bugs if called.