### PR TITLE
pyston_lite: create cibuildwheel buildbot

### DIFF
--- a/.github/workflows/build_pyston_lite_wheels.yml
+++ b/.github/workflows/build_pyston_lite_wheels.yml
@@ -1,0 +1,61 @@
+name: Build pyston_lite wheels
+
+on: [workflow_dispatch]
+
+jobs:
+  build_pyston_lite_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # we use 'make package_jit' on linux
+        #os: [ubuntu-20.04, macos-11]
+        os: [macos-11]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: checkout submodules
+        run: |
+          git submodule update --init pyston/LuaJIT
+
+      - name: checkout BOLT
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          git submodule update --init pyston/bolt
+          # we can't build BOLT here because it must be build inside the docker or we will see some shared library error.
+
+      - name: install macOS dependencies
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: |
+          curl https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg -o python.pkg
+          sudo installer -pkg python.pkg -target /
+
+          brew install luajit-openresty gcc@11
+          ln -s /usr/local/opt/luajit-openresty/bin/luajit /usr/local/bin/
+          echo "CC=gcc-11" >> $GITHUB_ENV
+
+      - name: create pyston_lite_autoload wheel
+        working-directory: pyston/pyston_lite
+        run: |
+          make package_autoload
+          mkdir wheelhouse/
+          cp autoload/dist/pyston_lite_autoload* wheelhouse/
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.6.0
+        with:
+          package-dir: pyston/pyston_lite
+        env:
+          CIBW_BUILD: cp38-*
+          CIBW_SKIP: "*_i686 *musllinux*"
+          CIBW_BUILD_VERBOSITY: 2
+          CIBW_BEFORE_ALL_LINUX: yum install -y luajit; make bolt -j`nproc`
+          CIBW_TEST_COMMAND: pip install {package}/wheelhouse/pyston_lite_autoload*.tar.gz && python -m test -j0 -x test_code test_distutils test_ensurepip test_minidom test_site test_xml_etree test_xml_etree_c test_capi test_bdb test_c_locale_coercion test_ctypes test_importlib test_ssl test_sysconfig
+          # pyston does not work on macos before 11 (e.g. 10.15).
+          # If we specify 11 here default pip version says it's not compatible, in order to workaround it
+          # we specify 10.16 which does not really exist because it got renamed to 11.
+          CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=10.16
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/

--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -148,3 +148,25 @@ jobs:
           NOPGO: "1"
           NOBOLT: "1"
 
+  pyston_lite_macos:
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v2
+      - name: checkout submodules
+        run: |
+          git submodule update --init pyston/LuaJIT
+      - name: run code
+        run: |
+          brew install gcc@11 luajit-openresty
+          export PATH="/usr/local/opt/luajit-openresty/bin:$PATH"
+          # gcc-11 is already in path
+
+          # install official python3.8 package
+          curl https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg -o python.pkg
+          sudo installer -pkg python.pkg -target /
+
+          cd pyston/pyston_lite
+
+          # pyston must be compiled by gcc not clang
+          CC=gcc-11 make test
+          SHOW_JIT_STATS=1 ./env/bin/python ../test/inplace_math.py

