### PR TITLE
better packaging for pyston_lite

### DIFF
--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -1164,7 +1164,7 @@ loadAttrCache(PyObject* owner, PyObject* name, _PyOpcache *co_opcache, PyObject*
         if (*res == NULL)
             *res = loadAttrCacheAttrNotFound(owner, name);
     } else {
-        fprintf("bad cache type %d\n", la->cache_type);
+        fprintf(stderr, "bad cache type %d\n", la->cache_type);
         abort();
     }
 

--- a/pyston/pyston_lite/.gitignore
+++ b/pyston/pyston_lite/.gitignore
@@ -2,3 +2,4 @@ aot_ceval_jit.prep.c
 aot_ceval_jit.gen.c
 env
 wheelhouse
+autoload/dist

--- a/pyston/pyston_lite/.gitignore
+++ b/pyston/pyston_lite/.gitignore
@@ -1,3 +1,4 @@
 aot_ceval_jit.prep.c
 aot_ceval_jit.gen.c
 env
+wheelhouse

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -29,9 +29,25 @@ clean:
 	rm -rf *.o *.so env
 
 
-package: aot_ceval_jit.gen.c
+package: package_jit package_autoload
+
+package_jit: aot_ceval_jit.gen.c
+	bash -c 'if [ -d wheelhouse ]; then sudo rm -rf wheelhouse ; fi'
 	docker run --rm -e PLAT=manylinux2014_x86_64 -v `pwd`/../../:/io quay.io/pypa/manylinux2014_x86_64 bash /io/pyston/pyston_lite/build_wheels.sh
 
