### PR TITLE
A few more optimizations

### DIFF
--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -32,12 +32,12 @@ pgo:
 	rm -rf pgo_env
 	$(PYTHON) -m venv pgo_env
 	cp pyston_lite.so autoload/pyston_lite_autoload.pth pgo_env/lib/$(DIR)/site-packages/
-	./pgo_env/bin/python ../../Lib/test/regrtest.py -j 0 -unone,decimal -x test_posix test_asyncio test_cmd_line_script test_compiler test_concurrent_futures test_ctypes test_dbm_dumb test_dbm_ndbm test_distutils test_ensurepip test_ftplib test_gdb test_httplib test_imaplib test_ioctl test_linuxaudiodev test_multiprocessing test_nntplib test_ossaudiodev test_poplib test_pydoc test_signal test_socket test_socketserver test_ssl test_subprocess test_sundry test_thread test_threaded_import test_threadedtempfile test_threading test_threading_local test_threadsignals test_venv test_zipimport_support test_code || true
+	./pgo_env/bin/python ../../Lib/test/regrtest.py -j 0 -unone,decimal -x test_posix test_asyncio test_cmd_line_script test_compiler test_concurrent_futures test_ctypes test_dbm_dumb test_dbm_ndbm test_distutils test_ensurepip test_ftplib test_gdb test_httplib test_imaplib test_ioctl test_linuxaudiodev test_multiprocessing test_nntplib test_ossaudiodev test_poplib test_pydoc test_signal test_socket test_socketserver test_ssl test_subprocess test_sundry test_thread test_threaded_import test_threadedtempfile test_threading test_threading_local test_threadsignals test_venv test_zipimport_support test_code test_multiprocessing test_multiprocessing_forkserver test_multiprocessing_spawn test_multiprocessing_fork|| true
 
 	$(MAKE) buildclean
 	$(MAKE) pyston_lite.so CFLAGS=-fprofile-use LDFLAGS=-fprofile-use
 
-pgo.stamp:
+pgo.stamp: $(wildcard *.c) $(wildcard *.h)
 	$(MAKE) pgo
 	touch $@
 

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -16,8 +16,12 @@ CC:=gcc
 CFLAGS:=$(CFLAGS) $(PY_CORE_CFLAGS) -I../../pyston/LuaJIT/ -Wno-address -Wpointer-to-int-cast -I$(PYTHON_INCL) -I$(PYTHON_INCL)/internal -DPYSTON_SPEEDUPS -DPy_BUILD_CORE -fPIC -Werror=implicit-function-declaration -g
 CFLAGS:=$(CFLAGS) -pthread -c -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -Wall -DENABLE_AOT   -fstack-protector -specs=../tools/no-pie-compile.specs -D_FORTIFY_SOURCE=2 -fno-reorder-blocks-and-partition -std=c99 -Wextra -Wno-unused-result -Wno-unused-parameter -Wno-missing-field-initializers -Werror=implicit-function-declaration  -I../../Include/internal -IObjects -IInclude -IPython -I. -I../../Include   -I../aot  -DPy_BUILD_CORE -Wno-unused-label
 CFLAGS:=$(CFLAGS) -std=gnu99 -fcf-protection=none
-CFLAGS:=$(CFLAGS) -O3
+CFLAGS:=$(CFLAGS) -O3 -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -fno-semantic-interposition
 CFLAGS:=$(CFLAGS) -DPYSTON_LITE
+LDFLAGS:=$(LDFLAGS) -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -fno-semantic-interposition
+
+# This file can't use lto due to the global registers:
+aot_ceval_jit_helper.o: CFLAGS+=-fno-lto
 
 pyston_lite.so: aot_ceval_jit.gen.o aot_ceval_jit_helper.o lib.o aot_ceval.o
 	$(CC) -shared $^ -o $@

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -1,4 +1,4 @@
-.DEFAULT_GOAL := pgo.stamp
+.DEFAULT_GOAL := env
 
 # Change these to target a different Python:
 PYTHON:=python3.8
@@ -17,7 +17,7 @@ override CFLAGS += $(PY_CORE_CFLAGS) -I../../pyston/LuaJIT/ -Wno-address -Wpoint
 override CFLAGS += -pthread -c -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -Wall -DENABLE_AOT   -fstack-protector -specs=../tools/no-pie-compile.specs -D_FORTIFY_SOURCE=2 -fno-reorder-blocks-and-partition -std=c99 -Wextra -Wno-unused-result -Wno-unused-parameter -Wno-missing-field-initializers -Werror=implicit-function-declaration  -I../../Include/internal -IObjects -IInclude -IPython -I. -I../../Include   -I../aot  -DPy_BUILD_CORE -Wno-unused-label
 override CFLAGS += -std=gnu99 -fcf-protection=none
 override CFLAGS += -O3 -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -fno-semantic-interposition