--- a/Include/internal/aot_ceval_jit_helper.h
+++ b/Include/internal/aot_ceval_jit_helper.h
@@ -21,11 +21,22 @@ extern "C" {
 #define JIT_HELPER_WITH_NAME_OPCACHE_AOT1(name_, py1) PyObject* JIT_HELPER_##name_(PyObject* name, PyObject* py1, _PyOpcache *co_opcache)
 #define JIT_HELPER_WITH_NAME_OPCACHE_AOT2(name_, py1, py2) PyObject* JIT_HELPER_##name_(PyObject* name, PyObject* py1, PyObject* py2, _PyOpcache *co_opcache)
 
+// on apple arm64 we can't have a writable and executable page at the same time.
+// instead the provide an api to quickly change the protection.
+#if __APPLE__ && __aarch64__
+#define JIT_MEM_RW() pthread_jit_write_protect_np(0)
+#define JIT_MEM_RX() pthread_jit_write_protect_np(1)
+#else
+#define JIT_MEM_RW()
+#define JIT_MEM_RX()
+#endif
+
 /* this directly modifies the destination of the jit generated call instruction */\
 #if __aarch64__
 #define SET_JIT_AOT_FUNC(dst_addr) do { \
     /* retrieve address of the instruction following the call instruction */ \
     unsigned int* ret_addr = (unsigned int*)__builtin_extract_return_addr(__builtin_return_address(0)); \
+    JIT_MEM_RW(); \
     if (ret_addr[-1] == 0xD63F00C0 /* blr x6 */ ) { \
         /* we generated one 'mov' followed by 3 'movk' */ \
         ret_addr[-5] = 0xD2800006 | ((unsigned long)dst_addr&0xFFFF)<<5; \
@@ -38,6 +49,7 @@ extern "C" {
         ret_addr[-1] = 0x94000000 | (((long)dst_addr - (long)&ret_addr[-1])&((1<<29)-1))>>2; \
         __builtin___clear_cache(&ret_addr[-1], &ret_addr[0]); \
     } \
+    JIT_MEM_RX(); \
 } while(0)
 #else
 #define SET_JIT_AOT_FUNC(dst_addr) do { \

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -4742,22 +4742,28 @@ void* jit_func(PyCodeObject* co, PyThreadState* tstate) {
                                MAP_PRIVATE | MAP_ANONYMOUS | map_flags, -1, 0);
         int failed = new_chunk == MAP_FAILED;
 #elif __aarch64__
+        int map_flags = 0;
+#if __linux__
+        // MAP_FIXED_NOREPLACE is available from linux 4.17, but older glibc don't define it.
+        // Older kernel will ignore this flag and will try to allocate the address supplied as hint
+        // but if not possible will just return a different address.
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+        map_flags |= MAP_FIXED_NOREPLACE;
+#elif __APPLE__
+        map_flags |= MAP_JIT;
+#endif
         // we try to allocate a memory block close to our AOT functions, because on ARM64 the relative call insruction 'bl'
         // can only address +-128MB from current IP. And this allows us to use bl for most calls.
         void* new_chunk = MAP_FAILED;
         // try allocate memory 25MB after this AOT func.
         char* start_addr = (char*)(((uint64_t)LAYOUT_TARGET + 25*1024*1024 + 4095) / 4096 * 4096);
         for (int i=0; i<8 && new_chunk == MAP_FAILED; ++i, start_addr += 5*1024*1024) {
-            // MAP_FIXED_NOREPLACE is available from linux 4.17, but older glibc don't define it.
-            // Older kernel will ignore this flag and will try to allocate the address supplied as hint
-            // but if not possible will just return a different address.
             // If the returned adddress does not fix in 32bit we abort the JIT compilation.
-#ifndef MAP_FIXED_NOREPLACE
-#define MAP_FIXED_NOREPLACE 0x100000
-#endif
             new_chunk = mmap(start_addr + mem_bytes_allocated, mem_chunk_bytes_remaining,
                              PROT_READ | PROT_WRITE | PROT_EXEC,
-                             MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+                             MAP_PRIVATE | MAP_ANONYMOUS | map_flags, -1, 0);
         }
         int failed = new_chunk == MAP_FAILED || !can_use_relative_call(new_chunk);
 #else
@@ -4781,6 +4787,8 @@ void* jit_func(PyCodeObject* co, PyThreadState* tstate) {
     mem_chunk_bytes_remaining -= size;
     mem_bytes_used += size;
 
+    JIT_MEM_RW();
+
     int dasm_encode_err = dasm_encode(Dst, mem);
     if (dasm_encode_err) {
 #if JIT_DEBUG
@@ -4798,6 +4806,8 @@ void* jit_func(PyCodeObject* co, PyThreadState* tstate) {
         JIT_ASSERT(IS_32BIT_SIGNED_VAL(offset),"");
         opcode_offset_begin[inst_idx] = (int)offset;
     }
+
+    JIT_MEM_RX();
 
     if (perf_map_file) {
         PyObject *type, *value, *traceback;

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -56,6 +56,10 @@ ifeq ($(shell uname),Darwin)
 # this test errors on macOS (also with stock cpython)
 ADDITIONAL_TESTS_TO_SKIP:=$(ADDITIONAL_TESTS_TO_SKIP) test_ctypes
 endif
+ifeq ($(shell uname -m),arm64) # only triggers on macOS (linux returns aarch64)
+# this tests crash on arm64 macOS (also with stock cpython)
+ADDITIONAL_TESTS_TO_SKIP:=$(ADDITIONAL_TESTS_TO_SKIP) test_dbm test_dbm_ndbm
+endif
 test: env/lite.stamp
 	set -ex; for fn in ../test/*.py; do if [ $$fn = ../test/test_rebuild_packages.py -o $$fn = ../test/test_venvs.py ]; then continue; fi; ./env/bin/python $$fn; done
 	./env/bin/python -c 'import test.support; test.support.check_impl_detail = lambda **kw: False; import test.test_code; test.test_code.test_main()'

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -52,6 +52,10 @@ env/update.stamp: env/lite.stamp
 # A number of other tests in the cpython testsuite fail with the Ubuntu packages, and I'm not sure why.
 # This happens regardless of whether pyston-lite is installed, so just exclude them.
 ADDITIONAL_TESTS_TO_SKIP?=
+ifeq ($(shell uname),Darwin)
+# this test errors on macOS (also with stock cpython)
+ADDITIONAL_TESTS_TO_SKIP:=$(ADDITIONAL_TESTS_TO_SKIP) test_ctypes
+endif
 test: env/lite.stamp
 	set -ex; for fn in ../test/*.py; do if [ $$fn = ../test/test_rebuild_packages.py -o $$fn = ../test/test_venvs.py ]; then continue; fi; ./env/bin/python $$fn; done
 	./env/bin/python -c 'import test.support; test.support.check_impl_detail = lambda **kw: False; import test.test_code; test.test_code.test_main()'

--- a/pyston/pyston_lite/lib.c
+++ b/pyston/pyston_lite/lib.c
@@ -599,16 +599,6 @@ lookup_maybe_method(PyObject *self, _Py_Identifier *attrid, int *unbound)
 }
 
 static PyObject *
-lookup_method_cached(PyObject *self, _Py_Identifier *attrid, int *unbound, PyObject** cache_slot)
-{
-    PyObject *res = lookup_maybe_method_cached(self, attrid, unbound, cache_slot);
-    if (res == NULL && !PyErr_Occurred()) {
-        PyErr_SetObject(PyExc_AttributeError, attrid->object);
-    }
-    return res;
-}
-
-static PyObject *
 lookup_method(PyObject *self, _Py_Identifier *attrid, int *unbound)
 {
     PyObject *res = lookup_maybe_method(self, attrid, unbound);

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -35,7 +35,7 @@ class pyston_build_ext(build_ext):
             return orig_compile_func(obj, src, ext, cc_args, extra_postargs, pp_opts)
         self.compiler._compile = new_compile
 
-        PGO_TESTS_TO_SKIP = "test_posix test_asyncio test_cmd_line_script test_compiler test_concurrent_futures test_ctypes test_dbm_dumb test_dbm_ndbm test_distutils test_ensurepip test_ftplib test_gdb test_httplib test_imaplib test_ioctl test_linuxaudiodev test_multiprocessing test_nntplib test_ossaudiodev test_poplib test_pydoc test_signal test_socket test_socketserver test_ssl test_subprocess test_sundry test_thread test_threaded_import test_threadedtempfile test_threading test_threading_local test_threadsignals test_venv test_zipimport_support test_code test_capi test_multiprocessing_forkserver test_multiprocessing_spawn test_multiprocessing_fork".split()
+        PGO_TESTS_TO_SKIP = "test_posix test_asyncio test_cmd_line_script test_compiler test_concurrent_futures test_ctypes test_dbm test_dbm_dumb test_dbm_ndbm test_distutils test_ensurepip test_ftplib test_gdb test_httplib test_imaplib test_ioctl test_linuxaudiodev test_multiprocessing test_nntplib test_ossaudiodev test_poplib test_pydoc test_signal test_socket test_socketserver test_ssl test_subprocess test_sundry test_thread test_threaded_import test_threadedtempfile test_threading test_threading_local test_threadsignals test_venv test_zipimport_support test_code test_capi test_multiprocessing_forkserver test_multiprocessing_spawn test_multiprocessing_fork".split()
 
         if NOPGO:
             super(pyston_build_ext, self).build_extension(ext)

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -8,6 +8,10 @@ import subprocess
 import sys
 import tempfile
 
+NOBOLT = "NOBOLT" in os.environ or sys.platform == "darwin"
+NOLTO = "NOLTO" in os.environ or sys.platform == "darwin"
+NOPGO = "NOPGO" in os.environ
+
 def check_call(args, **kw):
     print("check_call", " ".join([repr(a) for a in args]), kw)
     return subprocess.check_call(args, **kw)
@@ -33,7 +37,7 @@ class pyston_build_ext(build_ext):
 
         PGO_TESTS_TO_SKIP = "test_posix test_asyncio test_cmd_line_script test_compiler test_concurrent_futures test_ctypes test_dbm_dumb test_dbm_ndbm test_distutils test_ensurepip test_ftplib test_gdb test_httplib test_imaplib test_ioctl test_linuxaudiodev test_multiprocessing test_nntplib test_ossaudiodev test_poplib test_pydoc test_signal test_socket test_socketserver test_ssl test_subprocess test_sundry test_thread test_threaded_import test_threadedtempfile test_threading test_threading_local test_threadsignals test_venv test_zipimport_support test_code test_capi test_multiprocessing_forkserver test_multiprocessing_spawn test_multiprocessing_fork".split()
 
-        if "NOPGO" in os.environ:
+        if NOPGO:
             super(pyston_build_ext, self).build_extension(ext)
         else:
             # Step 1, build with instrumentation:
@@ -74,7 +78,7 @@ class pyston_build_ext(build_ext):
             ext.extra_link_args = extra_link_args
 
 
-        if "NOBOLT" not in os.environ:
+        if not NOBOLT:
             with tempfile.TemporaryDirectory() as dir:
                 envdir = os.path.join(dir, "bolt_env")
                 check_call([sys.executable, "-m", "venv", envdir])
@@ -106,13 +110,29 @@ class pyston_build_ext(build_ext):
 
         super(pyston_build_ext, self).run()
 
+def get_cflags():
+    flags = ["-std=gnu99", "-fno-semantic-interposition", "-specs=../tools/no-pie-compile.specs"]
+    if not NOLTO:
+        flags += ["-flto", "-fuse-linker-plugin", "-ffat-lto-objects", "-flto-partition=none"]
+    if not NOBOLT:
+        flags += ["-fno-reorder-blocks-and-partition"]
+    return flags
+
+def get_ldflags():
+    flags = ["-fno-semantic-interposition", "-specs=../tools/no-pie-link.specs"]
+    if not NOLTO:
+        flags += ["-flto", "-fuse-linker-plugin", "-ffat-lto-objects", "-flto-partition=none"]
+    if not NOBOLT:
+        flags += ["-Wl,--emit-relocs"]
+    return flags
+
 ext = Extension(
         "pyston_lite",
         sources=["aot_ceval.c", "aot_ceval_jit.gen.c", "aot_ceval_jit_helper.c", "lib.c"],
         include_dirs=["../../pyston/LuaJIT", os.path.join(sysconfig.get_python_inc(), "internal")],
         define_macros=[("PYSTON_LITE", None), ("PYSTON_SPEEDUPS", "1"), ("Py_BUILD_CORE", None), ("ENABLE_AOT", None), ("NO_DKVERSION", None)],
-        extra_compile_args=["-std=gnu99", "-flto", "-fuse-linker-plugin", "-ffat-lto-objects", "-flto-partition=none", "-fno-semantic-interposition", "-specs=../tools/no-pie-compile.specs", "-fno-reorder-blocks-and-partition"],
-        extra_link_args=["-flto", "-fuse-linker-plugin", "-ffat-lto-objects", "-flto-partition=none", "-fno-semantic-interposition", "-specs=../tools/no-pie-link.specs", "-Wl,--emit-relocs"],
+        extra_compile_args=get_cflags(),
+        extra_link_args=get_ldflags(),
 )
 
 setup(name="pyston_lite",

--- a/pyston/test/test_code_dealloc.py
+++ b/pyston/test/test_code_dealloc.py
@@ -1,7 +1,8 @@
 import gc
 import resource
+import sys
 
-if __name__ == "__main__":
+if __name__ == "__main__" and sys.platform == "linux":
     resource.setrlimit(resource.RLIMIT_AS, (2<<20, 2<<20))
 
     for i in range(100000):

--- a/pyston/tools/dynasm_preprocess.py
+++ b/pyston/tools/dynasm_preprocess.py
@@ -56,6 +56,7 @@ import sys
 
 ARCHS = {
     "aarch64": "ARM",
+    "arm64": "ARM", # macOS name
     "x86_64": "X86",
 }
 


### PR DESCRIPTION
- the workflow needs to be manually started: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
- enforces that the mac package is not available on 10.15 where pyston_lite currently crashes
- unfortunately we only have x86 CI machines so have to generate the remaining packages manually
- will only show up as workflow after it's merged
- works for linux amd64 too but I disabled it because otherwise we have two ways to build a package and `make package_jit` will also work on arm.
 
for macos arm64 I just manually run the steps in a terminal following the workflow file and created the wheel this way.