### PR TITLE
Add call_function "aot trace" to pyston_lite

### DIFF
--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -5224,7 +5224,7 @@ exit_eval_frame:
 // Entry point when executing a python function.
 // We check if we can use a JIT compiled version or have to use the Interpreter
 #ifdef PYSTON_LITE
-static PyObject* _Py_HOT_FUNCTION
+PyObject* _Py_HOT_FUNCTION
 _PyEval_EvalFrame_AOT
 #else
 PyObject* _Py_HOT_FUNCTION

--- a/pyston/pyston_lite/aot_lite.c
+++ b/pyston/pyston_lite/aot_lite.c
@@ -1,0 +1,422 @@
+#include "Python.h"
+
+#include "frameobject.h"
+#include "internal/pycore_object.h"
+#include "internal/pycore_pystate.h"
+#include "internal/pycore_tupleobject.h"
+
+#if __aarch64__
+#define SET_JIT_AOT_FUNC(dst_addr) do { \
+    /* retrieve address of the instruction following the call instruction */\
+    unsigned int* ret_addr = (unsigned int*)__builtin_extract_return_addr(__builtin_return_address(0));\
+    /* this updates the destination of the relative call instruction 'bl' */\
+    ret_addr[-1] = 0x94000000 | (((long)dst_addr - (long)&ret_addr[-1])&((1<<29)-1))>>2;\
+    __builtin___clear_cache(&ret_addr[-1], &ret_addr[0]);\
+} while(0)
+#else
+#define SET_JIT_AOT_FUNC(dst_addr) do { \
+    /* retrieve address of the instruction following the call instruction */\
+    unsigned char* ret_addr = (unsigned char*)__builtin_extract_return_addr(__builtin_return_address(0));\
+    if (ret_addr[-2] == 0xff && ret_addr[-1] == 0xd0) { /* abs call: call rax */\
+        unsigned long* call_imm = (unsigned long*)&ret_addr[-2-8];\
+        *call_imm = (unsigned long)dst_addr;\
+    } else { /* relative call */ \
+        /* 5 byte call instruction - get address of relative immediate operand of call */\
+        unsigned int* call_imm = (unsigned int*)&ret_addr[-4];\
+        /* set operand to newly calculated relative offset */\
+        *call_imm = (unsigned int)(unsigned long)(dst_addr) - (unsigned int)(unsigned long)ret_addr;\
+    } \
+} while(0)
+#endif
+
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+
+PyObject* call_function_ceval_no_kw(PyThreadState *tstate, PyObject **stack, Py_ssize_t oparg);
+
+PyObject *
+trace_call_function(PyThreadState *tstate,
+                    PyObject *func,
+                    PyObject **args, Py_ssize_t nargs,
+                    PyObject *kwnames);
+
+static PyFrameObject *free_list = NULL;
+static int numfree = 0;         /* number of frames currently in free_list */
+/* max value for numfree */
+#define PyFrame_MAXFREELIST 200
+
+inline PyFrameObject*
+_PyFrame_New_NoTrack(PyThreadState *tstate, PyCodeObject *code,
+                     PyObject *globals, PyObject *locals)
+{
+    _Py_IDENTIFIER(__builtins__);
+
+    PyFrameObject *back = tstate->frame;
+    PyFrameObject *f;
+    PyObject *builtins;
+    Py_ssize_t i;
+
+#ifdef Py_DEBUG
+    if (code == NULL || globals == NULL || !PyDict_Check(globals) ||
+        (locals != NULL && !PyMapping_Check(locals))) {
+        PyErr_BadInternalCall();
+        return NULL;
+    }
+#endif
+    if (back == NULL || back->f_globals != globals) {
+        builtins = _PyDict_GetItemIdWithError(globals, &PyId___builtins__);
+
+        if (builtins) {
+            if (
+#if PYSTON_SPEEDUPS
+                    Py_TYPE(builtins) != &PyDict_Type &&
+#endif
+                    PyModule_Check(builtins)) {
+                builtins = PyModule_GetDict(builtins);
+                assert(builtins != NULL);
+            }
+        }
+        if (builtins == NULL) {
+            if (PyErr_Occurred()) {
+                return NULL;
+            }
+            /* No builtins!              Make up a minimal one
+               Give them 'None', at least. */
+            builtins = PyDict_New();
+            if (builtins == NULL ||
+                PyDict_SetItemString(
+                    builtins, "None", Py_None) < 0)
+                return NULL;
+        }
+        else
+            Py_INCREF(builtins);
+
+    }
+    else {
+        /* If we share the globals, we share the builtins.
+           Save a lookup and a call. */
+        builtins = back->f_builtins;
+        assert(builtins != NULL);
+        Py_INCREF(builtins);
+    }
+    if (code->co_zombieframe != NULL) {
+        f = code->co_zombieframe;
+        code->co_zombieframe = NULL;
+        _Py_NewReference((PyObject *)f);
+        assert(f->f_code == code);
+    }
+    else {
+        Py_ssize_t extras, ncells, nfrees;
+        ncells = PyTuple_GET_SIZE(code->co_cellvars);
+        nfrees = PyTuple_GET_SIZE(code->co_freevars);
+        extras = code->co_stacksize + code->co_nlocals + ncells +
+            nfrees;
+        if (free_list == NULL) {
+            f = PyObject_GC_NewVar(PyFrameObject, &PyFrame_Type,
+            extras);
+            if (f == NULL) {
+                Py_DECREF(builtins);
+                return NULL;
+            }
+        }
+        else {
+            assert(numfree > 0);
+            --numfree;
+            f = free_list;
+            free_list = free_list->f_back;
+            if (Py_SIZE(f) < extras) {
+                PyFrameObject *new_f = PyObject_GC_Resize(PyFrameObject, f, extras);
+                if (new_f == NULL) {
+                    PyObject_GC_Del(f);
+                    Py_DECREF(builtins);
+                    return NULL;
+                }
+                f = new_f;
+            }
+            _Py_NewReference((PyObject *)f);
+        }
+
+        f->f_code = code;
+        extras = code->co_nlocals + ncells + nfrees;
+        f->f_valuestack = f->f_localsplus + extras;
+        for (i=0; i<extras; i++)
+            f->f_localsplus[i] = NULL;
+        f->f_locals = NULL;
+        f->f_trace = NULL;
+    }
+    f->f_stacktop = f->f_valuestack;
+    f->f_builtins = builtins;
+    Py_XINCREF(back);
+    f->f_back = back;
+    Py_INCREF(code);
+    Py_INCREF(globals);
+    f->f_globals = globals;
+    /* Most functions have CO_NEWLOCALS and CO_OPTIMIZED set. */
+    if ((code->co_flags & (CO_NEWLOCALS | CO_OPTIMIZED)) ==
+        (CO_NEWLOCALS | CO_OPTIMIZED))
+        ; /* f_locals = NULL; will be set by PyFrame_FastToLocals() */
+    else if (code->co_flags & CO_NEWLOCALS) {
+        locals = PyDict_New();
+        if (locals == NULL) {
+            Py_DECREF(f);
+            return NULL;
+        }
+        f->f_locals = locals;
+    }
+    else {
+        if (locals == NULL)
+            locals = globals;
+        Py_INCREF(locals);
+        f->f_locals = locals;
+    }
+
+    f->f_lasti = -1;
+    f->f_lineno = code->co_firstlineno;
+    f->f_iblock = 0;
+    f->f_executing = 0;
+    f->f_gen = NULL;
+    f->f_trace_opcodes = 0;
+    f->f_trace_lines = 1;
+
+    return f;
+}
+
+static void _Py_HOT_FUNCTION
+frame_dealloc_notrashcan(PyFrameObject *f)
+{
+    PyObject **p, **valuestack;
+    PyCodeObject *co;
+
+    if (_PyObject_GC_IS_TRACKED(f))
+        _PyObject_GC_UNTRACK(f);
+
+    //Py_TRASHCAN_SAFE_BEGIN(f)
+    /* Kill all local variables */
+    valuestack = f->f_valuestack;
+    for (p = f->f_localsplus; p < valuestack; p++)
+        Py_CLEAR(*p);
+
+    /* Free stack */
+    if (f->f_stacktop != NULL) {
+        PyObject** stacktop = f->f_stacktop;
+        for (p = valuestack; p < stacktop; p++)
+            Py_XDECREF(*p);
+    }
+
+    Py_XDECREF(f->f_back);
+    Py_DECREF(f->f_builtins);
+    Py_DECREF(f->f_globals);
+    Py_CLEAR(f->f_locals);
+    Py_CLEAR(f->f_trace);
+
+    co = f->f_code;
+    if (co->co_zombieframe == NULL)
+        co->co_zombieframe = f;
+    else if (numfree < PyFrame_MAXFREELIST) {
+        ++numfree;
+        f->f_back = free_list;
+        free_list = f;
+    }
+    else
+        PyObject_GC_Del(f);
+
+    Py_DECREF(co);
+    //Py_TRASHCAN_SAFE_END(f)
+}
+
+PyObject* _Py_HOT_FUNCTION
+_PyEval_EvalFrame_AOT(PyFrameObject *f, int throwflag);
+
+static inline PyObject* _Py_HOT_FUNCTION
+function_code_fastcall(PyCodeObject *co, PyObject *const *args, Py_ssize_t nargs,
+                       PyObject *globals)
+{
+    PyFrameObject *f;
+    PyThreadState *tstate = _PyThreadState_GET();
+    PyObject **fastlocals;
+    Py_ssize_t i;
+    PyObject *result;
+
+    assert(globals != NULL);
+    /* XXX Perhaps we should create a specialized
+       _PyFrame_New_NoTrack() that doesn't take locals, but does
+       take builtins without sanity checking them.
+       */
+    assert(tstate != NULL);
+    f = _PyFrame_New_NoTrack(tstate, co, globals, NULL);
+    if (f == NULL) {
+        return NULL;
+    }
+
+    fastlocals = f->f_localsplus;
+
+    for (i = 0; i < nargs; i++) {
+        Py_INCREF(*args);
+        fastlocals[i] = *args++;
+    }
+#if PYSTON_SPEEDUPS
+    result = _PyEval_EvalFrame_AOT(f, 0);
+#else
+    result = PyEval_EvalFrameEx(f,0);
+#endif
+
+    if (Py_REFCNT(f) > 1) {
+        Py_DECREF(f);
+        _PyObject_GC_TRACK(f);
+    }
+    else {
+#if PYSTON_SPEEDUPS
+        Py_REFCNT(f) = 0;
+        assert(Py_TYPE(f) == &PyFrame_Type);
+        frame_dealloc_notrashcan(f);
+        //PyFrame_Type.tp_dealloc(f);
+#else
+        ++tstate->recursion_depth;
+        Py_DECREF(f);
+        --tstate->recursion_depth;
+#endif
+    }
+    return result;
+}
+inline PyObject *
+_PyFunction_Vectorcall(PyObject *func, PyObject* const* stack,
+                       size_t nargsf, PyObject *kwnames)
+{
+    PyCodeObject *co = (PyCodeObject *)PyFunction_GET_CODE(func);
+    PyObject *globals = PyFunction_GET_GLOBALS(func);
+    PyObject *argdefs = PyFunction_GET_DEFAULTS(func);
+    PyObject *kwdefs, *closure, *name, *qualname;
+    PyObject **d;
+    Py_ssize_t nkwargs = (kwnames == NULL) ? 0 : PyTuple_GET_SIZE(kwnames);
+    Py_ssize_t nd;
+
+    assert(PyFunction_Check(func));
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    assert(nargs >= 0);
+    assert(kwnames == NULL || PyTuple_CheckExact(kwnames));
+    assert((nargs == 0 && nkwargs == 0) || stack != NULL);
+    /* kwnames must only contains str strings, no subclass, and all keys must
+       be unique */
+
+    if (co->co_kwonlyargcount == 0 && nkwargs == 0 &&
+#if PYSTON_SPEEDUPS
+        (co->co_flags & ~(PyCF_MASK | CO_NESTED)) == (CO_OPTIMIZED | CO_NEWLOCALS | CO_NOFREE))
+#else
+        (co->co_flags & ~PyCF_MASK) == (CO_OPTIMIZED | CO_NEWLOCALS | CO_NOFREE))
+#endif
+    {
+        int dofast = 0;
+        if (co->co_argcount == nargs)
+            dofast = 1;
+        else if (nargs == 0 && argdefs != NULL
+                 && co->co_argcount == PyTuple_GET_SIZE(argdefs)) {
+            /* function called with no arguments, but all parameters have
+               a default value: use default values as arguments .*/
+            stack = _PyTuple_ITEMS(argdefs);
+            nargs = PyTuple_GET_SIZE(argdefs);
+            dofast = 1;
+        }
+
+        if (dofast)
+            return function_code_fastcall(co, stack, nargs, globals);
+    }
+
+    kwdefs = PyFunction_GET_KW_DEFAULTS(func);
+    closure = PyFunction_GET_CLOSURE(func);
+    name = ((PyFunctionObject *)func) -> func_name;
+    qualname = ((PyFunctionObject *)func) -> func_qualname;
+
+    if (argdefs != NULL) {
+        d = _PyTuple_ITEMS(argdefs);
+        nd = PyTuple_GET_SIZE(argdefs);
+    }
+    else {
+        d = NULL;
+        nd = 0;
+    }
+    return _PyEval_EvalCodeWithName((PyObject*)co, globals, (PyObject *)NULL,
+                                    stack, nargs,
+                                    nkwargs ? _PyTuple_ITEMS(kwnames) : NULL,
+                                    stack + nargs,
+                                    nkwargs, 1,
+                                    d, (int)nd, kwdefs,
+                                    closure, name, qualname);
+}
+static inline vectorcallfunc
+_PyVectorcall_FunctionFunction(PyObject *callable)
+{
+    return _PyFunction_Vectorcall;
+}
+
+static inline PyObject *
+_PyObject_VectorcallFunction(PyObject *callable, PyObject *const *args,
+                     size_t nargsf, PyObject *kwnames)
+{
+    PyObject *res;
+    vectorcallfunc func;
+    assert(kwnames == NULL || PyTuple_Check(kwnames));
+    assert(args != NULL || PyVectorcall_NARGS(nargsf) == 0);
+    func = _PyVectorcall_FunctionFunction(callable);
+    if (func == NULL) {
+        Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+        return _PyObject_MakeTpCall(callable, args, nargs, kwnames);
+    }
+    res = func(callable, args, nargsf, kwnames);
+    return _Py_CheckFunctionResult(callable, res, NULL);
+}
+
+//Py_LOCAL_INLINE(PyObject *) _Py_HOT_FUNCTION
+static PyObject *
+call_functionFunction(PyThreadState *tstate, PyObject ** restrict pp_stack, Py_ssize_t oparg)
+{
+    PyObject* f = pp_stack[-oparg - 1];
+    if (unlikely(!(f->ob_type == &PyFunction_Type))) {
+        SET_JIT_AOT_FUNC(call_function_ceval_no_kw);
+        PyObject* ret = call_function_ceval_no_kw(tstate, pp_stack, oparg);
+        return ret;
+    }
+
+    PyObject *kwnames = NULL;
+
+    PyObject **pfunc = (pp_stack) - oparg - 1;
+    PyObject *func = *pfunc;
+    PyObject *x, *w;
+    Py_ssize_t nkwargs = (kwnames == NULL) ? 0 : PyTuple_GET_SIZE(kwnames);
+    Py_ssize_t nargs = oparg - nkwargs;
+    PyObject **stack = (pp_stack) - nargs - nkwargs;
+
+    if (tstate->use_tracing) {
+        x = trace_call_function(tstate, func, stack, nargs, kwnames);
+    }
+    else {
+        x = _PyObject_VectorcallFunction(func, stack, nargs | PY_VECTORCALL_ARGUMENTS_OFFSET, kwnames);
+    }
+
+    assert((x != NULL) ^ (_PyErr_Occurred(tstate) != NULL));
+
+    /* Clear the stack of the function object. */
+#if !defined(LLTRACE_DEF)
+    for (int i = oparg; i >= 0; i--) {
+        Py_DECREF(pfunc[i]);
+    }
+    pp_stack = pfunc;
+#else
+    while ((pp_stack) > pfunc) {
+        w = EXT_POP(pp_stack);
+        Py_DECREF(w);
+    }
+#endif
+
+    return x;
+}
+
+PyObject* call_function_ceval_no_kwProfile(PyThreadState * tstate, PyObject ** restrict stack, Py_ssize_t oparg) {
+    PyObject* f = *(stack - oparg - 1);
+    if (f->ob_type == &PyFunction_Type) {
+        SET_JIT_AOT_FUNC(call_functionFunction);
+        return call_functionFunction(tstate, stack, oparg);
+    }
+
+    SET_JIT_AOT_FUNC(call_function_ceval_no_kw);
+    return call_function_ceval_no_kw(tstate, stack, oparg);
+}

