### PR TITLE
Get bolt working with the manylinux wheel

### DIFF
--- a/Include/patchlevel.h
+++ b/Include/patchlevel.h
@@ -25,7 +25,7 @@
 
 #define PYSTON_MAJOR_VERSION        2
 #define PYSTON_MINOR_VERSION        3
-#define PYSTON_MICRO_VERSION        3
+#define PYSTON_MICRO_VERSION        4
 
 /* Version as a string */
 #define PY_VERSION              "3.8.12"

--- a/pyston/conda/installer/construct.yaml
+++ b/pyston/conda/installer/construct.yaml
@@ -3,7 +3,7 @@
 # constructor --output-dir release/conda_pkgs pyston/conda/installer
 
 name: PystonConda
-version: 1.2
+version: 1.3
 
 channels:
   - pyston

--- a/pyston/conda/pyston/meta.yaml
+++ b/pyston/conda/pyston/meta.yaml
@@ -1,6 +1,6 @@
 {% set build_num = 13 %} # caution: only reset when python_version changes
 {% set llvm_version = "13.0.1" %}
-{% set pyston_version = "2.3.3" %}
+{% set pyston_version = "2.3.4" %}
 {% set python_version = "3.8.12" %}
 {% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}
 {% set python_version2 = ".".join(python_version.split(".")[:2]) %}

--- a/pyston/conda/pyston_lite/meta.yaml
+++ b/pyston/conda/pyston_lite/meta.yaml
@@ -1,5 +1,5 @@
 {% set build_num = 0 %} # caution: only reset when python_version changes
-{% set pyston_version = "2.3.3" %}
+{% set pyston_version = "2.3.4" %}
 {% set python_version = "3.8" %}
 
 package:

--- a/pyston/conda/python/meta.yaml
+++ b/pyston/conda/python/meta.yaml
@@ -1,5 +1,5 @@
 {% set build_num = 4 %} # caution: only reset when python_version changes
-{% set pyston_version = "2.3.3" %}
+{% set pyston_version = "2.3.4" %}
 {% set python_version = "3.8.12" %}
 {% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}
 {% set python_version2 = ".".join(python_version.split(".")[:2]) %}

--- a/pyston/conda/python_abi/meta.yaml
+++ b/pyston/conda/python_abi/meta.yaml
@@ -1,5 +1,5 @@
 {% set build_num = 2 %} # caution: only reset when python_version changes
-{% set pyston_version = "2.3.3" %}
+{% set pyston_version = "2.3.4" %}
 {% set python_version = "3.8.12" %}
 {% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}
 {% set python_version2 = ".".join(python_version.split(".")[:2]) %}

--- a/pyston/debian/changelog
+++ b/pyston/debian/changelog
@@ -1,3 +1,8 @@
+pyston (2.3.4) unstable; urgency=medium
+
+  * Performance improvements and bugfixes
+
+ -- Kevin Modzelewski <kevmod@gmail.com>  Fri, 03 Jun 2022 17:46:12 +0200
 pyston (2.3.3) unstable; urgency=medium
 
   * First release which supports Arm64 (=aarch64)

--- a/pyston/doc/RELEASING.md
+++ b/pyston/doc/RELEASING.md
@@ -3,8 +3,8 @@
 2. add a `pyston/debian/changelog` entry (make sure the date is correct or the build fails in odd ways)
 3. adjust `PYSTON_*_VERSION` inside `Include/patchlevel.h`
 4. update `pyston/docker/Dockerfile\*` and `pyston/docker/build_docker.sh`
-5. update `pyston/conda/{pyston,python,python_abi}/meta.yaml` and update `build_num` if necessary
-6. update `pyston/conda/installer/construct.yaml`
+5. update `pyston/conda/{pyston,python,python_abi,pyston_lite}/meta.yaml` and update `build_num` if necessary
+6. update "version" `pyston/conda/installer/construct.yaml`
 7. update `pyston/pyston_lite/setup.py` and `pyston/pyston_lite/autoload/setup.py`
 
 In addition if more than only the micro version changes:

--- a/pyston/docker/Dockerfile
+++ b/pyston/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:20.04
 
-ENV PYSTON_VERSION='2.3.3'
+ENV PYSTON_VERSION='2.3.4'
 ENV UBUNTU_VERSION='20.04'
 
 # http://bugs.python.org/issue19846

