### PR TITLE
Build ubuntu 22.04 packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,7 @@ ifeq ($(RELEASE),16.04)
 	echo 10 > pyston/debian/compat
 	cd pyston; DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -b -d
 else
-	cd pyston; DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage --build=binary --no-sign --jobs=auto -d
+	cd pyston; DEB_BUILD_OPTIONS="nocheck optimize=-lto" dpkg-buildpackage --build=binary --no-sign --jobs=auto -d
 endif
 
 bench: $(OPT_BENCH_ENV) $(SYSTEM_BENCH_ENV)

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1792,7 +1792,7 @@ Python/aot_ceval_jit_helper.o: Python/aot_ceval_jit_helper.c
 	$(CC) -c $(filter-out -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none,$(PY_CORE_CFLAGS)) -std=gnu99 $(FCF_FLAG) -o $@ $<
 
 aot_optimized.o: $(AOT_DIR)/aot_all.bc
-	@if [ "$(findstring fprofile-generate, $(PY_CORE_CFLAGS))" != "" ]; \
+	@if [ "$(findstring fprofile-generate, $(PY_CORE_CFLAGS))" != "" ] && [ "$(shell lsb_release -sr)" != "22.04" ]; \
 	then \
 		echo "traces are compiled with instrumentation"; \
 		rm -rf $(AOT_DIR)/aot_prof; \

--- a/pyston/make_release_files/Dockerfile.22.04
+++ b/pyston/make_release_files/Dockerfile.22.04
@@ -1,0 +1,35 @@
+FROM ubuntu:22.04
+
+# have to set this else apt will ask for a config for tzdata
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN echo 'deb-src http://archive.ubuntu.com/ubuntu/ jammy main restricted' >> /etc/apt/sources.list
+
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y build-essential ninja-build git cmake clang libssl-dev libsqlite3-dev luajit python3 zlib1g-dev virtualenv libjpeg-dev linux-tools-common linux-tools-generic
+RUN apt-get install -y dh-make dh-exec debhelper patchelf
+RUN apt-get install -y rsync # used by the release script
+
+# we have to set a local else it will use ascii
+RUN apt-get install -y locales
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# if we don't install this option packages our build will have way fewer functions
+# e.g. no libreadline -> no repl history
+RUN apt build-dep -y python3
+
+# install dependencies for the test suite
+RUN apt-get install -y libwebp-dev libjpeg-dev python3-gdbm python3-tk python3-dev tk-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libbz2-dev nginx
+
+# revert bolt patched llvm
+RUN git config --global user.email "you@example.com"
+RUN git config --global user.name "Your Name"
+
+# we don't want default gcc11 instead use gcc9
+RUN apt-get install -y gcc-9 g++-9
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 50
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 50

--- a/pyston/tools/bench_release.sh
+++ b/pyston/tools/bench_release.sh
@@ -12,7 +12,7 @@ then
 fi
 mkdir -p $OUTPUT_DIR
 
-for DIST in 18.04 20.04
+for DIST in 18.04 20.04 22.04
 do
     echo "Benchmarking $DIST release"
     # mount input dir readonly to make sure we are not accidently modifying it
@@ -63,7 +63,7 @@ cat ${OUTPUT_DIR}/pyperformance_diff_20.04_${ARCH}.txt
 for f in ${OUTPUT_DIR}/results_pyston_20.04_${ARCH}/*.out
 do
     echo "benchmark: `basename $f`"
-    for DIST in 18.04 20.04
+    for DIST in 18.04 20.04 22.04
     do
         f_pyston=${f/20.04/$DIST}
         f_cpython=${f_pyston/results_pyston/results_cpython}

--- a/pyston/tools/make_release.sh
+++ b/pyston/tools/make_release.sh
@@ -23,7 +23,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ -z "$RELEASES" ]; then
-    RELEASES="18.04 20.04"
+    RELEASES="18.04 20.04 22.04"
 
     if [ -d $OUTPUT_DIR ]
     then


### PR DESCRIPTION
Unfortunately I run into some issues building 22.04 packages:
- our AOT PGO task is failing with - (producing empty profiles - I disabled it for now):
 >warning: ../aot_pic/aot_prof/default_16542604123857942053_0.profraw: failed to uncompress data (zlib)
error: no profile can be merged

- I'm seeing a lot of:
 >Warning -- files was modified by test_quopri
  Before: []
  After:  ['default.profraw']

I have not tested the performance of the resulting packages. But wanted to put it up as draft before my holiday in case 22.04 packages become a priority in the meantime.

I also noticed that one CFLAGS is different when using 22.04 and can be reverted by setting `DEB_BUILD_OPTIONS="reproducible=-fixfilepath"` but it did not fix the issues I encountered

We have a open issue for 22.04 packages at: https://github.com/pyston/pyston/issues/204