### PR TITLE
I guess rsync skips symlinks by default

### DIFF
--- a/pyston/tools/make_release.sh
+++ b/pyston/tools/make_release.sh
@@ -63,7 +63,7 @@ function make_release {
 set -ex
 
 # make a copy of the source because it's mounted read only and we want to modify it
-rsync -r /src/src_dir_host/ /src/build/ --exclude build
+rsync -rl /src/src_dir_host/ /src/build/ --exclude build
 cd /src/build
 rm -rf build
 git clean -fdx


### PR DESCRIPTION
The build mostly worked except it skipped some of the files in the macrobenchmarks directory, so the bolt task would fail