### PR TITLE
2.3.4: pump build_num for meta packages

### DIFF
--- a/pyston/conda/python/meta.yaml
+++ b/pyston/conda/python/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 4 %} # caution: only reset when python_version changes
+{% set build_num = 5 %} # caution: only reset when python_version changes
 {% set pyston_version = "2.3.4" %}
 {% set python_version = "3.8.12" %}
 {% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}

--- a/pyston/conda/python_abi/meta.yaml
+++ b/pyston/conda/python_abi/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 2 %} # caution: only reset when python_version changes
+{% set build_num = 3 %} # caution: only reset when python_version changes
 {% set pyston_version = "2.3.4" %}
 {% set python_version = "3.8.12" %}
 {% set pyston_version2 = ".".join(pyston_version.split(".")[:2]) %}

--- a/pyston/doc/RELEASING.md
+++ b/pyston/doc/RELEASING.md
@@ -3,7 +3,8 @@
 2. add a `pyston/debian/changelog` entry (make sure the date is correct or the build fails in odd ways)
 3. adjust `PYSTON_*_VERSION` inside `Include/patchlevel.h`
 4. update `pyston/docker/Dockerfile\*` and `pyston/docker/build_docker.sh`
-5. update `pyston/conda/{pyston,python,python_abi,pyston_lite}/meta.yaml` and update `build_num` if necessary
+5. update `pyston/conda/{pyston,python,python_abi,pyston_lite}/meta.yaml` 
+   and update `build_num` if necessary (mandatory for `python` and `python_abi`)
 6. update "version" `pyston/conda/installer/construct.yaml`
 7. update `pyston/pyston_lite/setup.py` and `pyston/pyston_lite/autoload/setup.py`
 


### PR DESCRIPTION
the use the python version number but reference the pyston version which means
we won't generate new meta packages which reference the new pyston version if the build_num stays the same.

I guess we could permanently fix this by integrating the full pyston build number into the build string
but this feels risky doing it now for the release without testing it more.

---
I already pushed the resulting packages `pyston`, `python` and `python_abi` to our pyston channel and it seemed to fix the installer issue where it would package the old version.

