### PR TITLE
Build wheels for pyston_lite_autoload

### DIFF
--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -2,7 +2,7 @@
 
 PYTHON:=python3.8
 
-package: package_jit package_autoload
+package: build_wheels build_autoload_sdist
 
 ARCH:=$(shell uname -m)
 ifeq ($(ARCH),x86_64)
@@ -10,19 +10,19 @@ ifeq ($(ARCH),x86_64)
 	BOLT_CMD:=python3 bolt_wheel.py wheelhouse/*.whl
 endif
 
-package_jit:
+build_wheels:
 	git clean -x -i -d -f .
 	bash -c 'if [ -d wheelhouse ]; then sudo rm -rf wheelhouse ; fi'
-	docker run -e NOBOLT=1 $(BOLT_DOCKERFLAGS) -e PLAT=manylinux2014_$(ARCH) -v `pwd`/../../:/io quay.io/pypa/manylinux2014_$(ARCH) bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/wheelhouse"
+	docker run -e NOBOLT=1 $(BOLT_DOCKERFLAGS) -e PLAT=manylinux2014_$(ARCH) -v `pwd`/../../:/io quay.io/pypa/manylinux2014_$(ARCH) bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/"
 	$(BOLT_CMD)
 
-package_autoload:
+build_autoload_sdist:
 	bash -c "cd autoload; rm -rf dist; $(PYTHON) setup.py sdist"
 
 upload_wheels: env
 	env/bin/pip install twine
 	./env/bin/twine upload autoload/dist/pyston_lite_autoload* || true
-	./env/bin/twine upload wheelhouse/*manylinux*.whl || true
+	./env/bin/twine upload wheelhouse/*.whl || true
 
 test_packages:
 	rm -rf /tmp/env

--- a/pyston/pyston_lite/autoload/setup.py
+++ b/pyston/pyston_lite/autoload/setup.py
@@ -36,7 +36,7 @@ class install_with_pth(install):
         if suffix.strip() == self._pth_contents.strip():
             self.install_lib = self.install_libbase
 
-VERSION = "2.3.4.2"
+VERSION = "2.3.4.4"
 setup(name="pyston_lite_autoload",
       cmdclass={"install": install_with_pth},
       version=VERSION,

--- a/pyston/pyston_lite/autoload/setup.py
+++ b/pyston/pyston_lite/autoload/setup.py
@@ -36,7 +36,7 @@ class install_with_pth(install):
         if suffix.strip() == self._pth_contents.strip():
             self.install_lib = self.install_libbase
 
-VERSION = "2.3.4.1"
+VERSION = "2.3.4.2"
 setup(name="pyston_lite_autoload",
       cmdclass={"install": install_with_pth},
       version=VERSION,

--- a/pyston/pyston_lite/bolt_wheel.py
+++ b/pyston/pyston_lite/bolt_wheel.py
@@ -53,5 +53,8 @@ def bolt_wheel(wheel):
 
 if __name__ == "__main__":
     args = sys.argv[1:]
-    assert len(args) == 1, args
-    bolt_wheel(args[0])
+
+    for a in args:
+        if "none-any" in a:
+            continue
+        bolt_wheel(args[0])

--- a/pyston/pyston_lite/build_wheels.sh
+++ b/pyston/pyston_lite/build_wheels.sh
@@ -1,5 +1,7 @@
 #/bin/sh
 
+set -ex
+
 cd $(dirname $0)
 
 PYTHON=/opt/python/cp38-cp38/bin/python3
@@ -15,9 +17,13 @@ fi
 
 $PYTHON -m pip wheel . --no-deps -w wheelhouse/
 
+$PYTHON -m pip wheel autoload/ --no-deps -w wheelhouse/
+
 rm -rf build pyston_lite.egg-info
 
 for whl in wheelhouse/*.whl; do
-    auditwheel repair $whl --plat $PLAT -w wheelhouse/
-    rm $whl
+    if [[ $whl != *"none-any"* ]]; then
+        auditwheel repair $whl --plat $PLAT -w wheelhouse/
+        rm $whl
+    fi
 done


### PR DESCRIPTION
I thought it was enough to provide a sdist, since there are no build dependencies,
but looks like it runs into the wheel-not-available/pip-too-old issue. Looks like
a basic wheel gets around that

Fixes #254; I uploaded the wheel for 2.3.4.2