### PR TITLE
Add aot function for calling python functions

### DIFF
--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -5224,7 +5224,7 @@ exit_eval_frame:
 // Entry point when executing a python function.
 // We check if we can use a JIT compiled version or have to use the Interpreter
 #ifdef PYSTON_LITE
-static PyObject* _Py_HOT_FUNCTION
+PyObject* _Py_HOT_FUNCTION
 _PyEval_EvalFrame_AOT
 #else
 PyObject* _Py_HOT_FUNCTION

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -1360,8 +1360,8 @@ setupLoadAttrCache(PyObject* obj, PyObject* name, _PyOpcache *co_opcache, PyObje
     if (!res)
         return -1;
 
-    if (co_opcache->num_failed >= 5)
-        return -1;
+    //if (co_opcache->num_failed >= 5)
+        //return -1;
 
     if (!PyType_HasFeature(tp, Py_TPFLAGS_VALID_VERSION_TAG))
         return -1;

--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -1360,8 +1360,8 @@ setupLoadAttrCache(PyObject* obj, PyObject* name, _PyOpcache *co_opcache, PyObje
     if (!res)
         return -1;
 
-    //if (co_opcache->num_failed >= 5)
-        //return -1;
+    if (co_opcache->num_failed >= 5)
+        return -1;
 
     if (!PyType_HasFeature(tp, Py_TPFLAGS_VALID_VERSION_TAG))
         return -1;

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -257,6 +257,8 @@ PyObject* cmp_outcomePyCmp_GT(PyObject *v, PyObject *w);
 PyObject* cmp_outcomePyCmp_GE(PyObject *v, PyObject *w);
 PyObject* cmp_outcomePyCmp_IN(PyObject *v, PyObject *w);
 PyObject* cmp_outcomePyCmp_NOT_IN(PyObject *v, PyObject *w);
+
+PyObject* call_function_ceval_no_kwProfile(PyThreadState * tstate, PyObject ** restrict stack, Py_ssize_t oparg);
 #else
 #include "aot.h"
 #endif
@@ -434,7 +436,7 @@ static void* __attribute__ ((const)) get_addr_of_aot_func(int opcode, int oparg,
     OPCODE_PROFILE(BINARY_POWER, PyNumber_PowerNone);
     OPCODE_PROFILE(INPLACE_POWER, PyNumber_InPlacePowerNone);
 
-    OPCODE_PROFILE(CALL_FUNCTION, call_function_ceval_no_kw);
+    OPCODE_PROFILE(CALL_FUNCTION, call_function_ceval_no_kwProfile);
     OPCODE_PROFILE(CALL_METHOD, call_function_ceval_no_kw);
     OPCODE_PROFILE(CALL_FUNCTION_KW, call_function_ceval_kw);
 

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -114,7 +114,7 @@
 #ifdef PYSTON_LITE
 #define ENABLE_DEFINED_TRACKING 0
 #else
-#define ENABLE_DEFINED_TRACKING 0
+#define ENABLE_DEFINED_TRACKING 1
 #endif
 
 #define DEFERRED_VS_MAX         16 /* used by STORE_SUBSCR */

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -114,7 +114,7 @@
 #ifdef PYSTON_LITE
 #define ENABLE_DEFINED_TRACKING 0
 #else
-#define ENABLE_DEFINED_TRACKING 1
+#define ENABLE_DEFINED_TRACKING 0
 #endif
 
 #define DEFERRED_VS_MAX         16 /* used by STORE_SUBSCR */

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -392,10 +392,13 @@ static void* __attribute__ ((const)) get_addr_of_helper_func(int opcode, int opa
 
 static void* __attribute__ ((const)) get_addr_of_aot_func(int opcode, int oparg, int opcache_available) {
     #define OPCODE_STATIC(x, func) if (opcode == x) return (func)
+    #define _OPCODE_PROFILE(x, func) OPCODE_STATIC(x, jit_use_aot ? func##Profile : func)
 #ifdef PYSTON_LITE
     #define OPCODE_PROFILE(x, func) OPCODE_STATIC(x, func)
+    #define OPCODE_PROFILE_LITE(x, func) _OPCODE_PROFILE(x, func)
 #else
-    #define OPCODE_PROFILE(x, func) OPCODE_STATIC(x, jit_use_aot ? func##Profile : func)
+    #define OPCODE_PROFILE(x, func) _OPCODE_PROFILE(x, func)
+    #define OPCODE_PROFILE_LITE(x, func) _OPCODE_PROFILE(x, func)
 #endif
 
     OPCODE_PROFILE(UNARY_POSITIVE, PyNumber_Positive);
@@ -436,13 +439,8 @@ static void* __attribute__ ((const)) get_addr_of_aot_func(int opcode, int oparg,
     OPCODE_PROFILE(BINARY_POWER, PyNumber_PowerNone);
     OPCODE_PROFILE(INPLACE_POWER, PyNumber_InPlacePowerNone);
 
-#ifdef PYSTON_LITE
-    OPCODE_PROFILE(CALL_FUNCTION, call_function_ceval_no_kwProfile);
-    OPCODE_PROFILE(CALL_METHOD, call_function_ceval_no_kwProfile);
-#else
-    OPCODE_PROFILE(CALL_FUNCTION, call_function_ceval_no_kw);
-    OPCODE_PROFILE(CALL_METHOD, call_function_ceval_no_kw);
-#endif
+    OPCODE_PROFILE_LITE(CALL_FUNCTION, call_function_ceval_no_kw);
+    OPCODE_PROFILE_LITE(CALL_METHOD, call_function_ceval_no_kw);
     OPCODE_PROFILE(CALL_FUNCTION_KW, call_function_ceval_kw);
 
     OPCODE_PROFILE(STORE_SUBSCR, PyObject_SetItem);

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -436,7 +436,11 @@ static void* __attribute__ ((const)) get_addr_of_aot_func(int opcode, int oparg,
     OPCODE_PROFILE(BINARY_POWER, PyNumber_PowerNone);
     OPCODE_PROFILE(INPLACE_POWER, PyNumber_InPlacePowerNone);
 
+#ifdef PYSTON_LITE
     OPCODE_PROFILE(CALL_FUNCTION, call_function_ceval_no_kwProfile);
+#else
+    OPCODE_PROFILE(CALL_FUNCTION, call_function_ceval_no_kw);
+#endif
     OPCODE_PROFILE(CALL_METHOD, call_function_ceval_no_kw);
     OPCODE_PROFILE(CALL_FUNCTION_KW, call_function_ceval_kw);
 

--- a/Python/aot_ceval_jit.c
+++ b/Python/aot_ceval_jit.c
@@ -438,10 +438,11 @@ static void* __attribute__ ((const)) get_addr_of_aot_func(int opcode, int oparg,
 
 #ifdef PYSTON_LITE
     OPCODE_PROFILE(CALL_FUNCTION, call_function_ceval_no_kwProfile);
+    OPCODE_PROFILE(CALL_METHOD, call_function_ceval_no_kwProfile);
 #else
     OPCODE_PROFILE(CALL_FUNCTION, call_function_ceval_no_kw);
-#endif
     OPCODE_PROFILE(CALL_METHOD, call_function_ceval_no_kw);
+#endif
     OPCODE_PROFILE(CALL_FUNCTION_KW, call_function_ceval_kw);
 
     OPCODE_PROFILE(STORE_SUBSCR, PyObject_SetItem);

--- a/Python/aot_ceval_jit_helper.c
+++ b/Python/aot_ceval_jit_helper.c
@@ -1256,7 +1256,7 @@ JIT_HELPER_WITH_NAME_OPCACHE_AOT1(LOAD_ATTR_CACHED, owner) {
 
     if (++co_opcache->num_failed >= 5) {
         // don't use the cache anymore
-        //SET_JIT_AOT_FUNC(JIT_HELPER_LOAD_ATTR);
+        SET_JIT_AOT_FUNC(JIT_HELPER_LOAD_ATTR);
     }
 
     res = PyObject_GetAttr(owner, name);
@@ -1268,7 +1268,7 @@ JIT_HELPER_WITH_NAME_OPCACHE_AOT1(LOAD_ATTR_CACHED, owner) {
     if (res) {
         if (setupLoadAttrCache(owner, name, co_opcache, res, 0/*= not LOAD_METHOD*/, 0 /*not inside_interpreter */)) {
             // don't use the cache anymore
-            //SET_JIT_AOT_FUNC(JIT_HELPER_LOAD_ATTR);
+            SET_JIT_AOT_FUNC(JIT_HELPER_LOAD_ATTR);
         }
     }
 la_common:

--- a/Python/aot_ceval_jit_helper.c
+++ b/Python/aot_ceval_jit_helper.c
@@ -1256,7 +1256,7 @@ JIT_HELPER_WITH_NAME_OPCACHE_AOT1(LOAD_ATTR_CACHED, owner) {
 
     if (++co_opcache->num_failed >= 5) {
         // don't use the cache anymore
-        SET_JIT_AOT_FUNC(JIT_HELPER_LOAD_ATTR);
+        //SET_JIT_AOT_FUNC(JIT_HELPER_LOAD_ATTR);
     }
 
     res = PyObject_GetAttr(owner, name);
@@ -1268,7 +1268,7 @@ JIT_HELPER_WITH_NAME_OPCACHE_AOT1(LOAD_ATTR_CACHED, owner) {
     if (res) {
         if (setupLoadAttrCache(owner, name, co_opcache, res, 0/*= not LOAD_METHOD*/, 0 /*not inside_interpreter */)) {
             // don't use the cache anymore
-            SET_JIT_AOT_FUNC(JIT_HELPER_LOAD_ATTR);
+            //SET_JIT_AOT_FUNC(JIT_HELPER_LOAD_ATTR);
         }
     }
 la_common:

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := env/lite.stamp
 
 PYTHON:=python3.8
+PYTHON:=/home/kmod/cpython_3.8/install/bin/python3
 
 package:
 	# They have to be built sequentially in this order:
@@ -77,11 +78,15 @@ test: env/lite.stamp
 	./env/bin/python -m test -j0 -x test_code test_distutils test_ensurepip test_minidom test_site test_xml_etree test_xml_etree_c test_capi $(ADDITIONAL_TESTS_TO_SKIP)
 
 ENV:=
-BENCH:=../macrobenchmarks/benchmarks/bm_flaskblogging/run_benchmark.py --legacy
+BENCH:=/tmp/env/lib/python3.8/site-packages/pyperformance/data-files/benchmarks/bm_python_startup/run_benchmark.py --worker -p 1 -w 0 -n 10 -l 10
+BENCH:=fib.py
 
 
 bench: env/update.stamp
 	$(ENV) ./env/bin/python $(BENCH)
+
+bench311: env/update.stamp
+	./env311/bin/python $(BENCH)
 
 bench_baseline: env/update.stamp
 	DISABLE_PYSTON=1 ./env/bin/python $(BENCH)
@@ -98,8 +103,18 @@ perf_bench_baseline: env/update.stamp
 perf_report_baseline:
 	perf report -i perf_baseline.data -n --objdump=../../pyston/tools/perf_jit.py
 
+perf_bench311: env/update.stamp
+	perf record -o perf_311.data ./env311/bin/python $(BENCH)
+	$(MAKE) perf_report311
+perf_report311:
+	perf report -i perf_311.data -n
+
 dbg_bench: env/update.stamp
-	DISABLE_PYSTONFULL=1 $(ENV) gdb --args ./env/bin/python $(BENCH) 1000000
+	$(ENV) gdb --args ./env/bin/python $(BENCH) -l 100000000
+
+dbg_bench311: env/update.stamp
+	gdb --args ./env311/bin/python $(BENCH) -l 100000000
+
 
 
 bench_full:

--- a/pyston/pyston_lite/aot_lite.c
+++ b/pyston/pyston_lite/aot_lite.c
@@ -1,0 +1,212 @@
+#include "Python.h"
+
+#include "frameobject.h"
+#include "internal/pycore_object.h"
+#include "internal/pycore_pystate.h"
+#include "internal/pycore_tupleobject.h"
+
+#define SET_JIT_AOT_FUNC(dst_addr) do { \
+    /* retrieve address of the instruction following the call instruction */\
+    unsigned char* ret_addr = (unsigned char*)__builtin_extract_return_addr(__builtin_return_address(0));\
+    if (ret_addr[-2] == 0xff && ret_addr[-1] == 0xd0) { /* abs call: call rax */\
+        unsigned long* call_imm = (unsigned long*)&ret_addr[-2-8];\
+        *call_imm = (unsigned long)dst_addr;\
+    } else { /* relative call */ \
+        /* 5 byte call instruction - get address of relative immediate operand of call */\
+        unsigned int* call_imm = (unsigned int*)&ret_addr[-4];\
+        /* set operand to newly calculated relative offset */\
+        *call_imm = (unsigned int)(unsigned long)(dst_addr) - (unsigned int)(unsigned long)ret_addr;\
+    } \
+} while(0)
+
+PyObject* call_function_ceval_no_kw(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg);
+
+PyObject *
+trace_call_function(PyThreadState *tstate,
+                    PyObject *func,
+                    PyObject **args, Py_ssize_t nargs,
+                    PyObject *kwnames);
+
+static PyObject* _Py_HOT_FUNCTION
+function_code_fastcall(PyCodeObject *co, PyObject *const *args, Py_ssize_t nargs,
+                       PyObject *globals)
+{
+    PyFrameObject *f;
+    PyThreadState *tstate = _PyThreadState_GET();
+    PyObject **fastlocals;
+    Py_ssize_t i;
+    PyObject *result;
+
+    assert(globals != NULL);
+    /* XXX Perhaps we should create a specialized
+       _PyFrame_New_NoTrack() that doesn't take locals, but does
+       take builtins without sanity checking them.
+       */
+    assert(tstate != NULL);
+    f = _PyFrame_New_NoTrack(tstate, co, globals, NULL);
+    if (f == NULL) {
+        return NULL;
+    }
+
+    fastlocals = f->f_localsplus;
+
+    for (i = 0; i < nargs; i++) {
+        Py_INCREF(*args);
+        fastlocals[i] = *args++;
+    }
+    result = PyEval_EvalFrameEx(f,0);
+
+    if (Py_REFCNT(f) > 1) {
+        Py_DECREF(f);
+        _PyObject_GC_TRACK(f);
+    }
+    else {
+#if PYSTON_SPEEDUPS
+        Py_REFCNT(f) = 0;
+        assert(Py_TYPE(f) == &PyFrame_Type);
+        //frame_dealloc_notrashcan(f);
+        PyFrame_Type.tp_dealloc(f);
+#else
+        ++tstate->recursion_depth;
+        Py_DECREF(f);
+        --tstate->recursion_depth;
+#endif
+    }
+    return result;
+}
+PyObject *
+_PyFunction_Vectorcall(PyObject *func, PyObject* const* stack,
+                       size_t nargsf, PyObject *kwnames)
+{
+    PyCodeObject *co = (PyCodeObject *)PyFunction_GET_CODE(func);
+    PyObject *globals = PyFunction_GET_GLOBALS(func);
+    PyObject *argdefs = PyFunction_GET_DEFAULTS(func);
+    PyObject *kwdefs, *closure, *name, *qualname;
+    PyObject **d;
+    Py_ssize_t nkwargs = (kwnames == NULL) ? 0 : PyTuple_GET_SIZE(kwnames);
+    Py_ssize_t nd;
+
+    assert(PyFunction_Check(func));
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    assert(nargs >= 0);
+    assert(kwnames == NULL || PyTuple_CheckExact(kwnames));
+    assert((nargs == 0 && nkwargs == 0) || stack != NULL);
+    /* kwnames must only contains str strings, no subclass, and all keys must
+       be unique */
+
+    if (co->co_kwonlyargcount == 0 && nkwargs == 0 &&
+#if PYSTON_SPEEDUPS
+        (co->co_flags & ~(PyCF_MASK | CO_NESTED)) == (CO_OPTIMIZED | CO_NEWLOCALS | CO_NOFREE))
+#else
+        (co->co_flags & ~PyCF_MASK) == (CO_OPTIMIZED | CO_NEWLOCALS | CO_NOFREE))
+#endif
+    {
+        if (
+#if !PYSTON_SPEEDUPS
+                argdefs == NULL &&
+#endif
+                co->co_argcount == nargs) {
+            return function_code_fastcall(co, stack, nargs, globals);
+        }
+        else if (nargs == 0 && argdefs != NULL
+                 && co->co_argcount == PyTuple_GET_SIZE(argdefs)) {
+            /* function called with no arguments, but all parameters have
+               a default value: use default values as arguments .*/
+            stack = _PyTuple_ITEMS(argdefs);
+            return function_code_fastcall(co, stack, PyTuple_GET_SIZE(argdefs),
+                                          globals);
+        }
+    }
+
+    kwdefs = PyFunction_GET_KW_DEFAULTS(func);
+    closure = PyFunction_GET_CLOSURE(func);
+    name = ((PyFunctionObject *)func) -> func_name;
+    qualname = ((PyFunctionObject *)func) -> func_qualname;
+
+    if (argdefs != NULL) {
+        d = _PyTuple_ITEMS(argdefs);
+        nd = PyTuple_GET_SIZE(argdefs);
+    }
+    else {
+        d = NULL;
+        nd = 0;
+    }
+    return _PyEval_EvalCodeWithName((PyObject*)co, globals, (PyObject *)NULL,
+                                    stack, nargs,
+                                    nkwargs ? _PyTuple_ITEMS(kwnames) : NULL,
+                                    stack + nargs,
+                                    nkwargs, 1,
+                                    d, (int)nd, kwdefs,
+                                    closure, name, qualname);
+}
+static inline vectorcallfunc
+_PyVectorcall_FunctionFunction(PyObject *callable)
+{
+    return _PyFunction_Vectorcall;
+}
+
+static inline PyObject *
+_PyObject_VectorcallFunction(PyObject *callable, PyObject *const *args,
+                     size_t nargsf, PyObject *kwnames)
+{
+    PyObject *res;
+    vectorcallfunc func;
+    assert(kwnames == NULL || PyTuple_Check(kwnames));
+    assert(args != NULL || PyVectorcall_NARGS(nargsf) == 0);
+    func = _PyVectorcall_FunctionFunction(callable);
+    if (func == NULL) {
+        Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+        return _PyObject_MakeTpCall(callable, args, nargs, kwnames);
+    }
+    res = func(callable, args, nargsf, kwnames);
+    return _Py_CheckFunctionResult(callable, res, NULL);
+}
+
+//Py_LOCAL_INLINE(PyObject *) _Py_HOT_FUNCTION
+static PyObject *
+call_functionFunction(PyThreadState *tstate, PyObject ** restrict pp_stack, Py_ssize_t oparg)
+{
+    PyObject *kwnames = NULL;
+
+    PyObject **pfunc = (pp_stack) - oparg - 1;
+    PyObject *func = *pfunc;
+    PyObject *x, *w;
+    Py_ssize_t nkwargs = (kwnames == NULL) ? 0 : PyTuple_GET_SIZE(kwnames);
+    Py_ssize_t nargs = oparg - nkwargs;
+    PyObject **stack = (pp_stack) - nargs - nkwargs;
+
+    if (tstate->use_tracing) {
+        x = trace_call_function(tstate, func, stack, nargs, kwnames);
+    }
+    else {
+        x = _PyObject_VectorcallFunction(func, stack, nargs | PY_VECTORCALL_ARGUMENTS_OFFSET, kwnames);
+    }
+
+    assert((x != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
+
+    /* Clear the stack of the function object. */
+#if !defined(LLTRACE_DEF)
+    for (int i = oparg; i >= 0; i--) {
+        Py_DECREF(pfunc[i]);
+    }
+    pp_stack = pfunc;
+#else
+    while ((pp_stack) > pfunc) {
+        w = EXT_POP(pp_stack);
+        Py_DECREF(w);
+    }
+#endif
+
+    return x;
+}
+
+PyObject* call_function_ceval_no_kwProfile(PyThreadState * tstate, PyObject ** restrict stack, Py_ssize_t oparg) {
+    PyObject* f = *(stack - oparg - 1);
+    if (f->ob_type == &PyFunction_Type) {
+        SET_JIT_AOT_FUNC(call_functionFunction);
+        return call_functionFunction(tstate, stack, oparg);
+    }
+
+    SET_JIT_AOT_FUNC(call_function_ceval_no_kw);
+    return call_function_ceval_no_kw(tstate, stack, oparg);
+}

--- a/pyston/pyston_lite/compare.py
+++ b/pyston/pyston_lite/compare.py
@@ -1,0 +1,101 @@
+"""
+Testing script, for identifying opportunities to make pyston-lite faster
+
+Usage:
+    make perf_report
+    make perf_report_baseline
+    python3 compare.py
+
+Will try to identify the largest differences between the two perf reports
+"""
+
+from collections import defaultdict
+import subprocess
+
+def parse(fn):
+    r = defaultdict(int)
+    total = None
+    for l in subprocess.check_output(["perf", "report", "-n", "--no-children", "-g", "none", "-i", fn]).decode("utf8").split('\n'):
+        if l.startswith("#"):
+            if "Event count" in l:
+                total = int(l.split()[-1])
+            continue
+        if '%' not in l:
+            continue
+
+        l = l.split()
+        if '[k]' in l:
+            l[-1] = "kernel"
+        # r[l[-1]] = int(l[1])
+        pct = float(l[0].rstrip("%"))
+        if pct == 0.0:
+            pct = 0.0025
+        r[l[-1]] = pct * total * 0.01
+    return r
+
+def compare():
+    baseline = defaultdict(int)
+    lite = defaultdict(int)
+
+    baseline = parse("/tmp/perf_baseline.data")
+    lite = parse("/tmp/perf_lite.data")
+
+    baseline_total = sum(baseline.values())
+    lite_total = sum(lite.values())
+
+    print("%.1fB\t%.1fB\t" % (baseline_total * 1e-9, lite_total * 1e-9), "%+.2f%%" % ((lite_total - baseline_total) / baseline_total * 100.0))
+    print("="*40)
+
+    for d in (lite, baseline):
+        # for k, v in list(d.items()):
+            # if "EvalFrame" in k:
+                # d["_EvalFrame"] += d.pop(k)
+                # d["_EvalFrame"] += d.pop(k)
+        d["call_functionFunction"] += d.pop("call_functionFunction2", 0)
+        d["call_functionFunction"] += d.pop("frame_dealloc", 0)
+
+        d["fib.py:1:fib"] += d.pop("fib.py:2:fib", 0)
+
+        d["cmp_outcomePyCmp_LELongLong2"] += d.pop("PyObject_RichCompare", 0)
+        d["cmp_outcomePyCmp_LELongLong2"] += d.pop("long_richcompare", 0)
+        d["cmp_outcomePyCmp_LELongLong2"] += d.pop("cmp_outcomePyCmp_LE", 0)
+
+        d["PyNumber_SubtractLongLong2"] += d.pop("PyNumber_Subtract", 0)
+        d["PyNumber_SubtractLongLong2"] += d.pop("long_sub", 0)
+
+        d["PyNumber_AddLongLong2"] += d.pop("PyNumber_Add", 0)
+        d["PyNumber_AddLongLong2"] += d.pop("long_add", 0)
+
+        d["_PyEval_EvalFrameDefault"] += d.pop("_PyEval_EvalFrame_AOT_Interpreter", 0)
+        d["_PyEval_EvalFrameDefault"] += d.pop("_PyEval_EvalFrame_AOT", 0)
+
+    all = set(baseline)
+    all.update(lite)
+
+    diffs = []
+    for k in all:
+        diffs.append((abs(baseline.setdefault(k, 0) - lite.setdefault(k, 0)), k))
+
+    diffs.sort(reverse=True)
+    for t in diffs[:10]:
+        k = t[-1]
+        f = baseline[k]
+        l = lite[k]
+        # print("%4.1f%%\t% 4.1f%%\t" % (100.0 * f / baseline_total, 100.0 * l / lite_total), "%+.2f%%" % ((l - f) / baseline_total * 100.0), k)
+        print("%d\t%d\t" % (f * 1e-6, l * 1e-6), "%+.2f%%" % ((l - f) / baseline_total * 100.0), k)
+
+def showPercents():
+    baseline = parse("/tmp/perf_baseline.data")
+    lite = parse("/tmp/perf_lite.data")
+    baseline_total = sum(baseline.values())
+    lite_total = sum(lite.values())
+
+    l = list(lite.items())
+    l.sort(key=lambda p:-p[1])
+
+    for k, v in l[:20]:
+        print("%4.1f%%\t%s" % (100.0 * v / lite_total, k))
+
+if __name__ == "__main__":
+    # showPercents()
+    compare()

--- a/pyston/pyston_lite/fib.py
+++ b/pyston/pyston_lite/fib.py
@@ -1,0 +1,9 @@
+import time
+def fib(n):
+    if n <= 2:
+        return n
+    return fib(n - 1) + fib(n - 2)
+
+start = time.time()
+print(fib(36))
+print(time.time() - start)

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -138,7 +138,7 @@ def get_ldflags():
 
 ext = Extension(
         "pyston_lite",
-        sources=["aot_ceval.c", "aot_ceval_jit.gen.c", "aot_ceval_jit_helper.c", "lib.c"],
+        sources=["aot_ceval.c", "aot_ceval_jit.gen.c", "aot_ceval_jit_helper.c", "lib.c", "aot_lite.c"],
         include_dirs=["../../pyston/LuaJIT", os.path.join(sysconfig.get_python_inc(), "internal")],
         define_macros=[("PYSTON_LITE", None), ("PYSTON_SPEEDUPS", "1"), ("Py_BUILD_CORE", None), ("ENABLE_AOT", None), ("NO_DKVERSION", None)],
         extra_compile_args=get_cflags(),


### PR DESCRIPTION
Draft -- I didn't manage to get an improvement out of this for now but I think it's still worth doing eventually

I noticed that Python->Python function calls in pyston-lite are a good deal slower than in pyston-full and cpython 3.11. There are two reasons I can think of for this: the extra overhead of using `co_extra` (required for PEP523 extensions), and the lack of AOT traces. In this PR I tried to tackle the second one.

I kind of manually constructed a trace for this by copying in the functions that would be called, making sure they would get inlined, and applying some of the static constant loading that we do (avoiding the runtime dynamic lookups). Unfortunately it didn't seem to produce a speedup. Also there are some test failures which I haven't looked into.

At this point I still don't know exactly why pyston-lite function calls are so much slower