--- a/pyston/docker/Dockerfile.conda
+++ b/pyston/docker/Dockerfile.conda
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-ENV PYSTON_VERSION='2.3.3'
+ENV PYSTON_VERSION='2.3.4'
 ENV INSTALLER_VERSION='1.1'
 
 RUN set -eux; \

--- a/pyston/docker/Dockerfile.slim-bullseye
+++ b/pyston/docker/Dockerfile.slim-bullseye
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-ENV PYSTON_VERSION='2.3.3'
+ENV PYSTON_VERSION='2.3.4'
 ENV UBUNTU_VERSION='20.04'
 
 # http://bugs.python.org/issue19846

--- a/pyston/docker/build_docker.sh
+++ b/pyston/docker/build_docker.sh
@@ -7,7 +7,7 @@
 
 set -eux
 
-BUILD_NAME=2.3.3
+BUILD_NAME=2.3.4
 DIR=$(dirname $0)
 PLATFORMS=linux/amd64,linux/arm64
 

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -27,6 +27,7 @@ upload_wheels: env
 test_packages:
 	rm -rf /tmp/env
 	$(PYTHON) -m venv /tmp/env
+	/tmp/env/bin/pip install wheel
 	/tmp/env/bin/pip install --upgrade pyston_lite_autoload
 	time /tmp/env/bin/python -c 'for i in range(100000000): pass'
 	DISABLE_PYSTON=1 time /tmp/env/bin/python -c 'for i in range(100000000): pass'

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -5,12 +5,16 @@ PYTHON:=python3.8
 package: package_jit package_autoload
 
 ARCH:=$(shell uname -m)
