### PR TITLE
pyston_lite: enable LA_CACHE_VALUE_CACHE_DICT for the case where the attribute comes from the class

### DIFF
--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -1515,20 +1515,16 @@ setupLoadAttrCache(PyObject* obj, PyObject* name, _PyOpcache *co_opcache, PyObje
         la->cache_type = LA_CACHE_BUILTIN;
         la->type = tp;
     } else {
+#ifndef PYSTON_LITE
         // guard on the instance dict shape if the instance dict is a splitdict and does not contain the attribute name as key.
         // else we will create guard which will check for the exact dict version (=less generic)
         int is_split_dict = dict && _PyDict_HasSplitTable((PyDictObject*)dict);
-#ifdef PYSTON_LITE
-        if (is_split_dict) {
-            return -1;
-        }
-#else
         if (is_split_dict && _PyDict_GetItemIndexSplitDict(dict, name) == -1) {
             la->u.value_cache.dict_ver = getSplitDictKeysVersionFromDictPtr(dictptr);
             la->cache_type = LA_CACHE_VALUE_CACHE_SPLIT_DICT;
-        }
+        } else
 #endif
-        else {
+        {
             la->u.value_cache.dict_ver = getDictVersionFromDictPtr(dictptr);
             la->cache_type = LA_CACHE_VALUE_CACHE_DICT;
         }

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -2261,15 +2261,10 @@ static int emit_special_compare_op(Jit* Dst, int oparg, RefStatus ref_status[2])
 }
 
 static int emit_inline_cache_loadattr_is_version_zero(_PyOpcache_LoadAttr *la) {
-#ifdef PYSTON_LITE
     int version_zero = (la->cache_type == LA_CACHE_VALUE_CACHE_DICT && la->u.value_cache.dict_ver == 0);
-#else
-    int version_zero = (la->cache_type == LA_CACHE_VALUE_CACHE_DICT && la->u.value_cache.dict_ver == 0) ||
-        (la->cache_type == LA_CACHE_IDX_SPLIT_DICT && la->u.split_dict_cache.splitdict_keys_version == 0);
-#endif
 
 #ifndef PYSTON_LITE
-    if (version_zero == 1 && la->cache_type == LA_CACHE_IDX_SPLIT_DICT) {
+    if (la->cache_type == LA_CACHE_IDX_SPLIT_DICT && la->u.split_dict_cache.splitdict_keys_version == 0) {
         // This case is currently impossible since it will always be a miss and we don't cache
         // misses, so it's untested.
         fprintf(stderr, "untested jit case");
@@ -2285,7 +2280,6 @@ static int emit_inline_cache_loadattr_supported(_PyOpcache *co_opcache, _PyOpcac
         return 0;
 
     int version_zero = emit_inline_cache_loadattr_is_version_zero(la);
-
     if (la->cache_type != LA_CACHE_BUILTIN && la->cache_type != LA_CACHE_DATA_DESCR && la->cache_type != LA_CACHE_SLOT_CACHE) {
         // fail the cache if dictoffset<0 rather than do the lengthier dict_ptr computation
         if (version_zero) {
@@ -2349,8 +2343,9 @@ static void emit_inline_cache_loadattr_entry(Jit* Dst, int opcode, int oparg, _P
             emit_load64_mem(Dst, arg2_idx, arg1_idx, la->type_tp_dictoffset);
             emit_cmp64_imm(Dst, arg2_idx, 0);
             if (version_zero) {
-                // null dict is always a cache hit
-                | branch_eq >2
+                // non-null dict is always a cache miss
+                | branch_ne >1
+                // we are finished and fallthrough to 2
             } else {
                 // null dict is always a cache miss
                 | branch_eq >1
@@ -2425,7 +2420,7 @@ static void emit_inline_cache_loadattr_entry(Jit* Dst, int opcode, int oparg, _P
             la->cache_type == LA_CACHE_VALUE_CACHE_SPLIT_DICT ||
 #endif
             la->cache_type == LA_CACHE_BUILTIN) {
-        if (version_zero && la->type_tp_dictoffset == 0) {
+        if (version_zero) {
             // Already guarded
         }
 #ifndef PYSTON_LITE


### PR DESCRIPTION
This catches some of the cases like this:
```python
    class Foo:
      a = 1
    foo = Foo()
    foo.a #<--
```
Unfortunately the instance dict will often change so this cache will frequently miss (but this also enabled the
normal caching code to handle it so as long as the instance dict is stable for at least a few iterations it will help).
Can you please confirm that you are not seeing a perf regression - my numbers are changing a lot but I did see a small performance increase.

