### PR TITLE
A few pyston-lite optimizations

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -55,11 +55,14 @@ enum _PyOpcache_LoadAttr_Types {
     // Has the advantage that even with modifications to the dict the cache will mostly hit.
     LA_CACHE_OFFSET_CACHE = 4,
 
+    // The same thing as LA_CACHE_OFFSET_CACHE but for split dicts
+    LA_CACHE_OFFSET_CACHE_SPLIT = 5,
+
     // caching the offset to attribute slot inside a python object.
     // used for __slots__
     // LA_CACHE_DATA_DESCR works too but is slower because it needs extra guarding
     // and emits a call to the decriptor function
-    LA_CACHE_SLOT_CACHE = 5,
+    LA_CACHE_SLOT_CACHE = 6,
 
     // This works similarly to LA_CACHE_VALUE_CACHE_DICT but is specifically
     // for immutable types, such as the builtins.
@@ -67,10 +70,10 @@ enum _PyOpcache_LoadAttr_Types {
     // (for two reasons: first we know that the type will stay alive so it's safe to
     // store a borrowed reference, and second we know the tp_version_tag won't change.)
     // This lets us constant-fold a number of the checks when we jit this load.
-    LA_CACHE_BUILTIN = 6,
+    LA_CACHE_BUILTIN = 7,
 
     // Used for polymorphic sites where we store an array of _PyOpcaches
-    LA_CACHE_POLYMORPHIC = 7,
+    LA_CACHE_POLYMORPHIC = 8,
 };
 typedef struct {
     union {
@@ -97,6 +100,10 @@ typedef struct {
             Py_ssize_t dk_size; /* dk_size of the dict */
             int64_t offset; /* offset in bytes from ma_keys->dk_indices to the item in the hash table */
         } offset_cache;
+        struct {
+            Py_ssize_t dk_size; /* dk_size of the dict */
+            int64_t ix; /* index in the table */
+        } offset_cache_split;
         struct {
             int64_t offset; /* offset in bytes from the start of the PyObject to the slot */
         } slot_cache;

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -199,7 +199,8 @@ int _PyCode_InitOpcache(PyCodeObject *co);
 
 // Defensiveness: it's a bug to use the CPython-managed fields, so lets make them compile errors:
 #define co_opcache_map DONTUSE
-#define co_opcache DONTUSE
+// There are local variables called this unfortunately:
+//#define co_opcache DONTUSE
 #define co_opcache_flag DONTUSE
 #define co_opcache_size DONTUSE
 

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -181,6 +181,98 @@ long loadmethod_hits = 0, loadmethod_misses = 0, loadmethod_uncached = 0, loadme
 long loadglobal_hits = 0, loadglobal_misses = 0, loadglobal_uncached = 0, loadglobal_noopcache = 0;
 #endif
 
+#ifdef PYSTON_LITE
+// In pyston-full we rely on LTO to inline cmp_outcome into the interpreter loop.
+// In pyston-lite we have to make the implementation available
+__attribute__((visibility("hidden"))) inline PyObject* cmp_outcome(PyThreadState *tstate, int, PyObject *v, PyObject *w);
+PyObject* cmp_outcomePyCmp_LT(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_LT, v, w);
+}
+PyObject* cmp_outcomePyCmp_LE(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_LE, v, w);
+}
+PyObject* cmp_outcomePyCmp_EQ(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_EQ, v, w);
+}
+PyObject* cmp_outcomePyCmp_NE(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_NE, v, w);
+}
+PyObject* cmp_outcomePyCmp_GT(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_GT, v, w);
+}
+PyObject* cmp_outcomePyCmp_GE(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_GE, v, w);
+}
+PyObject* cmp_outcomePyCmp_IN(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_IN, v, w);
+}
+PyObject* cmp_outcomePyCmp_NOT_IN(PyObject *v, PyObject *w) {
+  return cmp_outcome(NULL, PyCmp_NOT_IN, v, w);
+}
+
+#define CANNOT_CATCH_MSG "catching classes that do not inherit from "\
+                         "BaseException is not allowed"
+PyObject *
+cmp_outcome(PyThreadState *tstate, int op, PyObject *v, PyObject *w)
+{
+    int res = 0;
+    switch (op) {
+    case PyCmp_IS:
+        res = (v == w);
+        break;
+    case PyCmp_IS_NOT:
+        res = (v != w);
+        break;
+    case PyCmp_IN:
+        res = PySequence_Contains(w, v);
+        if (res < 0)
+            return NULL;
+        break;
+    case PyCmp_NOT_IN:
+        res = PySequence_Contains(w, v);
+        if (res < 0)
+            return NULL;
+        res = !res;
+        break;
+    case PyCmp_EXC_MATCH:
+        if (PyTuple_Check(w)) {
+            Py_ssize_t i, length;
+            length = PyTuple_Size(w);
+            for (i = 0; i < length; i += 1) {
+                PyObject *exc = PyTuple_GET_ITEM(w, i);
+                if (!PyExceptionClass_Check(exc)) {
+                    _PyErr_SetString(tstate, PyExc_TypeError,
+                                     CANNOT_CATCH_MSG);
+                    return NULL;
+                }
+            }
+        }
+        else {
+            if (!PyExceptionClass_Check(w)) {
+                _PyErr_SetString(tstate, PyExc_TypeError,
+                                 CANNOT_CATCH_MSG);
+                return NULL;
+            }
+        }
+        res = PyErr_GivenExceptionMatches(v, w);
+        break;
+    default:
+        return PyObject_RichCompare(v, w, op);
+    }
+    v = res ? Py_True : Py_False;
+    Py_INCREF(v);
+    return v;
+}
+
+PyObject* _Py_HOT_FUNCTION
+PyErr_Occurred(void)
+{
+    PyThreadState *tstate = _PyThreadState_GET();
+    return _PyErr_Occurred(tstate);
+}
+
+#endif
+
 #define GIL_REQUEST _Py_atomic_load_relaxed(&ceval->gil_drop_request)
 
 /* This can set eval_breaker to 0 even though gil_drop_request became

--- a/Python/aot_ceval_jit_helper.c
+++ b/Python/aot_ceval_jit_helper.c
@@ -43,7 +43,6 @@
 #include <ctype.h>
 
 #ifdef PYSTON_LITE
-#define SET_JIT_AOT_FUNC(JIT_HELPER_STORE_ATTR) (0)
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
 #else

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -64,7 +64,7 @@ env/update.stamp: env
 	touch $@
 
 
-ENV:=SHOW_OPCACHE_STATS=1 JIT_PERF_MAP=1
+ENV:=
 BENCH:=../macrobenchmarks/benchmarks/bm_flaskblogging/run_benchmark.py --legacy
 
 
@@ -82,13 +82,13 @@ bench_baseline: env/update.stamp
 	DISABLE_PYSTON=1 ./env/bin/python $(BENCH)
 
 perf_bench: env/update.stamp
-	DISABLE_PYSTONFULL=1 $(ENV) perf record -o perf_lite.data ./env/bin/python $(BENCH)
+	$(ENV) JIT_PERF_MAP=1 perf record -o perf_lite.data ./env/bin/python $(BENCH)
 	$(MAKE) perf_report
 perf_report:
 	perf report -i perf_lite.data -n --objdump=../../pyston/tools/perf_jit.py
 
 perf_bench_baseline: env/update.stamp
-	DISABLE_PYSTONFULL=1 DISABLE_PYSTON=1 perf record -o perf_baseline.data ./env/bin/python $(BENCH)
+	DISABLE_PYSTON=1 JIT_PERF_MAP=1 perf record -o perf_baseline.data ./env/bin/python $(BENCH)
 	$(MAKE) perf_report_baseline
 perf_report_baseline:
 	perf report -i perf_baseline.data -n --objdump=../../pyston/tools/perf_jit.py
@@ -103,7 +103,7 @@ bench_full:
 
 perf_bench_full:
 	$(MAKE) -C ../.. build/unoptshared_env/update.stamp
-	$(ENV) LD_LIBRARY_PATH=../../build/unoptshared_install/usr/lib:$$LD_LIBRARY_PATH perf record -o perf_full.data ../../build/unoptshared_env/bin/python $(BENCH)
+	$(ENV) LD_LIBRARY_PATH=../../build/unoptshared_install/usr/lib:$$LD_LIBRARY_PATH JIT_PERF_MAP=1 perf record -o perf_full.data ../../build/unoptshared_env/bin/python $(BENCH)
 	$(MAKE) perf_report_full
 perf_report_full:
 	perf report -i perf_full.data -n --objdump=../../pyston/tools/perf_jit.py
@@ -119,5 +119,5 @@ bench_fullopt:
 
 perf_bench_fullopt:
 	$(MAKE) -C ../.. build/optshared_env/update.stamp
-	$(ENV) LD_LIBRARY_PATH=../../build/optshared_install/usr/lib:$$LD_LIBRARY_PATH perf record ../../build/optshared_env/bin/python $(BENCH)
+	$(ENV) LD_LIBRARY_PATH=../../build/optshared_install/usr/lib:$$LD_LIBRARY_PATH JIT_PERF_MAP=1 perf record ../../build/optshared_env/bin/python $(BENCH)
 	perf report -n

--- a/pyston/pyston_lite/lib.c
+++ b/pyston/pyston_lite/lib.c
@@ -29,31 +29,6 @@ PyObject* PyNumber_PowerNone(PyObject *v, PyObject *w) {
 PyObject* PyNumber_InPlacePowerNone(PyObject *v, PyObject *w) {
   return PyNumber_InPlacePower(v, w, Py_None);
 }
-__attribute__((visibility("hidden"))) inline PyObject* cmp_outcome(PyThreadState *tstate, int, PyObject *v, PyObject *w);
-PyObject* cmp_outcomePyCmp_LT(PyObject *v, PyObject *w) {
-  return cmp_outcome(NULL, PyCmp_LT, v, w);
-}
-PyObject* cmp_outcomePyCmp_LE(PyObject *v, PyObject *w) {
-  return cmp_outcome(NULL, PyCmp_LE, v, w);
-}
-PyObject* cmp_outcomePyCmp_EQ(PyObject *v, PyObject *w) {
-  return cmp_outcome(NULL, PyCmp_EQ, v, w);
-}
-PyObject* cmp_outcomePyCmp_NE(PyObject *v, PyObject *w) {
-  return cmp_outcome(NULL, PyCmp_NE, v, w);
-}
-PyObject* cmp_outcomePyCmp_GT(PyObject *v, PyObject *w) {
-  return cmp_outcome(NULL, PyCmp_GT, v, w);
-}
-PyObject* cmp_outcomePyCmp_GE(PyObject *v, PyObject *w) {
-  return cmp_outcome(NULL, PyCmp_GE, v, w);
-}
-PyObject* cmp_outcomePyCmp_IN(PyObject *v, PyObject *w) {
-  return cmp_outcome(NULL, PyCmp_IN, v, w);
-}
-PyObject* cmp_outcomePyCmp_NOT_IN(PyObject *v, PyObject *w) {
-  return cmp_outcome(NULL, PyCmp_NOT_IN, v, w);
-}
 
 PyObject *
 trace_call_function(PyThreadState *tstate,
@@ -311,60 +286,6 @@ call_function_ceval_fast(PyThreadState *tstate, PyObject ***pp_stack, Py_ssize_t
 #endif
 
     return x;
-}
-
-#define CANNOT_CATCH_MSG "catching classes that do not inherit from "\
-                         "BaseException is not allowed"
-/*static*/ PyObject *
-cmp_outcome(PyThreadState *tstate, int op, PyObject *v, PyObject *w)
-{
-    int res = 0;
-    switch (op) {
-    case PyCmp_IS:
-        res = (v == w);
-        break;
-    case PyCmp_IS_NOT:
-        res = (v != w);
-        break;
-    case PyCmp_IN:
-        res = PySequence_Contains(w, v);
-        if (res < 0)
-            return NULL;
-        break;
-    case PyCmp_NOT_IN:
-        res = PySequence_Contains(w, v);
-        if (res < 0)
-            return NULL;
-        res = !res;
-        break;
-    case PyCmp_EXC_MATCH:
-        if (PyTuple_Check(w)) {
-            Py_ssize_t i, length;
-            length = PyTuple_Size(w);
-            for (i = 0; i < length; i += 1) {
-                PyObject *exc = PyTuple_GET_ITEM(w, i);
-                if (!PyExceptionClass_Check(exc)) {
-                    _PyErr_SetString(tstate, PyExc_TypeError,
-                                     CANNOT_CATCH_MSG);
-                    return NULL;
-                }
-            }
-        }
-        else {
-            if (!PyExceptionClass_Check(w)) {
-                _PyErr_SetString(tstate, PyExc_TypeError,
-                                 CANNOT_CATCH_MSG);
-                return NULL;
-            }
-        }
-        res = PyErr_GivenExceptionMatches(v, w);
-        break;
-    default:
-        return PyObject_RichCompare(v, w, op);
-    }
-    v = res ? Py_True : Py_False;
-    Py_INCREF(v);
-    return v;
 }
 
 static PySliceObject *slice_cache = NULL;