+package_autoload: env
+	bash -c "cd autoload; rm -rf dist; ../env/bin/python setup.py sdist"
+
+upload_wheels: env
+	env/bin/pip install twine
+	./env/bin/twine upload autoload/dist/pyston_lite_autoload* || true
+	./env/bin/twine upload wheelhouse/*manylinux*.whl || true
+
+test_packages:
+	python3.8 -m venv /tmp/env
+	/tmp/env/bin/pip install pyston_lite_autoload
+	time /tmp/env/bin/python -c 'for i in range(100000000): pass'
+	DISABLE_PYSTON=1 time /tmp/env/bin/python -c 'for i in range(100000000): pass'
 
 
 ######
@@ -39,7 +55,7 @@ package: aot_ceval_jit.gen.c
 
 env: pyston_lite.so
 	$(PYTHON) -m venv env
-	cp pyston_lite.so pyston_lite_autoload.pth env/lib/$(DIR)/site-packages/
+	cp pyston_lite.so autoload/pyston_lite_autoload.pth env/lib/$(DIR)/site-packages/
 
 env/update.stamp: env
 	./env/bin/pip install -r ../pgo_requirements.txt

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -31,9 +31,10 @@ clean:
 
 package: package_jit package_autoload
 
-package_jit: aot_ceval_jit.gen.c
+package_jit:
+	git clean -x -i -d -f .
 	bash -c 'if [ -d wheelhouse ]; then sudo rm -rf wheelhouse ; fi'
-	docker run --rm -e PLAT=manylinux2014_x86_64 -v `pwd`/../../:/io quay.io/pypa/manylinux2014_x86_64 bash /io/pyston/pyston_lite/build_wheels.sh
+	docker run --rm -e PLAT=manylinux2014_x86_64 -v `pwd`/../../:/io quay.io/pypa/manylinux2014_x86_64 bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/wheelhouse"
 
 package_autoload: env
 	bash -c "cd autoload; rm -rf dist; ../env/bin/python setup.py sdist"

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -29,6 +29,9 @@ clean:
 	rm -rf *.o *.so env
 
 
+package: aot_ceval_jit.gen.c
+	docker run --rm -e PLAT=manylinux2014_x86_64 -v `pwd`/../../:/io quay.io/pypa/manylinux2014_x86_64 bash /io/pyston/pyston_lite/build_wheels.sh
+
 
 
 ######

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -44,8 +44,9 @@ upload_wheels: env
 	./env/bin/twine upload wheelhouse/*manylinux*.whl || true
 
 test_packages:
+	rm -rf /tmp/env
 	python3.8 -m venv /tmp/env
-	/tmp/env/bin/pip install pyston_lite_autoload
+	/tmp/env/bin/pip install --upgrade pyston_lite_autoload
 	time /tmp/env/bin/python -c 'for i in range(100000000): pass'
 	DISABLE_PYSTON=1 time /tmp/env/bin/python -c 'for i in range(100000000): pass'
 

--- a/pyston/pyston_lite/autoload/pyston_lite_autoload.pth
+++ b/pyston/pyston_lite/autoload/pyston_lite_autoload.pth
@@ -1,0 +1,1 @@
+import os, sys; exec("""("DISABLE_PYSTON" not in os.environ) and __import__("pyston_lite").enable()""")

--- a/pyston/pyston_lite/autoload/setup.py
+++ b/pyston/pyston_lite/autoload/setup.py
@@ -3,11 +3,12 @@ from distutils import sysconfig
 import os
 import sys
 
+VERSION = "2.3.3.1"
 setup(name="pyston_lite_autoload",
-      version="0.1.1",
+      version=VERSION,
       description="Automatically loads and enables pyston_lite",
       author="The Pyston Team",
       url="https://www.github.com/pyston/pyston",
       data_files=[(sysconfig.get_python_lib(), ["pyston_lite_autoload.pth"])],
-      install_requires=["pyston_lite"],
+      install_requires=["pyston_lite==" + VERSION],
 )

--- a/pyston/pyston_lite/autoload/setup.py
+++ b/pyston/pyston_lite/autoload/setup.py
@@ -1,0 +1,13 @@
+from distutils.core import setup, Extension, Distribution
+from distutils import sysconfig
+import os
+import sys
+
+setup(name="pyston_lite_autoload",
+      version="0.1.1",
+      description="Automatically loads and enables pyston_lite",
+      author="The Pyston Team",
+      url="https://www.github.com/pyston/pyston",
+      data_files=[(sysconfig.get_python_lib(), ["pyston_lite_autoload.pth"])],
+      install_requires=["pyston_lite"],
+)

--- a/pyston/pyston_lite/build_wheels.sh
+++ b/pyston/pyston_lite/build_wheels.sh
@@ -1,0 +1,11 @@
+#/bin/sh
+
+cd $(dirname $0)
+
+PYTHON=/opt/python/cp38-cp38/bin/python
+
+$PYTHON -m pip wheel . --no-deps -w wheelhouse/
+
+for whl in wheelhouse/*.whl; do
+    auditwheel repair $whl --plat $PLAT -w wheelhouse/
+done

--- a/pyston/pyston_lite/build_wheels.sh
+++ b/pyston/pyston_lite/build_wheels.sh
@@ -2,10 +2,20 @@
 
 cd $(dirname $0)
 
-PYTHON=/opt/python/cp38-cp38/bin/python
+PYTHON=/opt/python/cp38-cp38/bin/python3
+
+yum install -y luajit
+
+# manylinux2014 doesn't come with a python3 symlink:
+if ! $(which python3) ; then
+    ln -s $PYTHON /usr/local/bin/
+fi
 
 $PYTHON -m pip wheel . --no-deps -w wheelhouse/
 
+rm -rf build pyston_lite.egg-info
+
 for whl in wheelhouse/*.whl; do
     auditwheel repair $whl --plat $PLAT -w wheelhouse/
+    rm $whl
 done

--- a/pyston/pyston_lite/pyston_lite_autoload.pth
+++ b/pyston/pyston_lite/pyston_lite_autoload.pth
@@ -1,1 +1,0 @@
-import os, sys; exec("""("PYSTON" in os.environ) and __import__("pyston_lite").enable()""")

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -1,21 +1,26 @@
 from distutils.core import setup, Extension, Distribution
+from distutils.command.build_ext import build_ext
 from distutils import sysconfig
 import os
+import subprocess
 import sys
 
-class PystonLiteExtension(Extension):
-    pass
+class pyston_build_ext(build_ext):
+    def run(self):
+        subprocess.check_call(["../../pyston/tools/dynasm_preprocess.py", "aot_ceval_jit.c", "aot_ceval_jit.prep.c"])
+        subprocess.check_call(["luajit", "../../pyston/LuaJIT/dynasm/dynasm.lua", "-o", "aot_ceval_jit.gen.c", "aot_ceval_jit.prep.c"])
+        return super(pyston_build_ext, self).run()
 
-ext = PystonLiteExtension(
+ext = Extension(
         "pyston_lite",
         sources=["aot_ceval.c", "aot_ceval_jit.gen.c", "aot_ceval_jit_helper.c", "lib.c"],
         include_dirs=["../../pyston/LuaJIT", os.path.join(sysconfig.get_python_inc(), "internal")],
         define_macros=[("PYSTON_LITE", None), ("PYSTON_SPEEDUPS", "1"), ("Py_BUILD_CORE", None), ("ENABLE_AOT", None)],
         extra_compile_args=["-std=gnu99"],
-        headers=["dict-common.h"]
 )
 
 setup(name="pyston_lite",
+      cmdclass={"build_ext":pyston_build_ext},
       version="2.3.3.1",
       description="A JIT for Python",
       author="The Pyston Team",

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -16,7 +16,7 @@ ext = PystonLiteExtension(
 )
 
 setup(name="pyston_lite",
-      version="0.1",
+      version="2.3.3.1",
       description="A JIT for Python",
       author="The Pyston Team",
       url="https://www.github.com/pyston/pyston",

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -1,0 +1,25 @@
+from distutils.core import setup, Extension, Distribution
+from distutils import sysconfig
+import os
+import sys
+
+class PystonLiteExtension(Extension):
+    pass
+
+ext = PystonLiteExtension(
+        "pyston_lite",
+        sources=["aot_ceval.c", "aot_ceval_jit.gen.c", "aot_ceval_jit_helper.c", "lib.c"],
+        include_dirs=["../../pyston/LuaJIT", os.path.join(sysconfig.get_python_inc(), "internal")],
+        define_macros=[("PYSTON_LITE", None), ("PYSTON_SPEEDUPS", "1"), ("Py_BUILD_CORE", None), ("ENABLE_AOT", None)],
+        extra_compile_args=["-std=gnu99"],
+        headers=["dict-common.h"]
+)
+
+setup(name="pyston_lite",
+      version="0.1",
+      description="A JIT for Python",
+      author="The Pyston Team",
+      url="https://www.github.com/pyston/pyston",
+      # packages=["pyston_lite_autoload"],
+      ext_modules=[ext],
+)

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -20,6 +20,5 @@ setup(name="pyston_lite",
       description="A JIT for Python",
       author="The Pyston Team",
       url="https://www.github.com/pyston/pyston",
-      # packages=["pyston_lite_autoload"],
       ext_modules=[ext],
 )


### PR DESCRIPTION
This is on top of #218

I wrote setup.py files for the main extension as well as pyston_lite_autoload which automatically enables pyston_lite. I'm open to the idea of just having a single extension that is always enabled.

I went ahead and uploaded some preliminary versions to pypi:

```
$ python3.8 -m venv /tmp/env
$ time /tmp/env/bin/python -c 'for i in range(100000000): pass'
2.89s
$ /tmp/env/bin/pip install pyston_lite_autoload
$ time /tmp/env/bin/python -c 'for i in range(100000000): pass'
2.36s
```