### PR TITLE
Initial version of pyston_lite

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -35,15 +35,19 @@ enum _PyOpcache_LoadAttr_Types {
     // (only used if the more powerful LA_CACHE_IDX_SPLIT_DICT or LA_CACHE_VALUE_CACHE_SPLIT_DICT is not possible)
     LA_CACHE_VALUE_CACHE_DICT = 0,
 
+#ifndef PYSTON_LITE
     // caching an index inside instance splitdict, guarded by the splitdict keys version (dict->ma_keys->dk_version_tag)
     LA_CACHE_IDX_SPLIT_DICT = 1,
+#endif
 
     // caching a data descriptor object, guarded by data descriptor types version
     LA_CACHE_DATA_DESCR = 2,
 
+#ifndef PYSTON_LITE
     // caching an object from the type, guarded by instance splitdict keys version (dict->ma_keys->dk_version_tag)
     // (making sure the attribute is not getting overwritten in the instance dict)
     LA_CACHE_VALUE_CACHE_SPLIT_DICT = 3,
+#endif
 
     // caching the offset to the instance dict entry inside the hash table.
     // Works for non split dicts but retrieval is slower than LA_CACHE_VALUE_CACHE_DICT
@@ -112,9 +116,11 @@ typedef struct {
 enum _PyOpcache_StoreAttr_Types {
     // we always guard on the type version - in addition:
 
+#ifndef PYSTON_LITE
     // caching an index inside instance splitdict, guarded by the splitdict keys version (dict->ma_keys->dk_version_tag)
     SA_CACHE_IDX_SPLIT_DICT = 0,
     SA_CACHE_IDX_SPLIT_DICT_INIT = 1, // same as the first but means we hit the dict not initialized path
+#endif
 
     // caching the offset to attribute slot inside a python object.
     // used for __slots__

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -1153,7 +1153,7 @@ loadAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache, PyObject*
         else
             Py_INCREF(*res);
 #endif
-    } else {
+    } else if (la->cache_type == LA_CACHE_DATA_DESCR) {
         PyObject* descr = la->u.descr_cache.descr;
         if (unlikely(Py_TYPE(descr)->tp_version_tag != la->u.descr_cache.descr_type_ver))
             return -1;
@@ -1163,6 +1163,9 @@ loadAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache, PyObject*
         // can be null, call into tp_getattro specific handler
         if (*res == NULL)
             *res = loadAttrCacheAttrNotFound(owner, name);
+    } else {
+        fprintf("bad cache type %d\n", la->cache_type);
+        abort();
     }
 
     co_opcache->num_failed = 0;

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -38,7 +38,27 @@
 #include <ctype.h>
 #include <sys/mman.h>
 
+#ifdef PYSTON_LITE
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+
+#define Py_INCREF_IMMORTAL Py_INCREF
+#define Py_DECREF_IMMORTAL Py_DECREF
+
+PyObject *
+_PyDict_LoadGlobalEx(PyDictObject *globals, PyDictObject *builtins, PyObject *key, int *out_wasglobal);
+
+int _PyCode_InitOpcache_Pyston(PyCodeObject *co);
+
+#define PyTuple_New_Nonzeroed PyTuple_New
+#define PyTuple_Pack3(a, b, c) PyTuple_Pack(3, a, b, c)
+
+#define PYSTON_SPEEDUPS 0
+
+static int code_jitfunc_index = -1;
+#else
 #include "aot.h"
+#endif
 
 #ifdef Py_DEBUG
 /* For debugging the interpreter: */
@@ -54,17 +74,25 @@
 /* Private API for the LOAD_METHOD opcode. */
 extern int _PyObject_GetMethod(PyObject *, PyObject *, PyObject **);
 
+#ifndef PYSTON_LITE
 uint64_t _PyDict_GetDictKeyVersionFromSplitDict(PyObject *op);
 uint64_t _PyDict_GetDictKeyVersionFromKeys(PyObject *op);
 PyObject *_PyDict_GetItemFromSplitDict(PyObject *op, Py_ssize_t index);
 int _PyDict_SetItemFromSplitDict(PyObject *op, PyObject *key, Py_ssize_t index, PyObject* value);
 int _PyDict_SetItemInitialFromSplitDict(PyTypeObject *tp, PyObject **dict_ptr, PyObject *key, Py_ssize_t index, PyObject* value);
 Py_ssize_t _PyDict_GetItemIndexSplitDict(PyObject *op, PyObject *key);
+#endif
 
 typedef PyObject *(*callproc)(PyObject *, PyObject *, PyObject *);
 
+#ifdef PYSTON_LITE
+#define CALL_FUNCTION_CEVAL call_function_ceval_fast
+#else
+#define CALL_FUNCTION_CEVAL call_function_ceval
+#endif
+
 /* Forward declarations */
-/*Py_LOCAL_INLINE(PyObject *)*/ PyObject * call_function_ceval(
+PyObject * CALL_FUNCTION_CEVAL(
     PyThreadState *tstate, PyObject ***pp_stack,
     Py_ssize_t oparg, PyObject *kwnames);
 /*static*/ PyObject * do_call_core(
@@ -838,6 +866,7 @@ static uint64_t getDictVersionFromDictPtr(PyObject** dictptr) {
     return dict->ma_version_tag;
 }
 
+#ifndef PYSTON_LITE
 static uint64_t getSplitDictKeysVersionFromDictPtr(PyObject** dictptr) {
     if (dictptr == NULL)
         return 0;
@@ -867,9 +896,13 @@ int setItemInitSplitDictCache(PyObject** dictptr, PyObject* obj, PyObject* v, Py
     }
     return err;
 }
+#endif
 
 int __attribute__((always_inline)) __attribute__((visibility("hidden")))
 storeAttrCache(PyObject* owner, PyObject* name, PyObject* v, _PyOpcache *co_opcache, int* err) {
+#ifdef PYSTON_LITE
+    return -1;
+#else
     _PyOpcache_StoreAttr *sa = &co_opcache->u.sa;
     PyTypeObject *tp = Py_TYPE(owner);
 
@@ -935,10 +968,14 @@ hit:
     storeattr_hits++;
 #endif
     return 0;
+#endif
 }
 
 int __attribute__((always_inline)) __attribute__((visibility("hidden")))
 setupStoreAttrCache(PyObject* obj, PyObject* name, _PyOpcache *co_opcache) {
+#ifdef PYSTON_LITE
+    return -1;
+#else
     _PyOpcache_StoreAttr *sa = &co_opcache->u.sa;
     PyTypeObject *tp = Py_TYPE(obj);
 
@@ -992,11 +1029,17 @@ common_cached:
     sa->type_tp_dictoffset = (short)tp->tp_dictoffset;
     sa->type_ver = tp->tp_version_tag;
     return 0;
+#endif
 }
 
 PyObject* slot_tp_getattr_hook_simple(PyObject *self, PyObject *name);
 PyObject* slot_tp_getattr_hook_simple_not_found(PyObject *self, PyObject *name);
+#ifdef PYSTON_LITE
+static void* module_getattro_value;
+#define module_getattro module_getattro_value
+#else
 PyObject* module_getattro(PyObject *_m, PyObject *name);
+#endif
 PyObject* module_getattro_not_found(PyObject *_m, PyObject *name);
 
 PyObject* loadAttrCacheAttrNotFound(PyObject *owner, PyObject *name) {
@@ -1070,12 +1113,19 @@ loadAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache, PyObject*
         if (*res == NULL)
             return -1;
         Py_INCREF(*res);
-    } else if (la->cache_type == LA_CACHE_VALUE_CACHE_DICT || la->cache_type == LA_CACHE_VALUE_CACHE_SPLIT_DICT || la->cache_type == LA_CACHE_BUILTIN)
+    } else if (la->cache_type == LA_CACHE_VALUE_CACHE_DICT ||
+#ifndef PYSTON_LITE
+            la->cache_type == LA_CACHE_VALUE_CACHE_SPLIT_DICT ||
+#endif
+            la->cache_type == LA_CACHE_BUILTIN)
     {
+#ifndef PYSTON_LITE
         if (la->cache_type == LA_CACHE_VALUE_CACHE_SPLIT_DICT) {
             if (la->u.value_cache.dict_ver != getSplitDictKeysVersionFromDictPtr(dictptr))
                 return -1;
-        } else if (la->cache_type == LA_CACHE_VALUE_CACHE_DICT) {
+        } else
+#endif
+        if (la->cache_type == LA_CACHE_VALUE_CACHE_DICT) {
             if (la->u.value_cache.dict_ver != getDictVersionFromDictPtr(dictptr))
                 return -1;
         } else {
@@ -1089,6 +1139,7 @@ loadAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache, PyObject*
         *res = la->u.value_cache.obj;
         assert(*res); // must be set because otherwise we would not have cached the value
         Py_INCREF(*res);
+#ifndef PYSTON_LITE
     } else if (la->cache_type == LA_CACHE_IDX_SPLIT_DICT) {
         // check if this dict has the same keys as the cached one
         if (la->u.split_dict_cache.splitdict_keys_version != getSplitDictKeysVersionFromDictPtr(dictptr))
@@ -1101,6 +1152,7 @@ loadAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache, PyObject*
             *res = loadAttrCacheAttrNotFound(owner, name);
         else
             Py_INCREF(*res);
+#endif
     } else {
         PyObject* descr = la->u.descr_cache.descr;
         if (unlikely(Py_TYPE(descr)->tp_version_tag != la->u.descr_cache.descr_type_ver))
@@ -1276,11 +1328,15 @@ setupLoadAttrCache(PyObject* obj, PyObject* name, _PyOpcache *co_opcache, PyObje
             // the hashtable entry which does not require us to guard on the exact dict version - but retrieval
             // is more expensive (=LA_CACHE_OFFSET_CACHE)
             if (_PyDict_HasSplitTable((PyDictObject*)dict)) {
+#ifdef PYSTON_LITE
+                return -1;
+#else
                 la->cache_type = LA_CACHE_IDX_SPLIT_DICT;
                 la->u.split_dict_cache.splitdict_keys_version = getSplitDictKeysVersionFromDictPtr(dictptr);
                 la->u.split_dict_cache.splitdict_index = _PyDict_GetItemIndexSplitDict(dict, name);
                 // <0 means we did not find the attribute but this should never happen
                 assert(la->u.split_dict_cache.splitdict_index >= 0);
+#endif
             } else if (co_opcache->num_failed >= 2) {
                 Py_ssize_t dk_size;
                 int64_t offset = _PyDict_GetItemOffset((PyDictObject*)dict, name, &dk_size);
@@ -1325,10 +1381,17 @@ setupLoadAttrCache(PyObject* obj, PyObject* name, _PyOpcache *co_opcache, PyObje
         // guard on the instance dict shape if the instance dict is a splitdict and does not contain the attribute name as key.
         // else we will create guard which will check for the exact dict version (=less generic)
         int is_split_dict = dict && _PyDict_HasSplitTable((PyDictObject*)dict);
+#ifdef PYSTON_LITE
+        if (is_split_dict) {
+            return -1;
+        }
+#else
         if (is_split_dict && _PyDict_GetItemIndexSplitDict(dict, name) == -1) {
             la->u.value_cache.dict_ver = getSplitDictKeysVersionFromDictPtr(dictptr);
             la->cache_type = LA_CACHE_VALUE_CACHE_SPLIT_DICT;
-        } else {
+        }
+#endif
+        else {
             la->u.value_cache.dict_ver = getDictVersionFromDictPtr(dictptr);
             la->cache_type = LA_CACHE_VALUE_CACHE_DICT;
         }
@@ -1406,9 +1469,15 @@ typedef struct {
 
 typedef JitRetVal (*JitFunc)(PyFrameObject* frame, PyThreadState * const tstate, PyObject** sp);
 
+#ifdef PYSTON_LITE
+JitFunc jit_func_lite(PyCodeObject* co, PyThreadState* tstate);
+void jit_start_lite();
+void jit_finish_lite();
+#else
 JitFunc jit_func(PyCodeObject* co, PyThreadState* tstate);
 void jit_start();
 void jit_finish();
+#endif
 static long opcache_min_runs = OPCACHE_MIN_RUNS;
 static long jit_min_runs = JIT_MIN_RUNS;
 
@@ -1419,6 +1488,9 @@ _PyEval_EvalFrame_AOT_JIT(PyFrameObject *f, PyThreadState * const tstate, PyObje
 __attribute__((noinline)) static PyObject* _Py_HOT_FUNCTION
 _PyEval_EvalFrame_AOT_Interpreter(PyFrameObject *f, int throwflag, PyThreadState * const tstate, PyObject** stack_pointer, int can_use_jit, int jit_first_trace_for_line);
 
+#ifdef PYSTON_LITE
+static
+#endif
 PyObject* _Py_HOT_FUNCTION
 _PyEval_EvalFrame_AOT_Interpreter(PyFrameObject *f, int throwflag, PyThreadState * const tstate, PyObject** stack_pointer, int can_use_jit, int jit_first_trace_for_line)
 {
@@ -1513,8 +1585,10 @@ _PyEval_EvalFrame_AOT_Interpreter(PyFrameObject *f, int throwflag, PyThreadState
 /* Import the static jump table */
 #ifdef PYSTON_LITE
 #include "../../Python/opcode_targets.h"
+#define INIT_OPCACHE _PyCode_InitOpcache_Pyston
 #else
 #include "opcode_targets.h"
+#define INIT_OPCACHE _PyCode_InitOpcache
 #endif
 
 #define TARGET(op) \
@@ -1779,7 +1853,7 @@ _PyEval_EvalFrame_AOT_Interpreter(PyFrameObject *f, int throwflag, PyThreadState
     do { \
         if (co->co_opcache_map == NULL && \
             co->co_opcache_flag >= opcache_min_runs && co->co_opcache_flag <= opcache_min_runs+OPCACHE_INC_FUNC_ENTRY) { \
-            if (_PyCode_InitOpcache(co) < 0) { \
+            if (INIT_OPCACHE(co) < 0) { \
                 return NULL; \
             } \
             opcache_code_objects_extra_mem += \
@@ -1799,7 +1873,7 @@ _PyEval_EvalFrame_AOT_Interpreter(PyFrameObject *f, int throwflag, PyThreadState
     do { \
         if (co->co_opcache_map == NULL && \
             co->co_opcache_flag >= opcache_min_runs && co->co_opcache_flag <= opcache_min_runs+OPCACHE_INC_FUNC_ENTRY) { \
-            if (_PyCode_InitOpcache(co) < 0) { \
+            if (INIT_OPCACHE(co) < 0) { \
                 return NULL; \
             } \
         } \
@@ -1808,6 +1882,35 @@ _PyEval_EvalFrame_AOT_Interpreter(PyFrameObject *f, int throwflag, PyThreadState
 #endif
 
 // increments the number of times this loop got ececuted and if the threshold is hit JIT func and do OSR.
+#ifdef PYSTON_LITE
+#define HANDLE_JUMP_BACKWARD_OSR() \
+    do {  \
+        ++co->co_opcache_flag;  \
+        OPCACHE_INIT_IF_HIT_THRESHOLD();  \
+        /* check if we should switch over to the JIT (OSR) */  \
+        if (co->co_opcache_flag > jit_min_runs && can_use_jit \
+            && !_Py_TracingPossible(ceval)) { /* don't OSR if tracing is enabled because we seem to skip a line */ \
+            void* code = JIT_FUNC_FAILED; \
+            _PyCode_GetExtra((PyObject*)co, code_jitfunc_index, &code); \
+            if (code == NULL) { \
+                code = jit_func_lite(co, tstate);  \
+                if (code) {  \
+                    _PyCode_SetExtra((PyObject*)co, code_jitfunc_index, code); \
+                    /* JUMPTO() did not update f->f_lasti  \
+                    (it still points to the JUMP_ABSOLUTE - not the destination of the jump)  \
+                     update f->f_lasti manually like DISPATCH() would do because  \
+                     we can only enter the machine code at jump targets. */ \
+                    f->f_lasti = INSTR_OFFSET() - 2; /* -2 because our JIT entry is always adding two */ \
+                    return _PyEval_EvalFrame_AOT_JIT(f, tstate, stack_pointer, (JitFunc)code); \
+                } else { \
+                    /* never try again to JIT compile this python function */ \
+                    _PyCode_SetExtra((PyObject*)co, code_jitfunc_index, JIT_FUNC_FAILED); \
+                    can_use_jit = 0; \
+                } \
+            } \
+        } \
+    } while (0)
+#else
 #define HANDLE_JUMP_BACKWARD_OSR() \
     do {  \
         ++co->co_opcache_flag;  \
@@ -1830,6 +1933,8 @@ _PyEval_EvalFrame_AOT_Interpreter(PyFrameObject *f, int throwflag, PyThreadState
             } \
         } \
     } while (0)
+#endif
+
 
 /* Start of code */
 #if PROFILE_OPCODES
@@ -1838,30 +1943,52 @@ _PyEval_EvalFrame_AOT_Interpreter(PyFrameObject *f, int throwflag, PyThreadState
 
     co = f->f_code;
 
-    if (can_use_jit && co->co_jit_code == 0 && co->co_opcache_flag >= jit_min_runs /* jit after that many calls or gen yields */) {
-        // JIT assumes opcache is always on
-        if (co->co_opcache_map == NULL) {
-            _PyCode_InitOpcache(co);
-        }
-#if 0
-        struct timespec start, end;
-        clock_gettime(CLOCK_REALTIME, &start);
-        co->co_jit_code = jit_func(co, tstate);
-        clock_gettime(CLOCK_REALTIME, &end);
-        long time = 1000*1000 * (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1000;
-        static long totaltime = 0;
-        totaltime += time;
-        printf("Took %ldus to jit %s (totaltime: %ld us)\n",
-                time, PyUnicode_AsUTF8(co->co_name), totaltime);
+    if (can_use_jit && co->co_opcache_flag >= jit_min_runs /* jit after that many calls or gen yields */) {
+#ifdef PYSTON_LITE
+        void* code = JIT_FUNC_FAILED;
+        _PyCode_GetExtra((PyObject*)co, code_jitfunc_index, &code);
 #else
-        co->co_jit_code = jit_func(co, tstate);
+        void* code = co->co_jit_code;
 #endif
-        if (co->co_jit_code) {
-            return _PyEval_EvalFrame_AOT_JIT(f, tstate, stack_pointer, (JitFunc)co->co_jit_code);
-        } else {
-            // never try again to JIT compile this python function
-            co->co_jit_code = JIT_FUNC_FAILED;
-            can_use_jit = 0;
+
+        if (code == NULL) {
+            // JIT assumes opcache is always on
+            if (co->co_opcache_map == NULL) {
+                INIT_OPCACHE(co);
+            }
+#if 0
+            struct timespec start, end;
+            clock_gettime(CLOCK_REALTIME, &start);
+            co->co_jit_code = jit_func_lite(co, tstate);
+            clock_gettime(CLOCK_REALTIME, &end);
+            long time = 1000*1000 * (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1000;
+            static long totaltime = 0;
+            totaltime += time;
+            printf("Took %ldus to jit %s (totaltime: %ld us)\n",
+                    time, PyUnicode_AsUTF8(co->co_name), totaltime);
+#else
+#ifdef PYSTON_LITE
+            code = jit_func_lite(co, tstate);
+#else
+            code = jit_func(co, tstate);
+#endif
+#endif
+            if (code) {
+#ifdef PYSTON_LITE
+                _PyCode_SetExtra((PyObject*)co, code_jitfunc_index, code);
+#else
+                co->co_jit_code = code;
+#endif
+                return _PyEval_EvalFrame_AOT_JIT(f, tstate, stack_pointer, (JitFunc)code);
+            } else {
+                // never try again to JIT compile this python function
+#ifdef PYSTON_LITE
+                _PyCode_SetExtra((PyObject*)co, code_jitfunc_index, JIT_FUNC_FAILED);
+#else
+                co->co_jit_code = JIT_FUNC_FAILED;
+#endif
+                can_use_jit = 0;
+            }
         }
     }
 
@@ -4327,7 +4454,7 @@ lm_before_dispatch:
                    `callable` will be POPed by call_function.
                    NULL will will be POPed manually later.
                 */
-                res = call_function_ceval(tstate, &sp, oparg, NULL);
+                res = CALL_FUNCTION_CEVAL(tstate, &sp, oparg, NULL);
                 stack_pointer = sp;
                 (void)POP(); /* POP the NULL. */
             }
@@ -4344,7 +4471,7 @@ lm_before_dispatch:
                   We'll be passing `oparg + 1` to call_function, to
                   make it accept the `self` as a first argument.
                 */
-                res = call_function_ceval(tstate, &sp, oparg + 1, NULL);
+                res = CALL_FUNCTION_CEVAL(tstate, &sp, oparg + 1, NULL);
                 stack_pointer = sp;
             }
 
@@ -4358,7 +4485,7 @@ lm_before_dispatch:
             PREDICTED(CALL_FUNCTION);
             PyObject **sp, *res;
             sp = stack_pointer;
-            res = call_function_ceval(tstate, &sp, oparg, NULL);
+            res = CALL_FUNCTION_CEVAL(tstate, &sp, oparg, NULL);
             stack_pointer = sp;
             PUSH(res);
             if (res == NULL) {
@@ -4373,7 +4500,7 @@ lm_before_dispatch:
             names = POP();
             assert(PyTuple_CheckExact(names) && PyTuple_GET_SIZE(names) <= oparg);
             sp = stack_pointer;
-            res = call_function_ceval(tstate, &sp, oparg, names);
+            res = CALL_FUNCTION_CEVAL(tstate, &sp, oparg, names);
             stack_pointer = sp;
             PUSH(res);
             Py_DECREF(names);
@@ -4817,8 +4944,14 @@ exit_yielding:
 
 // Entry point when executing a python function.
 // We check if we can use a JIT compiled version or have to use the Interpreter
+#ifdef PYSTON_LITE
+static PyObject* _Py_HOT_FUNCTION
+_PyEval_EvalFrame_AOT
+#else
 PyObject* _Py_HOT_FUNCTION
-_PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
+_PyEval_EvalFrameDefault
+#endif
+(PyFrameObject *f, int throwflag)
 {
     PyObject* retval = NULL;
     _PyRuntimeState * const runtime = &_PyRuntime;
@@ -4872,7 +5005,12 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
     f->f_stacktop = NULL;       /* remains NULL unless yield suspends frame */
     f->f_executing = 1;
 
+#ifdef PYSTON_LITE
+    JitFunc jit_code = JIT_FUNC_FAILED;
+    _PyCode_GetExtra((PyObject*)f->f_code, code_jitfunc_index, &jit_code);
+#else
     JitFunc jit_code = f->f_code->co_jit_code;
+#endif
 
     // The jit assumes that globals and builtins are dicts so that it doesn't have to check them.
     // It looks like they are not changeable for a given frame, so we only have to check once
@@ -5997,7 +6135,10 @@ if (tstate->use_tracing && tstate->c_profilefunc) { \
     x = call; \
     }
 
-static PyObject *
+#ifndef PYSTON_LITE
+static
+#endif
+PyObject *
 trace_call_function(PyThreadState *tstate,
                     PyObject *func,
                     PyObject **args, Py_ssize_t nargs,
@@ -6725,11 +6866,17 @@ static void showStats(const char* name, long hits, long misses, long uncached, l
            100.0 * hits / total, 100.0 * misses / total,
            100.0 * uncached / total, 100.0 * warmup / total);
 }
+
 void aot_exit()
 {
 #if OPCACHE_STATS
     char* env = getenv("SHOW_OPCACHE_STATS");
     if (env && atoi(env)) {
+#ifdef PYSTON_LITE
+        printf("Initialized %ld opcaches (pyston lite)\n", opcache_code_objects);
+#else
+        printf("Initialized %ld opcaches (pyston full)\n", opcache_code_objects);
+#endif
         showStats("LOAD_ATTR", loadattr_hits, loadattr_misses, loadattr_uncached, loadattr_noopcache);
         showStats("STORE_ATTR", storeattr_hits, storeattr_misses, storeattr_uncached, storeattr_noopcache);
         showStats("LOAD_METHOD", loadmethod_hits, loadmethod_misses, loadmethod_uncached, loadmethod_noopcache);
@@ -6772,9 +6919,118 @@ void aot_exit()
     }
 #endif
 
+#ifdef PYSTON_LITE
+    jit_finish_lite();
+#else
     jit_finish();
+#endif
 }
 void aot_ceval_opcode_profile(){}
+
+#ifdef PYSTON_LITE
+int
+_PyCode_InitOpcache_Pyston(PyCodeObject *co)
+{
+    Py_ssize_t co_size = PyBytes_Size(co->co_code) / sizeof(_Py_CODEUNIT);
+    co->co_opcache_map = (unsigned char *)PyMem_Calloc(co_size, 1);
+    if (co->co_opcache_map == NULL) {
+        return -1;
+    }
+
+    _Py_CODEUNIT *opcodes = (_Py_CODEUNIT*)PyBytes_AS_STRING(co->co_code);
+    Py_ssize_t opts = 0;
+
+    for (Py_ssize_t i = 0; i < co_size;) {
+        unsigned char opcode = _Py_OPCODE(opcodes[i]);
+        i++;  // 'i' is now aligned to (next_instr - first_instr)
+
+        if (opcode == LOAD_GLOBAL || opcode == LOAD_METHOD || opcode == LOAD_ATTR /*|| opcode == STORE_ATTR*/) {
+            opts++;
+            co->co_opcache_map[i] = (unsigned char)opts;
+            if (opts > 254) {
+                break;
+            }
+        }
+    }
+
+    if (opts) {
+        co->co_opcache = (_PyOpcache *)PyMem_Calloc(opts, sizeof(_PyOpcache));
+        if (co->co_opcache == NULL) {
+            PyMem_FREE(co->co_opcache_map);
+            return -1;
+        }
+    }
+    else {
+        PyMem_FREE(co->co_opcache_map);
+        co->co_opcache_map = NULL;
+        co->co_opcache = NULL;
+    }
+
+    co->co_opcache_size = (unsigned char)opts;
+    return 0;
+}
+
+PyObject* enable_pyston_lite(PyObject* _m) {
+    static int initialized = 0;
+    if (initialized)
+        Py_RETURN_NONE;
+    initialized = 1;
+
+    fprintf(stderr, "jit initialized\n");
+    Py_AtExit(aot_exit);
+
+    Py_True->ob_refcnt += (1LL<<48);
+    Py_False->ob_refcnt += (1LL<<48);
+
+    jit_start_lite();
+
+    // TODO: add free func
+    code_jitfunc_index = _PyEval_RequestCodeExtraIndex(NULL);
+
+    PyThreadState_Get()->interp->eval_frame = _PyEval_EvalFrame_AOT;
+
+#if PROFILE_OPCODES
+    opcode_profile_enabled = getenv("PRINT_OP_PROF") != NULL;
+#endif
+    char* val = getenv("JIT_MIN_RUNS");
+    if (val) {
+        jit_min_runs = atoll(val);
+        // adjust opcache thresholds too because the JIT can only emit efficient
+        // code for the caches if the opcache got used a few times.
+        if (jit_min_runs / 2 < opcache_min_runs)
+            opcache_min_runs = jit_min_runs / 2;
+    }
+    val = getenv("OPCACHE_MIN_RUNS");
+    if (val) {
+        opcache_min_runs = atoll(val);
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef PystonLiteMethods[] = {
+    {"enable",  enable_pyston_lite, METH_NOARGS,
+     "Enable all the Pyston optimizations."},
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+static struct PyModuleDef pystonlitemodule = {
+    PyModuleDef_HEAD_INIT,
+    "pyston_lite",
+    NULL,
+    -1,
+    &PystonLiteMethods
+};
+
+PyMODINIT_FUNC PyInit_pyston_lite(void) {
+    PyObject* m = PyModule_Create(&pystonlitemodule);
+    if (!m) return NULL;
+
+    module_getattro_value = m->ob_type->tp_getattro;
+
+    return m;
+}
+#else
 
 static PyMethodDef aot_cevalMethods[] = {
     {"test",  aot_ceval_test, METH_VARARGS, "Run test"},
@@ -6820,4 +7076,4 @@ PyInit_aot_ceval(void)
 
     return m;
 }
-
+#endif

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -11,17 +11,26 @@
 
 #include "Python.h"
 #include "pycore_ceval.h"
+#ifdef PYSTON_LITE
+// make sure this points to the Pyston version of this file:
+#include "../../Include/internal/pycore_code.h"
+#else
 #include "pycore_code.h"
+#endif
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pylifecycle.h"
 #include "pycore_pystate.h"
 #include "pycore_tupleobject.h"
 
+
 #include "code.h"
 #include "dictobject.h"
 #include "frameobject.h"
 #include "opcode.h"
+#ifdef PYSTON_LITE
+#undef WITH_DTRACE
+#endif
 #include "pydtrace.h"
 #include "setobject.h"
 #include "structmember.h"
@@ -212,7 +221,11 @@ static long loadglobal_hits = 0, loadglobal_misses = 0, loadglobal_uncached = 0,
 #include <errno.h>
 #endif
 #include "pythread.h"
+#ifdef PYSTON_LITE
+#include "../../Python/ceval_gil.h"
+#else
 #include "ceval_gil.h"
+#endif
 
 #if 0
 int
@@ -1498,7 +1511,11 @@ _PyEval_EvalFrame_AOT_Interpreter(PyFrameObject *f, int throwflag, PyThreadState
 
 #if USE_COMPUTED_GOTOS
 /* Import the static jump table */
+#ifdef PYSTON_LITE
+#include "../../Python/opcode_targets.h"
+#else
 #include "opcode_targets.h"
+#endif
 
 #define TARGET(op) \
     op: \

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -6976,7 +6976,12 @@ PyObject* enable_pyston_lite(PyObject* _m) {
         Py_RETURN_NONE;
     initialized = 1;
 
-    fprintf(stderr, "jit initialized\n");
+    if (PySys_GetObject("pyston_version_info")) {
+        //fprintf(stderr, "refusing to load pyston_lite into pyston since that doesn't work\n");
+        Py_RETURN_NONE;
+    }
+
+    //fprintf(stderr, "jit initialized\n");
     Py_AtExit(aot_exit);
 
     Py_True->ob_refcnt += (1LL<<48);

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -148,10 +148,10 @@ static size_t opcache_global_opts = 0;
 static size_t opcache_global_hits = 0;
 static size_t opcache_global_misses = 0;
 
-static long loadattr_hits = 0, loadattr_misses = 0, loadattr_uncached = 0, loadattr_noopcache = 0;
-static long storeattr_hits = 0, storeattr_misses = 0, storeattr_uncached = 0, storeattr_noopcache = 0;
-static long loadmethod_hits = 0, loadmethod_misses = 0, loadmethod_uncached = 0, loadmethod_noopcache = 0;
-static long loadglobal_hits = 0, loadglobal_misses = 0, loadglobal_uncached = 0, loadglobal_noopcache = 0;
+long loadattr_hits = 0, loadattr_misses = 0, loadattr_uncached = 0, loadattr_noopcache = 0;
+long storeattr_hits = 0, storeattr_misses = 0, storeattr_uncached = 0, storeattr_noopcache = 0;
+long loadmethod_hits = 0, loadmethod_misses = 0, loadmethod_uncached = 0, loadmethod_noopcache = 0;
+long loadglobal_hits = 0, loadglobal_misses = 0, loadglobal_uncached = 0, loadglobal_noopcache = 0;
 #endif
 
 #define GIL_REQUEST _Py_atomic_load_relaxed(&ceval->gil_drop_request)

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -914,11 +914,11 @@ static void switch_section(Jit* Dst, Section new_section) {
 // compares r_type_idx->tp_version_tag with type_ver
 // branches to false_branch on inequality else continues
 |.macro type_version_check, r_type_idx, type_ver, false_branch
-#ifdef PYSTON_LITE
+||#ifdef PYSTON_LITE
 || emit_cmp32_mem_imm(Dst, r_type_idx, offsetof(PyTypeObject, tp_version_tag), (unsigned int)type_ver);
-#else
+||#else
 || emit_cmp64_mem_imm(Dst, r_type_idx, offsetof(PyTypeObject, tp_version_tag), (unsigned int)type_ver);
-#endif
+||#endif
 |  branch_ne false_branch
 |.endmacro
 

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -59,7 +59,12 @@
 
 #include "Python.h"
 #include "pycore_ceval.h"
+#ifdef PYSTON_LITE
+// make sure this points to the Pyston version of this file:
+#include "../../Include/internal/pycore_code.h"
+#else
 #include "pycore_code.h"
+#endif
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pylifecycle.h"
@@ -71,6 +76,9 @@
 #include "dictobject.h"
 #include "frameobject.h"
 #include "opcode.h"
+#ifdef PYSTON_LITE
+#undef WITH_DTRACE
+#endif
 #include "pydtrace.h"
 #include "setobject.h"
 #include "structmember.h"
@@ -216,7 +224,9 @@ typedef struct Jit {
 #include <sys/mman.h>
 #include <ctype.h>
 
+#ifndef PYSTON_LITE
 #include "aot.h"
+#endif
 #include "aot_ceval_jit_helper.h"
 
 // used if JIT_PERF_MAP is enabled

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -72,7 +72,12 @@
 #include "pycore_tupleobject.h"
 
 #include "code.h"
+#ifdef PYSTON_LITE
+// Use the cpython version of this file:
+#include "dict-common.h"
+#else
 #include "../Objects/dict-common.h"
+#endif
 #include "dictobject.h"
 #include "frameobject.h"
 #include "opcode.h"

--- a/Python/aot_ceval_jit_helper.c
+++ b/Python/aot_ceval_jit_helper.c
@@ -17,7 +17,12 @@
 
 #include "Python.h"
 #include "pycore_ceval.h"
+#ifdef PYSTON_LITE
+// make sure this points to the Pyston version of this file:
+#include "../../Include/internal/pycore_code.h"
+#else
 #include "pycore_code.h"
+#endif
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pylifecycle.h"
@@ -28,6 +33,9 @@
 #include "dictobject.h"
 #include "frameobject.h"
 #include "opcode.h"
+#ifdef PYSTON_LITE
+#undef WITH_DTRACE
+#endif
 #include "pydtrace.h"
 #include "setobject.h"
 #include "structmember.h"

--- a/Python/aot_ceval_jit_helper.c
+++ b/Python/aot_ceval_jit_helper.c
@@ -42,7 +42,13 @@
 
 #include <ctype.h>
 
+#ifdef PYSTON_LITE
+#define SET_JIT_AOT_FUNC(JIT_HELPER_STORE_ATTR) (0)
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#else
 #include "aot.h"
+#endif
 
 #include "aot_ceval_jit_helper.h"
 

--- a/Python/aot_ceval_jit_helper.c
+++ b/Python/aot_ceval_jit_helper.c
@@ -46,6 +46,15 @@
 
 #include "aot_ceval_jit_helper.h"
 
+#define OPCACHE_STATS 0
+
+#if OPCACHE_STATS
+extern long loadattr_hits, loadattr_misses, loadattr_uncached, loadattr_noopcache;
+extern long storeattr_hits, storeattr_misses, storeattr_uncached, storeattr_noopcache;
+extern long loadmethod_hits, loadmethod_misses, loadmethod_uncached, loadmethod_noopcache;
+extern long loadglobal_hits, loadglobal_misses, loadglobal_uncached, loadglobal_noopcache;
+#endif
+
 extern int _PyObject_GetMethod(PyObject *, PyObject *, PyObject **);
 PyObject * call_function_ceval(
     PyThreadState *tstate, PyObject ***pp_stack,

--- a/pyston/pyston_lite/.gitignore
+++ b/pyston/pyston_lite/.gitignore
@@ -1,0 +1,3 @@
+aot_ceval_jit.prep.c
+aot_ceval_jit.gen.c
+env

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -1,0 +1,95 @@
+.DEFAULT_GOAL := pyston_lite.so
+
+# Change these to target a different Python:
+PYTHON:=python3.8
+DIR:=python3.8
+PYTHON_INCL:=/usr/include/$(DIR)/
+
+
+aot_ceval_jit.prep.c: aot_ceval_jit.c
+	../../pyston/tools/dynasm_preprocess.py $< $@
+
+aot_ceval_jit.gen.c: aot_ceval_jit.prep.c
+	luajit ../../pyston/LuaJIT/dynasm/dynasm.lua  -o aot_ceval_jit.gen.c $<
+
+CC:=gcc
+CFLAGS:=$(CFLAGS) $(PY_CORE_CFLAGS) -I../../pyston/LuaJIT/ -Wno-address -Wpointer-to-int-cast -I$(PYTHON_INCL) -I$(PYTHON_INCL)/internal -DPYSTON_SPEEDUPS -DPy_BUILD_CORE -fPIC -Werror=implicit-function-declaration -g
+CFLAGS:=$(CFLAGS) -pthread -c -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -Wall -DENABLE_AOT   -fstack-protector -specs=../tools/no-pie-compile.specs -D_FORTIFY_SOURCE=2 -fno-reorder-blocks-and-partition -std=c99 -Wextra -Wno-unused-result -Wno-unused-parameter -Wno-missing-field-initializers -Werror=implicit-function-declaration  -I../../Include/internal -IObjects -IInclude -IPython -I. -I../../Include   -I../aot  -DPy_BUILD_CORE -Wno-unused-label
+CFLAGS:=$(CFLAGS) -std=gnu99 -fcf-protection=none
+CFLAGS:=$(CFLAGS) -O3
+CFLAGS:=$(CFLAGS) -DPYSTON_LITE
+
+pyston_lite.so: aot_ceval_jit.gen.o aot_ceval_jit_helper.o lib.o aot_ceval.o
+	$(CC) -shared $^ -o $@
+
+%.o: %.c $(wildcard *.h)
+
+.PHONY: clean
+clean:
+	rm -rf *.o *.so env
+
+
+
+
+######
+# The rest of this file is for testing things:
+
+env:
+	$(PYTHON) -m venv env
+
+env/update.stamp: env pyston_lite.so
+	./env/bin/pip install -r ../pgo_requirements.txt
+	cp pyston_lite.so pyston_lite_autoload.pth env/lib/$(DIR)/site-packages/
+	touch $@
+
+
+ENV:=PYSTON=1 SHOW_JIT_STATS=1 SHOW_OPCACHE_STATS=1 JIT_PERF_MAP=1
+BENCH:=../macrobenchmarks/benchmarks/bm_flaskblogging/run_benchmark.py --legacy
+
+
+bench: env/update.stamp
+	$(ENV) ./env/bin/python $(BENCH)
+
+bench_baseline: env/update.stamp
+	$(patsubst PYSTON=1,,$(ENV)) ./env/bin/python $(BENCH)
+
+perf_bench: env/update.stamp
+	DISABLE_PYSTONFULL=1 $(ENV) perf record -o perf_lite.data ./env/bin/python $(BENCH)
+	$(MAKE) perf_report
+perf_report:
+	perf report -i perf_lite.data -n
+
+perf_bench_baseline: env/update.stamp
+	DISABLE_PYSTONFULL=1 $(patsubst PYSTON=1,,$(ENV)) perf record -o perf_baseline.data ./env/bin/python $(BENCH)
+	$(MAKE) perf_report_baseline
+perf_report_baseline:
+	perf report -i perf_baseline.data -n
+
+dbg_bench: env/update.stamp
+	DISABLE_PYSTONFULL=1 $(ENV) gdb --args ./env/bin/python $(BENCH) 1000000
+
+
+bench_full:
+	$(MAKE) -C ../.. build/unoptshared_env/update.stamp
+	$(ENV) LD_LIBRARY_PATH=../../build/unoptshared_install/usr/lib:$$LD_LIBRARY_PATH ../../build/unoptshared_env/bin/python $(BENCH)
+
+perf_bench_full:
+	$(MAKE) -C ../.. build/unoptshared_env/update.stamp
+	$(ENV) LD_LIBRARY_PATH=../../build/unoptshared_install/usr/lib:$$LD_LIBRARY_PATH perf record -o perf_full.data ../../build/unoptshared_env/bin/python $(BENCH)
+	$(MAKE) perf_report_full
+perf_report_full:
+	perf report -i perf_full.data -n
+
+dbg_bench_full:
+	$(MAKE) -C ../.. build/unoptshared_env/update.stamp
+	$(ENV) LD_LIBRARY_PATH=../../build/unoptshared_install/usr/lib:$$LD_LIBRARY_PATH gdb --args ../../build/unoptshared_env/bin/python $(BENCH) 1000000
+
+
+bench_fullopt:
+	$(MAKE) -C ../.. build/optshared_env/update.stamp
+	$(ENV) LD_LIBRARY_PATH=../../build/optshared_install/usr/lib:$$LD_LIBRARY_PATH ../../build/optshared_env/bin/python $(BENCH)
+
+perf_bench_fullopt:
+	$(MAKE) -C ../.. build/optshared_env/update.stamp
+	$(ENV) LD_LIBRARY_PATH=../../build/optshared_install/usr/lib:$$LD_LIBRARY_PATH perf record ../../build/optshared_env/bin/python $(BENCH)
+	perf report -n

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -64,13 +64,13 @@ perf_bench: env/update.stamp
 	DISABLE_PYSTONFULL=1 $(ENV) perf record -o perf_lite.data ./env/bin/python $(BENCH)
 	$(MAKE) perf_report
 perf_report:
-	perf report -i perf_lite.data -n
+	perf report -i perf_lite.data -n --objdump=../../pyston/tools/perf_jit.py
 
 perf_bench_baseline: env/update.stamp
 	DISABLE_PYSTONFULL=1 $(patsubst PYSTON=1,,$(ENV)) perf record -o perf_baseline.data ./env/bin/python $(BENCH)
 	$(MAKE) perf_report_baseline
 perf_report_baseline:
-	perf report -i perf_baseline.data -n
+	perf report -i perf_baseline.data -n --objdump=../../pyston/tools/perf_jit.py
 
 dbg_bench: env/update.stamp
 	DISABLE_PYSTONFULL=1 $(ENV) gdb --args ./env/bin/python $(BENCH) 1000000
@@ -85,7 +85,7 @@ perf_bench_full:
 	$(ENV) LD_LIBRARY_PATH=../../build/unoptshared_install/usr/lib:$$LD_LIBRARY_PATH perf record -o perf_full.data ../../build/unoptshared_env/bin/python $(BENCH)
 	$(MAKE) perf_report_full
 perf_report_full:
-	perf report -i perf_full.data -n
+	perf report -i perf_full.data -n --objdump=../../pyston/tools/perf_jit.py
 
 dbg_bench_full:
 	$(MAKE) -C ../.. build/unoptshared_env/update.stamp

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -51,6 +51,7 @@ BENCH:=../macrobenchmarks/benchmarks/bm_flaskblogging/run_benchmark.py --legacy
 # note: the testsuite doesn't pass for my Ubuntu system cpython, but it does pass
 # if I reconfigure this makefile to use a manually-built cpython
 testsuite: env
+	PYSTON=1 ./env/bin/python -c 'import test.support; test.support.check_impl_detail = lambda **kw: False; import test.test_code; test.test_code.test_main()'
 	PYSTON=1 ./env/bin/python -m test -j0 -x test_code
 
 bench: env/update.stamp

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -34,18 +34,24 @@ clean:
 ######
 # The rest of this file is for testing things:
 
-env:
+env: pyston_lite.so
 	$(PYTHON) -m venv env
-
-env/update.stamp: env pyston_lite.so
-	./env/bin/pip install -r ../pgo_requirements.txt
 	cp pyston_lite.so pyston_lite_autoload.pth env/lib/$(DIR)/site-packages/
+
+env/update.stamp: env
+	./env/bin/pip install -r ../pgo_requirements.txt
 	touch $@
 
 
 ENV:=PYSTON=1 SHOW_OPCACHE_STATS=1 JIT_PERF_MAP=1
 BENCH:=../macrobenchmarks/benchmarks/bm_flaskblogging/run_benchmark.py --legacy
 
+
+# test_code has a bug when run with another client that calls RequestCodeExtraIndex
+# note: the testsuite doesn't pass for my Ubuntu system cpython, but it does pass
+# if I reconfigure this makefile to use a manually-built cpython
+testsuite: env
+	PYSTON=1 ./env/bin/python -m test -j0 -x test_code
 
 bench: env/update.stamp
 	$(ENV) ./env/bin/python $(BENCH)

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -43,7 +43,7 @@ env/update.stamp: env pyston_lite.so
 	touch $@
 
 
-ENV:=PYSTON=1 SHOW_JIT_STATS=1 SHOW_OPCACHE_STATS=1 JIT_PERF_MAP=1
+ENV:=PYSTON=1 SHOW_OPCACHE_STATS=1 JIT_PERF_MAP=1
 BENCH:=../macrobenchmarks/benchmarks/bm_flaskblogging/run_benchmark.py --legacy
 
 

--- a/pyston/pyston_lite/aot_ceval.c
+++ b/pyston/pyston_lite/aot_ceval.c
@@ -1,0 +1,1 @@
+../../Python/aot_ceval.c

--- a/pyston/pyston_lite/aot_ceval_jit.c
+++ b/pyston/pyston_lite/aot_ceval_jit.c
@@ -1,0 +1,1 @@
+../../Python/aot_ceval_jit.c

--- a/pyston/pyston_lite/aot_ceval_jit_helper.c
+++ b/pyston/pyston_lite/aot_ceval_jit_helper.c
@@ -1,0 +1,1 @@
+../../Python/aot_ceval_jit_helper.c

--- a/pyston/pyston_lite/aot_ceval_jit_helper.h
+++ b/pyston/pyston_lite/aot_ceval_jit_helper.h
@@ -1,0 +1,1 @@
+../../Python/aot_ceval_jit_helper.h

--- a/pyston/pyston_lite/aot_ceval_jit_helper.h
+++ b/pyston/pyston_lite/aot_ceval_jit_helper.h
@@ -1,1 +1,1 @@
-../../Python/aot_ceval_jit_helper.h
+../../Include/internal/aot_ceval_jit_helper.h

--- a/pyston/pyston_lite/dict-common.h
+++ b/pyston/pyston_lite/dict-common.h
@@ -1,0 +1,68 @@
+#ifndef Py_DICT_COMMON_H
+#define Py_DICT_COMMON_H
+
+typedef struct {
+    /* Cached hash code of me_key. */
+    Py_hash_t me_hash;
+    PyObject *me_key;
+    PyObject *me_value; /* This field is only meaningful for combined tables */
+} PyDictKeyEntry;
+
+/* dict_lookup_func() returns index of entry which can be used like DK_ENTRIES(dk)[index].
+ * -1 when no entry found, -3 when compare raises error.
+ */
+typedef Py_ssize_t (*dict_lookup_func)
+    (PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
+
+#define DKIX_EMPTY (-1)
+#define DKIX_DUMMY (-2)  /* Used internally */
+#define DKIX_ERROR (-3)
+
+/* See dictobject.c for actual layout of DictKeysObject */
+struct _dictkeysobject {
+    Py_ssize_t dk_refcnt;
+
+    /* Size of the hash table (dk_indices). It must be a power of 2. */
+    Py_ssize_t dk_size;
+
+    /* Function to lookup in the hash table (dk_indices):
+
+       - lookdict(): general-purpose, and may return DKIX_ERROR if (and
+         only if) a comparison raises an exception.
+
+       - lookdict_unicode(): specialized to Unicode string keys, comparison of
+         which can never raise an exception; that function can never return
+         DKIX_ERROR.
+
+       - lookdict_unicode_nodummy(): similar to lookdict_unicode() but further
+         specialized for Unicode string keys that cannot be the <dummy> value.
+
+       - lookdict_split(): Version of lookdict() for split tables. */
+    dict_lookup_func dk_lookup;
+
+    /* Number of usable entries in dk_entries. */
+    Py_ssize_t dk_usable;
+
+    /* Number of used entries in dk_entries. */
+    Py_ssize_t dk_nentries;
+
+    /* Actual hash table of dk_size entries. It holds indices in dk_entries,
+       or DKIX_EMPTY(-1) or DKIX_DUMMY(-2).
+
+       Indices must be: 0 <= indice < USABLE_FRACTION(dk_size).
+
+       The size in bytes of an indice depends on dk_size:
+
+       - 1 byte if dk_size <= 0xff (char*)
+       - 2 bytes if dk_size <= 0xffff (int16_t*)
+       - 4 bytes if dk_size <= 0xffffffff (int32_t*)
+       - 8 bytes otherwise (int64_t*)
+
+       Dynamically sized, SIZEOF_VOID_P is minimum. */
+    char dk_indices[];  /* char is required to avoid strict aliasing. */
+
+    /* "PyDictKeyEntry dk_entries[dk_usable];" array follows:
+       see the DK_ENTRIES() macro */
+};
+
+#endif

--- a/pyston/pyston_lite/lib.c
+++ b/pyston/pyston_lite/lib.c
@@ -1,0 +1,393 @@
+#include "Python.h"
+
+#include "pycore_object.h"
+#include "pycore_pyerrors.h"
+#include "pycore_pystate.h"
+
+#include "../../Objects/dict-common.h"
+#include "frameobject.h"
+#include "moduleobject.h"
+#include "opcode.h"
+
+__attribute__((visibility("hidden"))) inline PyObject * call_function_ceval_fast(
+    PyThreadState *tstate, PyObject ***pp_stack,
+    Py_ssize_t oparg, PyObject *kwnames);
+PyObject * _Py_HOT_FUNCTION
+call_function_ceval_no_kw(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg) {
+    return call_function_ceval_fast(tstate, &stack, oparg, NULL /*kwnames*/);
+}
+PyObject * _Py_HOT_FUNCTION
+call_function_ceval_kw(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg, PyObject *kwnames) {
+    if (kwnames == NULL)
+        __builtin_unreachable();
+    return call_function_ceval_fast(tstate, &stack, oparg, kwnames);
+}
+PyObject* PyNumber_PowerNone(PyObject *v, PyObject *w) {
+  return PyNumber_Power(v, w, Py_None);
+}
+PyObject* PyNumber_InPlacePowerNone(PyObject *v, PyObject *w) {
+  return PyNumber_InPlacePower(v, w, Py_None);
+}
+__attribute__((visibility("hidden"))) inline PyObject* cmp_outcome(PyThreadState *tstate, int, PyObject *v, PyObject *w);
+PyObject* cmp_outcomePyCmp_LT(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_LT, v, w);
+}
+PyObject* cmp_outcomePyCmp_LE(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_LE, v, w);
+}
+PyObject* cmp_outcomePyCmp_EQ(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_EQ, v, w);
+}
+PyObject* cmp_outcomePyCmp_NE(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_NE, v, w);
+}
+PyObject* cmp_outcomePyCmp_GT(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_GT, v, w);
+}
+PyObject* cmp_outcomePyCmp_GE(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_GE, v, w);
+}
+PyObject* cmp_outcomePyCmp_IN(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_IN, v, w);
+}
+PyObject* cmp_outcomePyCmp_NOT_IN(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_NOT_IN, v, w);
+}
+
+PyObject *
+trace_call_function(PyThreadState *tstate,
+                    PyObject *func,
+                    PyObject **args, Py_ssize_t nargs,
+                    PyObject *kwnames);
+
+#define NAME_ERROR_MSG \
+    "name '%.200s' is not defined"
+#define UNBOUNDLOCAL_ERROR_MSG \
+    "local variable '%.200s' referenced before assignment"
+#define UNBOUNDFREE_ERROR_MSG \
+    "free variable '%.200s' referenced before assignment" \
+    " in enclosing scope"
+
+PyObject *
+_PyErr_Format(PyThreadState *tstate, PyObject *exception,
+              const char *format, ...);
+
+PyObject *
+_PyDict_LoadGlobalEx(PyDictObject *globals, PyDictObject *builtins, PyObject *key, int *out_wasglobal)
+{
+    Py_ssize_t ix;
+    Py_hash_t hash;
+    PyObject *value;
+
+    if (!PyUnicode_CheckExact(key) ||
+        (hash = ((PyASCIIObject *) key)->hash) == -1)
+    {
+        hash = PyObject_Hash(key);
+        if (hash == -1)
+            return NULL;
+    }
+
+    /* namespace 1: globals */
+    ix = globals->ma_keys->dk_lookup(globals, key, hash, &value);
+    if (ix == DKIX_ERROR)
+        return NULL;
+    if (ix != DKIX_EMPTY && value != NULL) {
+        *out_wasglobal = 1;
+        return value;
+    }
+
+    /* namespace 2: builtins */
+    ix = builtins->ma_keys->dk_lookup(builtins, key, hash, &value);
+    if (ix < 0)
+        return NULL;
+
+    *out_wasglobal = 0;
+
+    return value;
+}
+
+static PyObject *
+call_attribute(PyObject *self, PyObject *attr, PyObject *name)
+{
+    PyObject *res, *descr = NULL;
+    descrgetfunc f = Py_TYPE(attr)->tp_descr_get;
+
+    if (f != NULL) {
+        descr = f(attr, self, (PyObject *)(Py_TYPE(self)));
+        if (descr == NULL)
+            return NULL;
+        else
+            attr = descr;
+    }
+    res = PyObject_CallFunctionObjArgs(attr, name, NULL);
+    Py_XDECREF(descr);
+    return res;
+}
+
+PyObject *slot_tp_getattr_hook_simple_not_found(PyObject *self, PyObject *name)
+{
+    PyObject* res = NULL;
+    if ((!PyErr_Occurred() || PyErr_ExceptionMatches(PyExc_AttributeError))) {
+        PyTypeObject *tp = Py_TYPE(self);
+        _Py_IDENTIFIER(__getattr__);
+        PyErr_Clear();
+        PyObject *getattr = _PyType_LookupId(tp, &PyId___getattr__);
+        Py_INCREF(getattr);
+        res = call_attribute(self, getattr, name);
+        Py_DECREF(getattr);
+    }
+    return res;
+}
+
+PyObject *slot_tp_getattr_hook_simple(PyObject *self, PyObject *name)
+{
+    PyObject *res = _PyObject_GenericGetAttrWithDict(self, name, NULL, 1 /* suppress */);
+    if (res == NULL)
+        return slot_tp_getattr_hook_simple_not_found(self, name);
+    return res;
+}
+
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *md_dict;
+    struct PyModuleDef *md_def;
+    void *md_state;
+    PyObject *md_weaklist;
+    PyObject *md_name;  /* for logging purposes after md_dict is cleared */
+} PyModuleObject;
+
+static PyObject*
+module_getgetattr(PyModuleObject* mod) {
+    _Py_IDENTIFIER(__getattr__);
+    return _PyDict_GetItemId(mod->md_dict, &PyId___getattr__);
+}
+
+PyObject* module_getattro_not_found(PyObject *_m, PyObject *name)
+{
+    PyModuleObject *m = (PyModuleObject*)_m;
+    PyObject *mod_name, *getattr;
+    PyObject* err = PyErr_Occurred();
+    if (err) {
+        if (!PyErr_GivenExceptionMatches(err, PyExc_AttributeError))
+            return NULL;
+        PyErr_Clear();
+    }
+
+    if (m->md_dict) {
+        getattr = module_getgetattr(m);
+        if (getattr) {
+            PyObject* stack[1] = {name};
+            return _PyObject_FastCall(getattr, stack, 1);
+        }
+        _Py_IDENTIFIER(__name__);
+        mod_name = _PyDict_GetItemId(m->md_dict, &PyId___name__);
+        if (mod_name && PyUnicode_Check(mod_name)) {
+            _Py_IDENTIFIER(__spec__);
+            Py_INCREF(mod_name);
+            PyObject *spec = _PyDict_GetItemId(m->md_dict, &PyId___spec__);
+            Py_XINCREF(spec);
+            if (_PyModuleSpec_IsInitializing(spec)) {
+                PyErr_Format(PyExc_AttributeError,
+                             "partially initialized "
+                             "module '%U' has no attribute '%U' "
+                             "(most likely due to a circular import)",
+                             mod_name, name);
+            }
+            else {
+                PyErr_Format(PyExc_AttributeError,
+                             "module '%U' has no attribute '%U'",
+                             mod_name, name);
+            }
+            Py_XDECREF(spec);
+            Py_DECREF(mod_name);
+            return NULL;
+        }
+    }
+    PyErr_Format(PyExc_AttributeError,
+                "module has no attribute '%U'", name);
+    return NULL;
+}
+
+#define DK_SIZE(dk) ((dk)->dk_size)
+#if SIZEOF_VOID_P > 4
+#define DK_IXSIZE(dk)                          \
+    (DK_SIZE(dk) <= 0xff ?                     \
+        1 : DK_SIZE(dk) <= 0xffff ?            \
+            2 : DK_SIZE(dk) <= 0xffffffff ?    \
+                4 : sizeof(int64_t))
+#else
+#define DK_IXSIZE(dk)                          \
+    (DK_SIZE(dk) <= 0xff ?                     \
+        1 : DK_SIZE(dk) <= 0xffff ?            \
+            2 : sizeof(int32_t))
+#endif
+#define DK_ENTRIES(dk) \
+    ((PyDictKeyEntry*)(&((int8_t*)((dk)->dk_indices))[DK_SIZE(dk) * DK_IXSIZE(dk)]))
+
+#define DK_MASK(dk) (((dk)->dk_size)-1)
+#define IS_POWER_OF_2(x) (((x) & (x-1)) == 0)
+
+extern void* lookdict_split_value;
+PyObject* _PyDict_GetItemByOffset(PyDictObject *mp, PyObject *key, Py_ssize_t dk_size, int64_t offset) {
+    assert(PyDict_CheckExact((PyObject*)mp));
+    assert(PyUnicode_CheckExact(key));
+    assert(offset >= 0);
+
+    if (mp->ma_keys->dk_size != dk_size)
+        return NULL;
+
+    if (mp->ma_keys->dk_lookup == lookdict_split_value)
+        return NULL;
+
+    PyDictKeyEntry *ep = (PyDictKeyEntry*)(mp->ma_keys->dk_indices + offset);
+    if (ep->me_key != key)
+        return NULL;
+
+    return ep->me_value;
+}
+
+int64_t _PyDict_GetItemOffset(PyDictObject *mp, PyObject *key, Py_ssize_t *dk_size)
+{
+    Py_hash_t hash;
+
+    assert(PyDict_CheckExact((PyObject*)mp));
+    assert(PyUnicode_CheckExact(key));
+
+    if ((hash = ((PyASCIIObject *) key)->hash) == -1)
+        return -1;
+
+    if (mp->ma_keys->dk_lookup == lookdict_split_value)
+        return -1;
+
+    // don't cache if error is set because we could overwrite it
+    if (PyErr_Occurred())
+        return -1;
+
+    PyObject *value = NULL;
+    Py_ssize_t ix = (mp->ma_keys->dk_lookup)(mp, key, hash, &value);
+    if (ix < 0) {
+        PyErr_Clear();
+        return -1;
+    }
+
+    *dk_size = mp->ma_keys->dk_size;
+    return (char*)(&DK_ENTRIES(mp->ma_keys)[ix]) - (char*)mp->ma_keys->dk_indices;
+}
+
+
+PyObject * _Py_HOT_FUNCTION
+call_function_ceval_fast(PyThreadState *tstate, PyObject ***pp_stack, Py_ssize_t oparg, PyObject *kwnames)
+{
+    PyObject** stack_top = *pp_stack;
+    PyObject **pfunc = stack_top - oparg - 1;
+    PyObject *func = *pfunc;
+    PyObject *x, *w;
+    Py_ssize_t nkwargs = (kwnames == NULL) ? 0 : PyTuple_GET_SIZE(kwnames);
+    Py_ssize_t nargs = oparg - nkwargs;
+    PyObject **stack = stack_top - nargs - nkwargs;
+
+    if (__builtin_expect(tstate->use_tracing, 0)) {
+        x = trace_call_function(tstate, func, stack, nargs, kwnames);
+    }
+    else {
+        x = _PyObject_Vectorcall(func, stack, nargs | PY_VECTORCALL_ARGUMENTS_OFFSET, kwnames);
+    }
+
+    assert((x != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
+
+    /* Clear the stack of the function object. */
+#if !defined(LLTRACE_DEF)
+    for (int i = oparg; i >= 0; i--) {
+        Py_DECREF(pfunc[i]);
+    }
+    *pp_stack = pfunc;
+#else
+    while ((*pp_stack) > pfunc) {
+        w = EXT_POP(*pp_stack);
+        Py_DECREF(w);
+    }
+#endif
+
+    return x;
+}
+
+#define CANNOT_CATCH_MSG "catching classes that do not inherit from "\
+                         "BaseException is not allowed"
+/*static*/ PyObject *
+cmp_outcome(PyThreadState *tstate, int op, PyObject *v, PyObject *w)
+{
+    int res = 0;
+    switch (op) {
+    case PyCmp_IS:
+        res = (v == w);
+        break;
+    case PyCmp_IS_NOT:
+        res = (v != w);
+        break;
+    case PyCmp_IN:
+        res = PySequence_Contains(w, v);
+        if (res < 0)
+            return NULL;
+        break;
+    case PyCmp_NOT_IN:
+        res = PySequence_Contains(w, v);
+        if (res < 0)
+            return NULL;
+        res = !res;
+        break;
+    case PyCmp_EXC_MATCH:
+        if (PyTuple_Check(w)) {
+            Py_ssize_t i, length;
+            length = PyTuple_Size(w);
+            for (i = 0; i < length; i += 1) {
+                PyObject *exc = PyTuple_GET_ITEM(w, i);
+                if (!PyExceptionClass_Check(exc)) {
+                    _PyErr_SetString(tstate, PyExc_TypeError,
+                                     CANNOT_CATCH_MSG);
+                    return NULL;
+                }
+            }
+        }
+        else {
+            if (!PyExceptionClass_Check(w)) {
+                _PyErr_SetString(tstate, PyExc_TypeError,
+                                 CANNOT_CATCH_MSG);
+                return NULL;
+            }
+        }
+        res = PyErr_GivenExceptionMatches(v, w);
+        break;
+    default:
+        return PyObject_RichCompare(v, w, op);
+    }
+    v = res ? Py_True : Py_False;
+    Py_INCREF(v);
+    return v;
+}
+
+static PySliceObject *slice_cache = NULL;
+PyObject *
+PySlice_NewSteal(PyObject *start, PyObject *stop, PyObject *step) {
+    PySliceObject *obj;
+    if (slice_cache != NULL) {
+        obj = slice_cache;
+        slice_cache = NULL;
+        _Py_NewReference((PyObject *)obj);
+    } else {
+        obj = PyObject_GC_New(PySliceObject, &PySlice_Type);
+        if (obj == NULL) {
+            Py_DECREF(start);
+            Py_DECREF(stop);
+            Py_DECREF(step);
+            return NULL;
+        }
+    }
+
+    obj->step = step;
+    obj->start = start;
+    obj->stop = stop;
+
+    _PyObject_GC_TRACK(obj);
+    return (PyObject *) obj;
+}

--- a/pyston/pyston_lite/lib.c
+++ b/pyston/pyston_lite/lib.c
@@ -4,7 +4,8 @@
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"
 
-#include "../../Objects/dict-common.h"
+// Use the cpython version of this file:
+#include "dict-common.h"
 #include "frameobject.h"
 #include "moduleobject.h"
 #include "opcode.h"

--- a/pyston/pyston_lite/pyston_lite_autoload.pth
+++ b/pyston/pyston_lite/pyston_lite_autoload.pth
@@ -1,1 +1,1 @@
-import os, sys; exec("""sys.path.append("/home/kmod/pyston/pyston/pyston_lite"); ("PYSTON" in os.environ) and __import__("pyston_lite").enable()""")
+import os, sys; exec("""("PYSTON" in os.environ) and __import__("pyston_lite").enable()""")

--- a/pyston/pyston_lite/pyston_lite_autoload.pth
+++ b/pyston/pyston_lite/pyston_lite_autoload.pth
@@ -1,0 +1,1 @@
+import os, sys; exec("""sys.path.append("/home/kmod/pyston/pyston/pyston_lite"); ("PYSTON" in os.environ) and __import__("pyston_lite").enable()""")

--- a/pyston/tools/dynasm_preprocess.py
+++ b/pyston/tools/dynasm_preprocess.py
@@ -116,6 +116,8 @@ def preprocess(filename_in, filename_out):
                     raise_exc("Unknown architecture: " + line_stripped)
             else:
                 file.write("\n" if skip else line)
+                if line_stripped.startswith("|") or (line_stripped.startswith("#") and '\\' not in line_stripped):
+                    file.write('#line %d "%s"\n' % (lineno + 1, filename_in))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is only a few percent faster, but I wanted to put up an initial PR and will add some optimizations in later PRs.

I originally did the development by copying all the jit files into a separate directory, but this made for a tough merge. I think it makes sense to try to keep just a single version of our jit with appropriate ifdefs for pyston_lite, so that's how this PR does it.

This PR is just the basics to get pyston_lite working, which is mainly removing the features that we can't use, and finding replacements for the ones that we still need. From a perf standpoint the biggest hit is the removal of the split-dict caches, but I will add my new version of the cache that helps with that.

In a future PR I will also make this a bit more safe in case you run for a while before switching to pyston_lite (in particular, dealing with any opcaches that were already initialized).

I used a bare-bones Makefile for now; you can test it by going into `pyston/pyston_lite` and doing `make bench` or `make bench_baseline`. I'll migrate this to a setup.py in a later PR