+ifeq ($(ARCH),x86_64)
+	BOLT_DOCKERFLAGS:=-e BOLTFLAGS=1
+	BOLT_CMD:=python3.8 bolt_wheel.py wheelhouse/*.whl
+endif
 
 package_jit:
 	git clean -x -i -d -f .
 	bash -c 'if [ -d wheelhouse ]; then sudo rm -rf wheelhouse ; fi'
-	docker run --rm -e NOBOLT=1 -e BOLTFLAGS=1 -e PLAT=manylinux2014_$(ARCH) -v `pwd`/../../:/io quay.io/pypa/manylinux2014_$(ARCH) bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/wheelhouse"
-	python3.8 bolt_wheel.py wheelhouse/*.whl
+	docker run -e NOBOLT=1 $(BOLT_DOCKERFLAGS) -e PLAT=manylinux2014_$(ARCH) -v `pwd`/../../:/io quay.io/pypa/manylinux2014_$(ARCH) bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/wheelhouse"
+	$(BOLT_CMD)
 
 package_autoload:
 	bash -c "cd autoload; rm -rf dist; $(PYTHON) setup.py sdist"

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -7,7 +7,7 @@ package: package_jit package_autoload
 ARCH:=$(shell uname -m)
 ifeq ($(ARCH),x86_64)
 	BOLT_DOCKERFLAGS:=-e BOLTFLAGS=1
-	BOLT_CMD:=python3.8 bolt_wheel.py wheelhouse/*.whl
+	BOLT_CMD:=python3 bolt_wheel.py wheelhouse/*.whl
 endif
 
 package_jit:
@@ -26,7 +26,7 @@ upload_wheels: env
 
 test_packages:
 	rm -rf /tmp/env
-	python3.8 -m venv /tmp/env
+	$(PYTHON) -m venv /tmp/env
 	/tmp/env/bin/pip install --upgrade pyston_lite_autoload
 	time /tmp/env/bin/python -c 'for i in range(100000000): pass'
 	DISABLE_PYSTON=1 time /tmp/env/bin/python -c 'for i in range(100000000): pass'

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -7,7 +7,8 @@ package: package_jit package_autoload
 package_jit:
 	git clean -x -i -d -f .
 	bash -c 'if [ -d wheelhouse ]; then sudo rm -rf wheelhouse ; fi'
-	docker run --rm -e PLAT=manylinux2014_x86_64 -v `pwd`/../../:/io quay.io/pypa/manylinux2014_x86_64 bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/wheelhouse"
+	docker run --rm -e NOBOLT=1 -e BOLTFLAGS=1 -e PLAT=manylinux2014_x86_64 -v `pwd`/../../:/io quay.io/pypa/manylinux2014_x86_64 bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/wheelhouse"
+	python3.8 bolt_wheel.py wheelhouse/*.whl
 
 package_autoload:
 	bash -c "cd autoload; rm -rf dist; $(PYTHON) setup.py sdist"

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -4,10 +4,12 @@ PYTHON:=python3.8
 
 package: package_jit package_autoload
 
+ARCH:=$(shell uname -m)
+
 package_jit:
 	git clean -x -i -d -f .
 	bash -c 'if [ -d wheelhouse ]; then sudo rm -rf wheelhouse ; fi'
-	docker run --rm -e NOBOLT=1 -e BOLTFLAGS=1 -e PLAT=manylinux2014_x86_64 -v `pwd`/../../:/io quay.io/pypa/manylinux2014_x86_64 bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/wheelhouse"
+	docker run --rm -e NOBOLT=1 -e BOLTFLAGS=1 -e PLAT=manylinux2014_$(ARCH) -v `pwd`/../../:/io quay.io/pypa/manylinux2014_$(ARCH) bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/wheelhouse"
 	python3.8 bolt_wheel.py wheelhouse/*.whl
 
 package_autoload:

--- a/pyston/pyston_lite/autoload/setup.py
+++ b/pyston/pyston_lite/autoload/setup.py
@@ -36,7 +36,7 @@ class install_with_pth(install):
         if suffix.strip() == self._pth_contents.strip():
             self.install_lib = self.install_libbase
 
-VERSION = "2.3.3.1"
+VERSION = "2.3.4"
 setup(name="pyston_lite_autoload",
       cmdclass={"install": install_with_pth},
       version=VERSION,

--- a/pyston/pyston_lite/bolt_wheel.py
+++ b/pyston/pyston_lite/bolt_wheel.py
@@ -1,0 +1,57 @@
+import glob
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+def check_call(args, **kw):
+    print("check_call", " ".join([repr(a) for a in args]), kw)
+    return subprocess.check_call(args, **kw)
+
+def check_output(args, **kw):
+    print("check_output", " ".join([repr(a) for a in args]), kw)
+    return subprocess.check_output(args, **kw)
+
+def bolt_wheel(wheel):
+    with tempfile.TemporaryDirectory() as dir:
+        envdir = os.path.join(dir, "bolt_env")
+        unzipdir = os.path.join(dir, "unzip")
+
+        check_call(["unzip", wheel, "-d", unzipdir])
+        os.rename(wheel, wheel + ".prebolt")
+
+        sos = glob.glob(os.path.join(unzipdir, "*.so"))
+        assert len(sos) == 1, sos
+        so, = sos
+        os.rename(so, so + ".prebolt")
+
+        check_call([sys.executable, "-m", "venv", envdir])
+
+        env_python = os.path.join(envdir, "bin/python3")
+
+        site_packages = check_output([env_python, "-c", "import site; print(site.getsitepackages()[0])"]).decode("utf8").strip()
+
+        shutil.copy(os.path.join(os.path.dirname(__file__), "autoload/pyston_lite_autoload.pth"), site_packages)
+
+        # ext_name = self.get_ext_fullpath(ext.name)
+        # os.rename(ext_name, ext_name + ".prebolt")
+        install_extname = os.path.join(site_packages, os.path.basename(so))
+        check_call(["../../build/bolt/bin/llvm-bolt", so + ".prebolt", "-instrument", "-instrumentation-file-append-pid", "-instrumentation-file=" + install_extname, "-o", install_extname, "-skip-funcs=_PyEval_EvalFrameDefault,_PyEval_EvalFrame_AOT_Interpreter.*"])
+
+
+        PGO_TESTS_TO_SKIP = "test_posix test_asyncio test_cmd_line_script test_compiler test_concurrent_futures test_ctypes test_dbm test_dbm_dumb test_dbm_ndbm test_distutils test_ensurepip test_ftplib test_gdb test_httplib test_imaplib test_ioctl test_linuxaudiodev test_multiprocessing test_nntplib test_ossaudiodev test_poplib test_pydoc test_signal test_socket test_socketserver test_ssl test_subprocess test_sundry test_thread test_threaded_import test_threadedtempfile test_threading test_threading_local test_threadsignals test_venv test_zipimport_support test_code test_capi test_multiprocessing_forkserver test_multiprocessing_spawn test_multiprocessing_fork".split()
+        subprocess.call([env_python, os.path.join(os.path.dirname(__file__), "../../Lib/test/regrtest.py"), "-j0", "-unone,decimal", "-x"] + PGO_TESTS_TO_SKIP)
+
+        check_call(["../../build/bolt/bin/merge-fdata"] + glob.glob(install_extname + ".*.fdata"), stdout=open(install_extname + ".fdata", "wb"))
+
+        check_call(["../../build/bolt/bin/llvm-bolt", so + ".prebolt", "-o", so, "-data=" + install_extname + ".fdata", "-update-debug-sections", "-reorder-blocks=cache+", "-reorder-functions=hfsort+", "-split-functions=3", "-icf=1", "-inline-all", "-split-eh", "-reorder-functions-use-hot-size", "-peepholes=all", "-jump-tables=aggressive", "-inline-ap", "-indirect-call-promotion=all", "-dyno-stats", "-use-gnu-stack", "-jump-tables=none", "-frame-opt=hot"])
+        os.unlink(so + ".prebolt")
+
+        check_call(["zip", os.path.abspath(wheel), "-r"] + os.listdir(unzipdir), cwd=unzipdir)
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    assert len(args) == 1, args
+    bolt_wheel(args[0])

--- a/pyston/pyston_lite/build_wheels.sh
+++ b/pyston/pyston_lite/build_wheels.sh
@@ -4,7 +4,9 @@ cd $(dirname $0)
 
 PYTHON=/opt/python/cp38-cp38/bin/python3
 
-yum install -y luajit
+make -C ../LuaJIT -j`nproc`
+make -C ../LuaJIT -j`nproc` install
+ln -sf luajit-2.1.0-beta3 /usr/local/bin/luajit
 
 # manylinux2014 doesn't come with a python3 symlink:
 if ! $(which python3) ; then

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -11,6 +11,7 @@ import tempfile
 NOBOLT = "NOBOLT" in os.environ or sys.platform == "darwin"
 NOLTO = "NOLTO" in os.environ or sys.platform == "darwin"
 NOPGO = "NOPGO" in os.environ
+BOLTFLAGS = "BOLTFLAGS" in os.environ
 
 def check_call(args, **kw):
     print("check_call", " ".join([repr(a) for a in args]), kw)
@@ -114,7 +115,7 @@ def get_cflags():
     flags = ["-std=gnu99", "-fno-semantic-interposition", "-specs=../tools/no-pie-compile.specs"]
     if not NOLTO:
         flags += ["-flto", "-fuse-linker-plugin", "-ffat-lto-objects", "-flto-partition=none"]
-    if not NOBOLT:
+    if not NOBOLT or BOLTFLAGS:
         flags += ["-fno-reorder-blocks-and-partition"]
     return flags
 
@@ -122,7 +123,7 @@ def get_ldflags():
     flags = ["-fno-semantic-interposition", "-specs=../tools/no-pie-link.specs"]
     if not NOLTO:
         flags += ["-flto", "-fuse-linker-plugin", "-ffat-lto-objects", "-flto-partition=none"]
-    if not NOBOLT:
+    if not NOBOLT or BOLTFLAGS:
         flags += ["-Wl,--emit-relocs"]
     return flags
 

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -137,7 +137,7 @@ ext = Extension(
 
 setup(name="pyston_lite",
       cmdclass={"build_ext":pyston_build_ext},
-      version="2.3.3.1",
+      version="2.3.4",
       description="A JIT for Python",
       author="The Pyston Team",
       url="https://www.github.com/pyston/pyston",

--- a/pyston/tools/bench_release.sh
+++ b/pyston/tools/bench_release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-VERSION=2.3.3
+VERSION=2.3.4
 INPUT_DIR=${PWD}/release/${VERSION}
 OUTPUT_DIR=`realpath ${INPUT_DIR}/bench`
 ARCH=`dpkg --print-architecture`

--- a/pyston/tools/make_release.sh
+++ b/pyston/tools/make_release.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-VERSION=2.3.3
+VERSION=2.3.4
 SRC_DIR=`git rev-parse --show-toplevel`
 OUTPUT_DIR=${PWD}/release/${VERSION}
 ARCH=`dpkg --print-architecture`


### PR DESCRIPTION
The bolt that has been built on the host does not typically work
inside the manylinux container. We could try to build bolt inside
the container, or maybe we could create a package and install it.

But it seemed easier to just generate a non-bolted wheel, then
run bolt on the host and repackage the wheel.