--- a/pyston/pyston_lite/lib.c
+++ b/pyston/pyston_lite/lib.c
@@ -223,6 +223,24 @@ PyObject* _PyDict_GetItemByOffset(PyDictObject *mp, PyObject *key, Py_ssize_t dk
     return ep->me_value;
 }
 
+PyObject* _PyDict_GetItemByOffsetSplit(PyDictObject *mp, PyObject *key, Py_ssize_t dk_size, int64_t ix) {
+    assert(PyDict_CheckExact((PyObject*)mp));
+    assert(PyUnicode_CheckExact(key));
+    assert(offset >= 0);
+
+    if (mp->ma_keys->dk_size != dk_size)
+        return NULL;
+
+    if (mp->ma_keys->dk_lookup != lookdict_split_value)
+        return NULL;
+
+    PyDictKeyEntry *ep = DK_ENTRIES(mp->ma_keys) + ix;
+    if (ep->me_key != key)
+        return NULL;
+
+    return mp->ma_values[ix];
+}
+
 int64_t _PyDict_GetItemOffset(PyDictObject *mp, PyObject *key, Py_ssize_t *dk_size)
 {
     Py_hash_t hash;
@@ -249,6 +267,34 @@ int64_t _PyDict_GetItemOffset(PyDictObject *mp, PyObject *key, Py_ssize_t *dk_si
 
     *dk_size = mp->ma_keys->dk_size;
     return (char*)(&DK_ENTRIES(mp->ma_keys)[ix]) - (char*)mp->ma_keys->dk_indices;
+}
+
+int64_t _PyDict_GetItemOffsetSplit(PyDictObject *mp, PyObject *key, Py_ssize_t *dk_size)
+{
+    Py_hash_t hash;
+
+    assert(PyDict_CheckExact((PyObject*)mp));
+    assert(PyUnicode_CheckExact(key));
+
+    if ((hash = ((PyASCIIObject *) key)->hash) == -1)
+        return -1;
+
+    if (mp->ma_keys->dk_lookup != lookdict_split_value)
+        return -1;
+
+    // don't cache if error is set because we could overwrite it
+    if (PyErr_Occurred())
+        return -1;
+
+    PyObject *value = NULL;
+    Py_ssize_t ix = (mp->ma_keys->dk_lookup)(mp, key, hash, &value);
+    if (ix < 0) {
+        PyErr_Clear();
+        return -1;
+    }
+
+    *dk_size = mp->ma_keys->dk_size;
+    return ix;
 }
 
 


### PR DESCRIPTION
The benchmark numbers have quite a bit of variance, but they look good:

```
  system 0.01+-0.00              net +0.0%
lite 462 0.01+-0.00              net +6.2% merge conflict
lite 323 0.01+-0.00  -0.7%+-0.3% net +5.5% Forgot to update this makefile after swapping opt-
lite c12 0.01+-0.00  +0.3%+-0.3% net +5.9% clean this up a bit
lite f30 0.01+-0.00  -0.3%+-0.3% net +5.5% Better approach to the co_opcache conflict
lite dd1 0.01+-0.00  -3.7%+-0.3% net +1.6% pyston-lite: enable de-specialization
lite 886 0.01+-0.00  +0.3%+-0.3% net +1.9% micro-optimize _PyEval_EvalFrame_AOT
lite d16 0.01+-0.00  -0.3%+-0.3% net +1.6% Move these functions into aot_ceval so they can be
lite 110 0.01+-0.00  -1.2%+-0.3% net +0.4% Optimize our co_extra handling
lite bdb 0.00+-0.00  -1.8%+-0.3% net -1.4% Implement split-dict-offset cache for pyston-lite
```

ie it's about 7% total.

Everything but the last commit are fixes to things that slow pyston-lite down relative to stock CPython. I would still expect us to be faster because of the JIT, but on the machine for these numbers the jit barely helps at all (on my AMD machine it helps 10%). Something for us to look into.