--- a/pyston/pyston_lite/compare.py
+++ b/pyston/pyston_lite/compare.py
@@ -1,0 +1,101 @@
+"""
+Testing script, for identifying opportunities to make pyston-lite faster
+
+Usage:
+    make perf_report
+    make perf_report_baseline
+    python3 compare.py
+
+Will try to identify the largest differences between the two perf reports
+"""
+
+from collections import defaultdict
+import subprocess
+
+def parse(fn):
+    r = defaultdict(int)
+    total = None
+    for l in subprocess.check_output(["perf", "report", "-n", "--no-children", "-g", "none", "-i", fn]).decode("utf8").split('\n'):
+        if l.startswith("#"):
+            if "Event count" in l:
+                total = int(l.split()[-1])
+            continue
+        if '%' not in l:
+            continue
+
+        l = l.split()
+        if '[k]' in l:
+            l[-1] = "kernel"
+        # r[l[-1]] = int(l[1])
+        pct = float(l[0].rstrip("%"))
+        if pct == 0.0:
+            pct = 0.0025
+        r[l[-1]] = pct * total * 0.01
+    return r
+
+def compare():
+    baseline = defaultdict(int)
+    lite = defaultdict(int)
+
+    baseline = parse("/tmp/perf_baseline.data")
+    lite = parse("/tmp/perf_lite.data")
+
+    baseline_total = sum(baseline.values())
+    lite_total = sum(lite.values())
+
+    print("%.1fB\t%.1fB\t" % (baseline_total * 1e-9, lite_total * 1e-9), "%+.2f%%" % ((lite_total - baseline_total) / baseline_total * 100.0))
+    print("="*40)
+
+    for d in (lite, baseline):
+        # for k, v in list(d.items()):
+            # if "EvalFrame" in k:
+                # d["_EvalFrame"] += d.pop(k)
+                # d["_EvalFrame"] += d.pop(k)
+        d["call_functionFunction"] += d.pop("call_functionFunction2", 0)
+        d["call_functionFunction"] += d.pop("frame_dealloc", 0)
+
+        d["fib.py:1:fib"] += d.pop("fib.py:2:fib", 0)
+
+        d["cmp_outcomePyCmp_LELongLong2"] += d.pop("PyObject_RichCompare", 0)
+        d["cmp_outcomePyCmp_LELongLong2"] += d.pop("long_richcompare", 0)
+        d["cmp_outcomePyCmp_LELongLong2"] += d.pop("cmp_outcomePyCmp_LE", 0)
+
+        d["PyNumber_SubtractLongLong2"] += d.pop("PyNumber_Subtract", 0)
+        d["PyNumber_SubtractLongLong2"] += d.pop("long_sub", 0)
+
+        d["PyNumber_AddLongLong2"] += d.pop("PyNumber_Add", 0)
+        d["PyNumber_AddLongLong2"] += d.pop("long_add", 0)
+
+        d["_PyEval_EvalFrameDefault"] += d.pop("_PyEval_EvalFrame_AOT_Interpreter", 0)
+        d["_PyEval_EvalFrameDefault"] += d.pop("_PyEval_EvalFrame_AOT", 0)
+
+    all = set(baseline)
+    all.update(lite)
+
+    diffs = []
+    for k in all:
+        diffs.append((abs(baseline.setdefault(k, 0) - lite.setdefault(k, 0)), k))
+
+    diffs.sort(reverse=True)
+    for t in diffs[:10]:
+        k = t[-1]
+        f = baseline[k]
+        l = lite[k]
+        # print("%4.1f%%\t% 4.1f%%\t" % (100.0 * f / baseline_total, 100.0 * l / lite_total), "%+.2f%%" % ((l - f) / baseline_total * 100.0), k)
+        print("%d\t%d\t" % (f * 1e-6, l * 1e-6), "%+.2f%%" % ((l - f) / baseline_total * 100.0), k)
+
+def showPercents():
+    baseline = parse("/tmp/perf_baseline.data")
+    lite = parse("/tmp/perf_lite.data")
+    baseline_total = sum(baseline.values())
+    lite_total = sum(lite.values())
+
+    l = list(lite.items())
+    l.sort(key=lambda p:-p[1])
+
+    for k, v in l[:20]:
+        print("%4.1f%%\t%s" % (100.0 * v / lite_total, k))
+
+if __name__ == "__main__":
+    # showPercents()
+    compare()

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -138,7 +138,7 @@ def get_ldflags():
 
 ext = Extension(
         "pyston_lite",
-        sources=["aot_ceval.c", "aot_ceval_jit.gen.c", "aot_ceval_jit_helper.c", "lib.c"],
+        sources=["aot_ceval.c", "aot_ceval_jit.gen.c", "aot_ceval_jit_helper.c", "lib.c", "aot_lite.c"],
         include_dirs=["../../pyston/LuaJIT", os.path.join(sysconfig.get_python_inc(), "internal")],
         define_macros=[("PYSTON_LITE", None), ("PYSTON_SPEEDUPS", "1"), ("Py_BUILD_CORE", None), ("ENABLE_AOT", None), ("NO_DKVERSION", None)],
         extra_compile_args=get_cflags(),


### PR DESCRIPTION
I took another look at this optimization I tried to do last week and discovered the issue was that
I had only specialized function calls, not method calls (which are essentially the same but more common)

I think we could probably get another percent or two by adding specializations for a few other cases,
but I haven't done the investigation to know what they are.

---

Doesn't use any of the actual "aot" machinery; I just copied in
all of the relevant functions and specialized them by hand, and the
inliner takes care of merging them into a single function.

This commit only adds specializations for calling Python functions / methods.
It is not specialized for the argument count, unlike pyston-full.

About a 2% speedup on pyperformance and 1% on macrobenchmarks