### PR TITLE
CI: add pyston_lite arm64 qemu bot

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -123,3 +123,22 @@ jobs:
           name: core-dump-unopt_build
           path: /cores/
           if-no-files-found: ignore
+
+  pyston_lite_arm64_qemu:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: checkout submodules
+        run: |
+          git submodule update --init pyston/LuaJIT
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: build pyston and test
+        run: |
+          docker buildx build -t ubuntu_nonroot --platform linux/arm64 .github/workflows/
+          docker run -e ADDITIONAL_TESTS_TO_SKIP -iv${PWD}:/pyston_dir -iv/cores:/cores --name pyston_build ubuntu_nonroot /pyston_dir/.github/workflows/pyston_lite.sh
+        env:
+          # this tests fail with qemu
+          ADDITIONAL_TESTS_TO_SKIP: "test_cmd_line test_faulthandler test_posix test_signal test_socket
+    test_subprocess"
+

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -43,10 +43,11 @@ env: pyston_lite.so
 #
 # A number of other tests in the cpython testsuite fail with the Ubuntu packages, and I'm not sure why.
 # This happens regardless of whether pyston-lite is installed, so just exclude them.
+ADDITIONAL_TESTS_TO_SKIP?=
 test: env
 	set -ex; for fn in ../test/*.py; do if [ $$fn = ../test/test_rebuild_packages.py -o $$fn = ../test/test_venvs.py ]; then continue; fi; ./env/bin/python $$fn; done
 	./env/bin/python -c 'import test.support; test.support.check_impl_detail = lambda **kw: False; import test.test_code; test.test_code.test_main()'
-	./env/bin/python -m test -j0 -x test_code test_distutils test_ensurepip test_minidom test_site test_xml_etree test_xml_etree_c
+	./env/bin/python -m test -j0 -x test_code test_distutils test_ensurepip test_minidom test_site test_xml_etree test_xml_etree_c $(ADDITIONAL_TESTS_TO_SKIP)
 
 
 


### PR DESCRIPTION
Takes about 1h to run so will not slowdown our CI runs. 
I had to disable a few tests which segfault with qemu (which is not very encouraging) but I think we should try out and if it often causes issues disable it again. But it's super nice to get at least some feedback about arm without having to run the tests all the time manually.
