### PR TITLE
A new LOAD_GLOBAL cache

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -35,10 +35,9 @@ enum _PyOpcache_LoadAttr_Types {
     // (only used if the more powerful LA_CACHE_IDX_SPLIT_DICT or LA_CACHE_VALUE_CACHE_SPLIT_DICT is not possible)
     LA_CACHE_VALUE_CACHE_DICT = 0,
 
-#ifndef NO_DKVERSION
     // caching an index inside instance splitdict, guarded by the splitdict keys version (dict->ma_keys->dk_version_tag)
+    // if available, otherwise by the keys pointer value.
     LA_CACHE_IDX_SPLIT_DICT = 1,
-#endif
 
     // caching a data descriptor object, guarded by data descriptor types version
     LA_CACHE_DATA_DESCR = 2,
@@ -106,12 +105,14 @@ typedef struct {
             uint64_t dk_version;
         } value_cache_split;
 #endif
-#ifndef NO_DKVERSION
         struct {
+#ifdef NO_DKVERSION
+            void* keys_obj;
+#else
             uint64_t splitdict_keys_version;  /* dk_version_tag of dict */
+#endif
             Py_ssize_t splitdict_index;  /* index into dict value array */
         } split_dict_cache;
-#endif
         struct {
             PyObject *descr;  /* Cached pointer (borrowed reference) */
             uint64_t descr_type_ver;  /* tp_version_tag of the descriptor type */

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -94,10 +94,16 @@ typedef struct {
         } value_cache;
 #ifdef NO_DKVERSION
         struct {
-            PyObject *obj;  /* Cached pointer (borrowed reference) */
-            // TODO maybe we can use the bottom bits of obj and keys_obj to store dk_nentries?
-            void* keys_obj;
-            Py_ssize_t dk_nentries;
+            // This struct notionally stores the following fields:
+            // PyObject *obj;
+            // void* keys_obj;
+            // Py_ssize_t dk_nentries;
+            // But since that would make this the largest struct in the union,
+            // we try a bit harder to save space. Both obj and keys_obj are
+            // 16-bit aligned, so we steal the bottom 4 bits of each to store dk_nentries,
+            // and punt on caching this cache type if there are >=256 attributes
+            uintptr_t obj_and_nentries;
+            uintptr_t keysobj_and_nentries;
         } value_cache_split;
 #else
         struct {

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1492,6 +1492,24 @@ PyObject* _PyDict_GetItemByOffset(PyDictObject *mp, PyObject *key, Py_ssize_t dk
     return ep->me_value;
 }
 
+PyObject* _PyDict_GetItemByOffsetSplit(PyDictObject *mp, PyObject *key, Py_ssize_t dk_size, int64_t ix) {
+    assert(PyDict_CheckExact((PyObject*)mp));
+    assert(PyUnicode_CheckExact(key));
+    assert(offset >= 0);
+
+    if (mp->ma_keys->dk_size != dk_size)
+        return NULL;
+
+    if (mp->ma_keys->dk_lookup != lookdict_split)
+        return NULL;
+
+    PyDictKeyEntry *ep = DK_ENTRIES(mp->ma_keys) + ix;
+    if (ep->me_key != key)
+        return NULL;
+
+    return mp->ma_values[ix];
+}
+
 int64_t _PyDict_GetItemOffset(PyDictObject *mp, PyObject *key, Py_ssize_t *dk_size)
 {
     Py_hash_t hash;
@@ -1518,6 +1536,34 @@ int64_t _PyDict_GetItemOffset(PyDictObject *mp, PyObject *key, Py_ssize_t *dk_si
 
     *dk_size = mp->ma_keys->dk_size;
     return (char*)(&DK_ENTRIES(mp->ma_keys)[ix]) - (char*)mp->ma_keys->dk_indices;
+}
+
+int64_t _PyDict_GetItemOffsetSplit(PyDictObject *mp, PyObject *key, Py_ssize_t *dk_size)
+{
+    Py_hash_t hash;
+
+    assert(PyDict_CheckExact((PyObject*)mp));
+    assert(PyUnicode_CheckExact(key));
+
+    if ((hash = ((PyASCIIObject *) key)->hash) == -1)
+        return -1;
+
+    if (mp->ma_keys->dk_lookup != lookdict_split)
+        return -1;
+
+    // don't cache if error is set because we could overwrite it
+    if (PyErr_Occurred())
+        return -1;
+
+    PyObject *value = NULL;
+    Py_ssize_t ix = (mp->ma_keys->dk_lookup)(mp, key, hash, &value);
+    if (ix < 0) {
+        PyErr_Clear();
+        return -1;
+    }
+
+    *dk_size = mp->ma_keys->dk_size;
+    return ix;
 }
 
 PyObject *

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -3622,16 +3622,26 @@ sa_common:
                 if (co_opcache != NULL && co_opcache->optimized > 0) {
                     _PyOpcache_LoadGlobal *lg = &co_opcache->u.lg;
 
-                    if (lg->globals_ver ==
-                            ((PyDictObject *)f->f_globals)->ma_version_tag
-                        && (lg->builtins_ver == LOADGLOBAL_WAS_GLOBAL ||
-                            lg->builtins_ver == ((PyDictObject *)f->f_builtins)->ma_version_tag))
+                    PyObject *ptr = NULL;
+                    if (lg->cache_type == LG_GLOBAL) {
+                        if (lg->u.global_cache.globals_ver == ((PyDictObject *)f->f_globals)->ma_version_tag)
+                            ptr = lg->u.global_cache.ptr;
+                    } else if (lg->cache_type == LG_BUILTIN) {
+                        if (lg->u.builtin_cache.globals_ver == ((PyDictObject *)f->f_globals)->ma_version_tag &&
+                                lg->u.builtin_cache.builtins_ver == ((PyDictObject *)f->f_builtins)->ma_version_tag)
+                            ptr = lg->u.builtin_cache.ptr;
+                    } else if (lg->cache_type == LG_GLOBAL_OFFSET) {
+                        ptr = _PyDict_GetItemByOffset((PyDictObject*)f->f_globals, name, lg->u.global_offset_cache.dk_size, lg->u.global_offset_cache.offset);
+                    } else {
+                        abort();
+                    }
+
+                    if (ptr)
                     {
 #if OPCACHE_STATS
                         loadglobal_hits++;
 #endif
                         co_opcache->num_failed = 0;
-                        PyObject *ptr = lg->ptr;
                         OPCACHE_STAT_GLOBAL_HIT();
                         assert(ptr != NULL);
                         Py_INCREF(ptr);
@@ -3674,14 +3684,30 @@ sa_common:
                     }
 
                     co_opcache->optimized = 1;
-                    lg->globals_ver =
-                        ((PyDictObject *)f->f_globals)->ma_version_tag;
-                    if (wasglobal)
-                        lg->builtins_ver = LOADGLOBAL_WAS_GLOBAL;
-                    else
-                        lg->builtins_ver =
+                    if (wasglobal && co_opcache->num_failed >= 2 && !_PyDict_HasSplitTable((PyDictObject*)f->f_globals)) {
+                        Py_ssize_t dk_size;
+                        int64_t offset = _PyDict_GetItemOffset((PyDictObject*)f->f_globals, name, &dk_size);
+
+                        if (offset >= 0) {
+                            lg->u.global_offset_cache.dk_size = dk_size;
+                            lg->u.global_offset_cache.offset = offset;
+                            lg->cache_type = LG_GLOBAL_OFFSET;
+                        } else {
+                            co_opcache->optimized = 0;
+                        }
+                    } else if (wasglobal) {
+                        lg->cache_type = LG_GLOBAL;
+                        lg->u.global_cache.globals_ver =
+                            ((PyDictObject *)f->f_globals)->ma_version_tag;
+                        lg->u.global_cache.ptr = v; /* borrowed */
+                    } else {
+                        lg->cache_type = LG_BUILTIN;
+                        lg->u.builtin_cache.globals_ver =
+                            ((PyDictObject *)f->f_globals)->ma_version_tag;
+                        lg->u.builtin_cache.builtins_ver =
                             ((PyDictObject *)f->f_builtins)->ma_version_tag;
-                    lg->ptr = v; /* borrowed */
+                        lg->u.builtin_cache.ptr = v; /* borrowed */
+                    }
                 }
 
                 Py_INCREF(v);

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -280,10 +280,8 @@ PyObject* cmp_outcomePyCmp_EXC_MATCH(PyObject *v, PyObject *w);
 
 int eval_breaker_jit_helper();
 PyObject* loadAttrCacheAttrNotFound(PyObject *owner, PyObject *name);
-#ifndef PYSTON_LITE
 int setItemSplitDictCache(PyObject* dict, Py_ssize_t splitdict_index, PyObject* v, PyObject* name);
 int setItemInitSplitDictCache(PyObject** dictptr, PyObject* obj, PyObject* v, Py_ssize_t splitdict_index,PyObject* name);
-#endif
 
 PyObject * import_name(PyThreadState *, PyFrameObject *,
                               PyObject *, PyObject *, PyObject *);
@@ -2975,13 +2973,11 @@ static int emit_inline_cache(Jit* Dst, int opcode, int oparg, _PyOpcache* co_opc
         ++jit_stat_store_attr_total;
         _PyOpcache_StoreAttr *sa = &co_opcache->u.sa;
         if (co_opcache->num_failed == 0 && sa->type_ver != 0 && co_opcache->optimized) {
-#ifndef PYSTON_LITE
             if ((sa->cache_type == SA_CACHE_IDX_SPLIT_DICT || sa->cache_type == SA_CACHE_IDX_SPLIT_DICT_INIT)
                 && sa->type_tp_dictoffset <= 0) {
                 // fail the cache if dictoffset<=0 rather than do the lengthier dict_ptr computation
                 return -1;
             }
-#endif
 
             ++jit_stat_store_attr_inline;
 
@@ -3001,7 +2997,6 @@ static int emit_inline_cache(Jit* Dst, int opcode, int oparg, _PyOpcache* co_opc
                 }
                 emit_xdecref(Dst, res_idx);
             } else {
-#ifndef PYSTON_LITE
                 if (sa->cache_type == SA_CACHE_IDX_SPLIT_DICT) {
                     // arg1 = *(obj + dictoffset)
                     emit_load64_mem(Dst, arg1_idx, arg2_idx, sa->type_tp_dictoffset);
@@ -3014,7 +3009,11 @@ static int emit_inline_cache(Jit* Dst, int opcode, int oparg, _PyOpcache* co_opc
                     // _PyDict_GetDictKeyVersionFromSplitDict:
                     // arg5 = arg1->ma_keys
                     emit_load64_mem(Dst, arg5_idx, arg1_idx, offsetof(PyDictObject, ma_keys));
+#ifdef NO_DKVERSION
+                    emit_cmp64_imm(Dst, arg5_idx, (uint64_t)sa->u.split_dict_cache.keys_obj);
+#else
                     emit_cmp64_mem_imm(Dst, arg5_idx, offsetof(PyDictKeysObject, dk_version_tag), (uint64_t)sa->u.split_dict_cache.splitdict_keys_version);
+#endif
                     | branch_ne >1
 
                     if (ref_status[0] == OWNED) {
@@ -3039,8 +3038,12 @@ static int emit_inline_cache(Jit* Dst, int opcode, int oparg, _PyOpcache* co_opc
                     emit_cmp64_imm(Dst, arg4_idx, 0);
                     | branch_eq >1
 
+#ifdef NO_DKVERSION
+                    emit_cmp64_imm(Dst, arg5_idx, (uint64_t)sa->u.split_dict_cache.keys_obj);
+#else
                     //if (_PyDict_GetDictKeyVersionFromKeys((PyObject*)keys) != sa->u.split_dict_cache.splitdict_keys_version)
                     emit_cmp64_mem_imm(Dst, arg4_idx, offsetof(PyDictKeysObject, dk_version_tag), (uint64_t)sa->u.split_dict_cache.splitdict_keys_version);
+#endif
                     | branch_ne >1
 
                     emit_mov_imm2(Dst, arg4_idx, (void*)sa->u.split_dict_cache.splitdict_index,
@@ -3048,8 +3051,6 @@ static int emit_inline_cache(Jit* Dst, int opcode, int oparg, _PyOpcache* co_opc
                     emit_call_decref_args2(Dst, setItemInitSplitDictCache, arg2_idx, arg3_idx, ref_status);
                     emit_if_res_32b_not_0_error(Dst);
                 }
-
-#endif
             }
             if (jit_stats_enabled) {
                 emit_inc_qword_ptr(Dst, &jit_stat_store_attr_hit, 1 /*=can use tmp_reg*/);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2522,12 +2522,12 @@ main_loop:
                 if (co_opcache != NULL && co_opcache->optimized > 0) {
                     _PyOpcache_LoadGlobal *lg = &co_opcache->u.lg;
 
-                    if (lg->globals_ver ==
+                    if (lg->u.builtin_cache.globals_ver ==
                             ((PyDictObject *)f->f_globals)->ma_version_tag
-                        && lg->builtins_ver ==
+                        && lg->u.builtin_cache.builtins_ver ==
                            ((PyDictObject *)f->f_builtins)->ma_version_tag)
                     {
-                        PyObject *ptr = lg->ptr;
+                        PyObject *ptr = lg->u.builtin_cache.ptr;
                         OPCACHE_STAT_GLOBAL_HIT();
                         assert(ptr != NULL);
                         Py_INCREF(ptr);
@@ -2561,11 +2561,11 @@ main_loop:
                     }
 
                     co_opcache->optimized = 1;
-                    lg->globals_ver =
+                    lg->u.builtin_cache.globals_ver =
                         ((PyDictObject *)f->f_globals)->ma_version_tag;
-                    lg->builtins_ver =
+                    lg->u.builtin_cache.builtins_ver =
                         ((PyDictObject *)f->f_builtins)->ma_version_tag;
-                    lg->ptr = v; /* borrowed */
+                    lg->u.builtin_cache.ptr = v; /* borrowed */
                 }
 
                 Py_INCREF(v);

--- a/pyston/pyston_lite/lib.c
+++ b/pyston/pyston_lite/lib.c
@@ -314,6 +314,18 @@ int64_t _PyDict_GetItemOffsetSplit(PyDictObject *mp, PyObject *key, Py_ssize_t *
     return ix;
 }
 
+Py_ssize_t
+_PyDict_GetItemIndexSplitDict(PyObject *op, PyObject *key) {
+    PyDictObject* mp = (PyDictObject *)op;
+    Py_hash_t hash = ((PyASCIIObject *) key)->hash;
+    PyObject *value;
+
+    // this should always be set because we will get only here if a previous lookup succeeded
+    // and the keys are static unicode strings
+    assert(hash != -1);
+
+    return (mp->ma_keys->dk_lookup)(mp, key, hash, &value);
+}
 
 PyObject * _Py_HOT_FUNCTION
 call_function_ceval_fast(PyThreadState *tstate, PyObject ***pp_stack, Py_ssize_t oparg, PyObject *kwnames)

--- a/pyston/pyston_lite/lib.c
+++ b/pyston/pyston_lite/lib.c
@@ -314,6 +314,13 @@ int64_t _PyDict_GetItemOffsetSplit(PyDictObject *mp, PyObject *key, Py_ssize_t *
     return ix;
 }
 
+PyObject *
+_PyDict_GetItemFromSplitDict(PyObject *op, Py_ssize_t index) {
+    PyDictObject* mp = (PyDictObject *)op;
+    assert(index >= 0);
+    return mp->ma_values[index];
+}
+
 Py_ssize_t
 _PyDict_GetItemIndexSplitDict(PyObject *op, PyObject *key) {
     PyDictObject* mp = (PyDictObject *)op;

--- a/pyston/pyston_lite/lib.c
+++ b/pyston/pyston_lite/lib.c
@@ -327,6 +327,160 @@ _PyDict_GetItemIndexSplitDict(PyObject *op, PyObject *key) {
     return (mp->ma_keys->dk_lookup)(mp, key, hash, &value);
 }
 
+#define MAINTAIN_TRACKING(mp, key, value) \
+    do { \
+        if (!_PyObject_GC_IS_TRACKED(mp)) { \
+            if (_PyObject_GC_MAY_BE_TRACKED(key) || \
+                _PyObject_GC_MAY_BE_TRACKED(value)) { \
+                _PyObject_GC_TRACK(mp); \
+            } \
+        } \
+    } while(0)
+
+#define CACHED_KEYS(tp) (((PyHeapTypeObject*)tp)->ht_cached_keys)
+
+#ifdef DEBUG_PYDICT
+#  define ASSERT_CONSISTENT(op) assert(_PyDict_CheckConsistency((PyObject *)(op), 1))
+#else
+#  define ASSERT_CONSISTENT(op) assert(_PyDict_CheckConsistency((PyObject *)(op), 0))
+#endif
+
+#define new_values(size) PyMem_NEW(PyObject *, size)
+#define free_values(values) PyMem_FREE(values)
+
+#define USABLE_FRACTION(n) (((n) << 1)/3)
+
+#define PyDict_MINSIZE 8
+
+// Pyston: I can't find a way to access CPython's pydict_global_version field,
+// but it should be ok if we maintain our own counter which will never overlap with theirs.
+static uint64_t pydict_global_version = 1LL << 63;
+#define DICT_NEXT_VERSION() (++pydict_global_version)
+
+// Pyston: Similarly we have to maintain our own freelist:
+#define PyDict_MAXFREELIST 80
+static PyDictObject *free_list[PyDict_MAXFREELIST];
+static int numfree = 0;
+static PyDictKeysObject *keys_free_list[PyDict_MAXFREELIST];
+static int numfreekeys = 0;
+
+static PyObject *empty_values[1] = { NULL };
+
+static void
+free_keys_object(PyDictKeysObject *keys)
+{
+    PyDictKeyEntry *entries = DK_ENTRIES(keys);
+    Py_ssize_t i, n;
+    for (i = 0, n = keys->dk_nentries; i < n; i++) {
+        Py_XDECREF(entries[i].me_key);
+        Py_XDECREF(entries[i].me_value);
+    }
+    if (keys->dk_size == PyDict_MINSIZE && numfreekeys < PyDict_MAXFREELIST) {
+        keys_free_list[numfreekeys++] = keys;
+        return;
+    }
+    PyObject_FREE(keys);
+}
+
+static inline void
+dictkeys_incref(PyDictKeysObject *dk)
+{
+    _Py_INC_REFTOTAL;
+    dk->dk_refcnt++;
+}
+
+static inline void
+dictkeys_decref(PyDictKeysObject *dk)
+{
+    assert(dk->dk_refcnt > 0);
+    _Py_DEC_REFTOTAL;
+    if (--dk->dk_refcnt == 0) {
+        free_keys_object(dk);
+    }
+}
+
+static PyObject *
+new_dict(PyDictKeysObject *keys, PyObject **values)
+{
+    PyDictObject *mp;
+    assert(keys != NULL);
+    if (numfree) {
+        mp = free_list[--numfree];
+        assert (mp != NULL);
+        assert (Py_TYPE(mp) == &PyDict_Type);
+        _Py_NewReference((PyObject *)mp);
+    }
+    else {
+        mp = PyObject_GC_New(PyDictObject, &PyDict_Type);
+        if (mp == NULL) {
+            dictkeys_decref(keys);
+            if (values != empty_values) {
+                free_values(values);
+            }
+            return NULL;
+        }
+    }
+    mp->ma_keys = keys;
+    mp->ma_values = values;
+    mp->ma_used = 0;
+    mp->ma_version_tag = DICT_NEXT_VERSION();
+    ASSERT_CONSISTENT(mp);
+    return (PyObject *)mp;
+}
+
+static PyObject *
+new_dict_with_shared_keys(PyDictKeysObject *keys)
+{
+    PyObject **values;
+    Py_ssize_t i, size;
+
+    size = USABLE_FRACTION(DK_SIZE(keys));
+    values = new_values(size);
+    if (values == NULL) {
+        dictkeys_decref(keys);
+        return PyErr_NoMemory();
+    }
+    for (i = 0; i < size; i++) {
+        values[i] = NULL;
+    }
+    return new_dict(keys, values);
+}
+
+int
+_PyDict_SetItemFromSplitDict(PyObject *op, PyObject *key, Py_ssize_t index, PyObject* value) {
+    PyDictObject* mp = (PyDictObject *)op;
+    PyObject* old_val = mp->ma_values[index];
+
+    // we have to do the slow thing will convert splitdict to regular one
+    if (old_val == NULL && mp->ma_used != index)
+        return PyDict_SetItem(op, key, value);
+
+    Py_INCREF(value);
+    mp->ma_values[index] = value;
+
+    if (old_val == NULL) {
+        /* pending state */
+        assert(index == mp->ma_used);
+        mp->ma_used++;
+    } else
+        Py_DECREF(old_val);
+
+    if (old_val != value)
+        mp->ma_version_tag = DICT_NEXT_VERSION();
+    MAINTAIN_TRACKING(mp, key, value);
+    return 0;
+}
+
+int
+_PyDict_SetItemInitialFromSplitDict(PyTypeObject *tp, PyObject **dictptr, PyObject* key, Py_ssize_t index, PyObject* value) {
+    PyObject *dict;
+    dictkeys_incref(CACHED_KEYS(tp));
+    *dictptr = dict = new_dict_with_shared_keys(CACHED_KEYS(tp));
+    if (dict == NULL)
+        return -1;
+    return _PyDict_SetItemFromSplitDict(dict, key, index, value);
+}
+
 PyObject * _Py_HOT_FUNCTION
 call_function_ceval_fast(PyThreadState *tstate, PyObject ***pp_stack, Py_ssize_t oparg, PyObject *kwnames)
 {

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -110,7 +110,7 @@ ext = Extension(
         "pyston_lite",
         sources=["aot_ceval.c", "aot_ceval_jit.gen.c", "aot_ceval_jit_helper.c", "lib.c"],
         include_dirs=["../../pyston/LuaJIT", os.path.join(sysconfig.get_python_inc(), "internal")],
-        define_macros=[("PYSTON_LITE", None), ("PYSTON_SPEEDUPS", "1"), ("Py_BUILD_CORE", None), ("ENABLE_AOT", None)],
+        define_macros=[("PYSTON_LITE", None), ("PYSTON_SPEEDUPS", "1"), ("Py_BUILD_CORE", None), ("ENABLE_AOT", None), ("NO_DKVERSION", None)],
         extra_compile_args=["-std=gnu99", "-flto", "-fuse-linker-plugin", "-ffat-lto-objects", "-flto-partition=none", "-fno-semantic-interposition", "-specs=../tools/no-pie-compile.specs", "-fno-reorder-blocks-and-partition"],
         extra_link_args=["-flto", "-fuse-linker-plugin", "-ffat-lto-objects", "-flto-partition=none", "-fno-semantic-interposition", "-specs=../tools/no-pie-link.specs", "-Wl,--emit-relocs"],
 )

--- a/pyston/test/caches.py
+++ b/pyston/test/caches.py
@@ -119,7 +119,7 @@ def main():
     # Scanning different number of iters to try to test different opcache/jit combinations
     for i in range(15):
         iters = int(1.5 * (1 << i))
-        print("Testing with %d iters" % iters)
+        # print("Testing with %d iters" % iters)
         testLoadMethodCache(iters)
 
 main()
@@ -219,3 +219,44 @@ def test_splitdict_unset():
     except AttributeError:
         pass
 test_splitdict_unset()
+
+
+def test_splitdict_fromtype():
+    """
+    tests some edge cases around getting attributes
+    from the type when the instances have split dicts
+    """
+
+    class C:
+        def __init__(self):
+            self.x = 2
+            self.y = 2
+
+        def f(self):
+            return 1
+
+    def f():
+        c2 = C()
+
+        def g(c):
+            return c.f()
+
+        for i in range(1000):
+            g(c2)
+
+        assert g(c2) == 1
+        c3 = C()
+        c3.f = lambda: 2
+        assert g(c3) == 2, g(c3)
+
+        def h(c):
+            return c.f()
+
+        for i in range(1000):
+            h(c3)
+
+        assert h(c3) == 2
+        assert h(c2) == 1
+
+    f()
+test_splitdict_fromtype()


### PR DESCRIPTION
This is on top of #239

It uses our OFFSET approach, where we store the offset in
the hashtable and then check to make sure the same key
is still stored there. This lets it work for cases that
the globals are being reassigned.

This new cache type is about twice as fast as no-cache, and
and the directly-cache-the-value type is twice again as fast.

Faster CPython does this by guarding on the keys version, which
we could also do (would be faster than this new cache type, and
would also allow caching builtin lookups when globals change),
but I don't think there's an easy way to get that to work for pyston-lite so I just did this one for now