### PR TITLE
Install cargo into the github ci

### DIFF
--- a/.github/workflows/unopt_build.sh
+++ b/.github/workflows/unopt_build.sh
@@ -32,6 +32,6 @@ make unopt -j$(nproc)
 # running the tests
 git submodule update --init "pyston/test/*"
 # have to install late because it will update llvm-10 to 13 or so
-sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y rustc
+sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y rustc cargo
 
 make test -j$(nproc)

--- a/pyston/test/external/urllib3_requirements.txt
+++ b/pyston/test/external/urllib3_requirements.txt
@@ -1,5 +1,5 @@
 astroid==2.4.2
-atomicwrites==1.4.0
+atomicwrites==1.4.1
 attrs==20.2.0
 certifi==2020.6.20
 cffi==1.14.3


### PR DESCRIPTION
I'm not sure why this all of a sudden became required.
This is to build cryptography, a Rust extension, but we didn't
change the version of cryptography so I'm not sure why
the build process changed.

This also seems unrelated to the urllib3 flakiness that
I've been investigating.