### PR TITLE
jit: inplace modify temporary float objects

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -140,10 +140,17 @@ typedef struct {
     PyTypeObject* type;  /* borrowed type */
 } _PyOpcache_Type;
 
+typedef struct {
+    PyTypeObject* type;  /* borrowed type */
+    unsigned char refcnt1_left; /* how many times had the left operand a refcnt of 1 */
+    unsigned char refcnt1_right;/* how many times had the left operand a refcnt of 1 */
+} _PyOpcache_TypeRefcnt;
+
 _Static_assert(sizeof(_PyOpcache_LoadMethod) <= 32,  "_data[32] needs to be updated");
 _Static_assert(sizeof(_PyOpcache_LoadAttr) <= 32,  "_data[32] needs to be updated");
 _Static_assert(sizeof(_PyOpcache_StoreAttr) <= 32,  "_data[32] needs to be updated");
 _Static_assert(sizeof(_PyOpcache_Type) <= 32,  "_data[32] needs to be updated");
+_Static_assert(sizeof(_PyOpcache_TypeRefcnt) <= 32,  "_data[32] needs to be updated");
 #endif
 
 struct _PyOpcache {
@@ -154,6 +161,7 @@ struct _PyOpcache {
         _PyOpcache_LoadAttr la;
         _PyOpcache_StoreAttr sa;
         _PyOpcache_Type t;
+        _PyOpcache_TypeRefcnt t_refcnt;
 #endif
     } u;
     char optimized;

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -280,6 +280,8 @@ _PyCode_InitOpcache(PyCodeObject *co)
 #if PYSTON_SPEEDUPS
                 || opcode == LOAD_METHOD || opcode == LOAD_ATTR || opcode == STORE_ATTR
                 || opcode == BINARY_ADD || opcode == INPLACE_ADD
+                || opcode == BINARY_SUBTRACT || opcode == INPLACE_SUBTRACT
+                || opcode == BINARY_MULTIPLY || opcode == INPLACE_MULTIPLY
                 || opcode == BINARY_SUBSCR || opcode == STORE_SUBSCR
 #endif
                 ) {

--- a/pyston/test/inplace_math.py
+++ b/pyston/test/inplace_math.py
@@ -1,0 +1,27 @@
+# check that the inplace float modification optimization
+# generates same results
+def add():
+    a = 1.5
+    b = -7.4
+    c = 4.2
+    r = a + b
+    r = r + c
+    assert a + b + c == r
+def sub():
+    a = 1.5
+    b = -7.4
+    c = 4.2
+    r = a - b
+    r = r - c
+    assert a - b - c == r
+def mul():
+    a = 1.5
+    b = -7.4
+    c = 4.2
+    r = a * b
+    r = r * c
+    assert a * b * c == r
+for i in range(10000):
+    add()
+    sub()
+    mul()


### PR DESCRIPTION
This identifies owned floats with refcount==1 which can be inplace modified.
Works very well on math heavy code:
```
nbody                    1.25x faster
scimark_fft:             1.09x faster
scimark_sparse_mat_mult: 1.15x faster
spectral_norm:           1.08x faster
```
While Pyston is not focusing on on speedup math code this is quite a small and simple change
which shows quite large speedups on different workloads so I think it's worth adding it.

I had a earlier version which also added a path for longs but this had more mixed results because it only handled some of the longs which have been positive not using the small int cache etc... I will try adding a free list instead.