-override CFLAGS += -DPYSTON_LITE
+override CFLAGS += -DPYSTON_LITE -DPY_DEBUGGING_CHECKS=0
 override LDFLAGS += -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -fno-semantic-interposition
 
 # This file can't use lto due to the global registers:
@@ -72,7 +72,7 @@ ADDITIONAL_TESTS_TO_SKIP?=
 test: env
 	set -ex; for fn in ../test/*.py; do if [ $$fn = ../test/test_rebuild_packages.py -o $$fn = ../test/test_venvs.py ]; then continue; fi; ./env/bin/python $$fn; done
 	./env/bin/python -c 'import test.support; test.support.check_impl_detail = lambda **kw: False; import test.test_code; test.test_code.test_main()'
-	./env/bin/python -m test -j0 -x test_code test_distutils test_ensurepip test_minidom test_site test_xml_etree test_xml_etree_c $(ADDITIONAL_TESTS_TO_SKIP)
+	./env/bin/python -m test -j0 -x test_code test_distutils test_ensurepip test_minidom test_site test_xml_etree test_xml_etree_c test_capi $(ADDITIONAL_TESTS_TO_SKIP)
 
 
 

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -1,4 +1,4 @@
-.DEFAULT_GOAL := pyston_lite.so
+.DEFAULT_GOAL := pgo.stamp
 
 # Change these to target a different Python:
 PYTHON:=python3.8
@@ -13,27 +13,48 @@ aot_ceval_jit.gen.c: aot_ceval_jit.prep.c
 	luajit ../../pyston/LuaJIT/dynasm/dynasm.lua  -o aot_ceval_jit.gen.c $<
 
 CC:=gcc
-CFLAGS:=$(CFLAGS) $(PY_CORE_CFLAGS) -I../../pyston/LuaJIT/ -Wno-address -Wpointer-to-int-cast -I$(PYTHON_INCL) -I$(PYTHON_INCL)/internal -DPYSTON_SPEEDUPS -DPy_BUILD_CORE -fPIC -Werror=implicit-function-declaration -g
-CFLAGS:=$(CFLAGS) -pthread -c -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -Wall -DENABLE_AOT   -fstack-protector -specs=../tools/no-pie-compile.specs -D_FORTIFY_SOURCE=2 -fno-reorder-blocks-and-partition -std=c99 -Wextra -Wno-unused-result -Wno-unused-parameter -Wno-missing-field-initializers -Werror=implicit-function-declaration  -I../../Include/internal -IObjects -IInclude -IPython -I. -I../../Include   -I../aot  -DPy_BUILD_CORE -Wno-unused-label
-CFLAGS:=$(CFLAGS) -std=gnu99 -fcf-protection=none
-CFLAGS:=$(CFLAGS) -O3 -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -fno-semantic-interposition
-CFLAGS:=$(CFLAGS) -DPYSTON_LITE
-LDFLAGS:=$(LDFLAGS) -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -fno-semantic-interposition
+override CFLAGS += $(PY_CORE_CFLAGS) -I../../pyston/LuaJIT/ -Wno-address -Wpointer-to-int-cast -I$(PYTHON_INCL) -I$(PYTHON_INCL)/internal -DPYSTON_SPEEDUPS -DPy_BUILD_CORE -fPIC -Werror=implicit-function-declaration -g
+override CFLAGS += -pthread -c -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -Wall -DENABLE_AOT   -fstack-protector -specs=../tools/no-pie-compile.specs -D_FORTIFY_SOURCE=2 -fno-reorder-blocks-and-partition -std=c99 -Wextra -Wno-unused-result -Wno-unused-parameter -Wno-missing-field-initializers -Werror=implicit-function-declaration  -I../../Include/internal -IObjects -IInclude -IPython -I. -I../../Include   -I../aot  -DPy_BUILD_CORE -Wno-unused-label
+override CFLAGS += -std=gnu99 -fcf-protection=none
+override CFLAGS += -O3 -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -fno-semantic-interposition
+override CFLAGS += -DPYSTON_LITE
+override LDFLAGS += -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -fno-semantic-interposition
 
 # This file can't use lto due to the global registers:
 aot_ceval_jit_helper.o: CFLAGS+=-fno-lto
 
+pgo:
+	$(MAKE) buildclean
+	rm -f *.gcda
+
+	$(MAKE) pyston_lite.so CFLAGS=-fprofile-generate LDFLAGS=-fprofile-generate
+
+	rm -rf pgo_env
+	$(PYTHON) -m venv pgo_env
+	cp pyston_lite.so autoload/pyston_lite_autoload.pth pgo_env/lib/$(DIR)/site-packages/
+	./pgo_env/bin/python ../../Lib/test/regrtest.py -j 0 -unone,decimal -x test_posix test_asyncio test_cmd_line_script test_compiler test_concurrent_futures test_ctypes test_dbm_dumb test_dbm_ndbm test_distutils test_ensurepip test_ftplib test_gdb test_httplib test_imaplib test_ioctl test_linuxaudiodev test_multiprocessing test_nntplib test_ossaudiodev test_poplib test_pydoc test_signal test_socket test_socketserver test_ssl test_subprocess test_sundry test_thread test_threaded_import test_threadedtempfile test_threading test_threading_local test_threadsignals test_venv test_zipimport_support test_code || true
+
+	$(MAKE) buildclean
+	$(MAKE) pyston_lite.so CFLAGS=-fprofile-use LDFLAGS=-fprofile-use
+
+pgo.stamp:
+	$(MAKE) pgo
+	touch $@
+
 pyston_lite.so: aot_ceval_jit.gen.o aot_ceval_jit_helper.o lib.o aot_ceval.o
-	$(CC) -shared $^ -o $@
+	$(CC) $(LDFLAGS) -shared $^ -o $@
 
 %.o: %.c $(wildcard *.h)
 
-.PHONY: clean
-clean:
+.PHONY: clean buildclean
+buildclean:
 	rm -rf *.o *.so env
+clean:
+	$(MAKE) buildclean
+	rm -f *.gcda pgo.stamp
 
 
-env: pyston_lite.so
+env: pgo.stamp
 	$(PYTHON) -m venv env
 	cp pyston_lite.so autoload/pyston_lite_autoload.pth env/lib/$(DIR)/site-packages/
 	touch $@

--- a/pyston/pyston_lite/lib.c
+++ b/pyston/pyston_lite/lib.c
@@ -10,6 +10,23 @@
 #include "moduleobject.h"
 #include "opcode.h"
 
+#undef _Py_Dealloc
+void
+_Py_Dealloc(PyObject *op)
+{
+    destructor dealloc = Py_TYPE(op)->tp_dealloc;
+#ifdef Py_TRACE_REFS
+    _Py_ForgetReference(op);
+#else
+    _Py_INC_TPFREES(op);
+#endif
+    (*dealloc)(op);
+}
+
+PyObject* _Py_CheckFunctionResult(PyObject *callable, PyObject *result, const char *where) {
+    return result;
+}
+
 __attribute__((visibility("hidden"))) inline PyObject * call_function_ceval_fast(
     PyThreadState *tstate, PyObject ***pp_stack,
     Py_ssize_t oparg, PyObject *kwnames);

--- a/pyston/pyston_lite/lib.c
+++ b/pyston/pyston_lite/lib.c
@@ -359,3 +359,148 @@ PySlice_NewSteal(PyObject *start, PyObject *stop, PyObject *step) {
     _PyObject_GC_TRACK(obj);
     return (PyObject *) obj;
 }
+
+
+_Py_IDENTIFIER(__getattribute__);
+
+PyObject * lookup_maybe_method_cached(PyObject *self, _Py_Identifier *attrid, int *unbound, PyObject** cache_slot);
+
+static PyObject*
+call_unbound(int unbound, PyObject *func, PyObject *self,
+             PyObject **args, Py_ssize_t nargs)
+{
+    if (unbound) {
+        return _PyObject_FastCall_Prepend(func, self, args, nargs);
+    }
+    else {
+        return _PyObject_FastCall(func, args, nargs);
+    }
+}
+
+static PyObject*
+_process_method(PyObject* self, PyObject* res, int* unbound) {
+    if (res == NULL) {
+        return NULL;
+    }
+
+    if (PyType_HasFeature(Py_TYPE(res), Py_TPFLAGS_METHOD_DESCRIPTOR)) {
+        /* Avoid temporary PyMethodObject */
+        *unbound = 1;
+        Py_INCREF(res);
+    }
+    else {
+        *unbound = 0;
+        descrgetfunc f = Py_TYPE(res)->tp_descr_get;
+        if (f == NULL) {
+            Py_INCREF(res);
+        }
+        else {
+            res = f(res, self, (PyObject *)(Py_TYPE(self)));
+        }
+    }
+    return res;
+}
+
+static PyObject *
+lookup_maybe_method(PyObject *self, _Py_Identifier *attrid, int *unbound)
+{
+    PyObject *res = _PyType_LookupId(Py_TYPE(self), attrid);
+    return _process_method(self, res, unbound);
+}
+
+static PyObject *
+lookup_method_cached(PyObject *self, _Py_Identifier *attrid, int *unbound, PyObject** cache_slot)
+{
+    PyObject *res = lookup_maybe_method_cached(self, attrid, unbound, cache_slot);
+    if (res == NULL && !PyErr_Occurred()) {
+        PyErr_SetObject(PyExc_AttributeError, attrid->object);
+    }
+    return res;
+}
+
+static PyObject *
+lookup_method(PyObject *self, _Py_Identifier *attrid, int *unbound)
+{
+    PyObject *res = lookup_maybe_method(self, attrid, unbound);
+    if (res == NULL && !PyErr_Occurred()) {
+        PyErr_SetObject(PyExc_AttributeError, attrid->object);
+    }
+    return res;
+}
+
+static PyObject *
+call_method(PyObject *obj, _Py_Identifier *name,
+            PyObject **args, Py_ssize_t nargs)
+{
+    int unbound;
+    PyObject *func, *retval;
+
+    func = lookup_method(obj, name, &unbound);
+    if (func == NULL) {
+        return NULL;
+    }
+    retval = call_unbound(unbound, func, obj, args, nargs);
+    Py_DECREF(func);
+    return retval;
+}
+
+static PyObject *
+slot_tp_getattro(PyObject *self, PyObject *name)
+{
+    PyObject *stack[1] = {name};
+    return call_method(self, &PyId___getattribute__, stack, 1);
+}
+
+// This is Pyston's modified slot_tp_getattr_hook (but renamed)
+PyObject *
+slot_tp_getattr_hook_complex(PyObject *self, PyObject *name)
+{
+    PyTypeObject *tp = Py_TYPE(self);
+    PyObject *getattr, *getattribute, *res;
+    _Py_IDENTIFIER(__getattr__);
+
+    /* speed hack: we could use lookup_maybe, but that would resolve the
+       method fully for each attribute lookup for classes with
+       __getattr__, even when the attribute is present. So we use
+       _PyType_Lookup and create the method only when needed, with
+       call_attribute. */
+    getattr = _PyType_LookupId(tp, &PyId___getattr__);
+    if (getattr == NULL) {
+        /* No __getattr__ hook: use a simpler dispatcher */
+        tp->tp_getattro = slot_tp_getattro;
+        return slot_tp_getattro(self, name);
+    }
+    Py_INCREF(getattr);
+    /* speed hack: we could use lookup_maybe, but that would resolve the
+       method fully for each attribute lookup for classes with
+       __getattr__, even when self has the default __getattribute__
+       method. So we use _PyType_Lookup and create the method only when
+       needed, with call_attribute. */
+    getattribute = _PyType_LookupId(tp, &PyId___getattribute__);
+    if (getattribute == NULL ||
+        (Py_TYPE(getattribute) == &PyWrapperDescr_Type &&
+         ((PyWrapperDescrObject *)getattribute)->d_wrapped ==
+         (void *)PyObject_GenericGetAttr)) {
+#if PYSTON_SPEEDUPS
+        // switch to version which does not check for __getattribute__
+        tp->tp_getattro = slot_tp_getattr_hook_simple;
+        res = _PyObject_GenericGetAttrWithDict(self, name, NULL, 1 /* suppress */);
+#else
+        res = PyObject_GenericGetAttr(self, name);
+#endif
+    } else {
+        Py_INCREF(getattribute);
+        res = call_attribute(self, getattribute, name);
+        Py_DECREF(getattribute);
+    }
+#if PYSTON_SPEEDUPS
+    if (res == NULL && (!PyErr_Occurred() || PyErr_ExceptionMatches(PyExc_AttributeError))) {
+#else
+    if (res == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+#endif
+        PyErr_Clear();
+        res = call_attribute(self, getattr, name);
+    }
+    Py_DECREF(getattr);
+    return res;
+}


### PR DESCRIPTION
On flaskblogging:
- LTO + PGO: about 0.8% combined (mostly lto)
- Reenable caches for classes with `__getattr__` but not `__getattribute__`: 2.4%
- Copy in some function definitions so that they can get inlined: 0.8%

I did the lto+pgo work in the makefile, I'll convert that over to setup.py next