### PR TITLE
pyston_lite: update make package

### DIFF
--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -9825,6 +9825,11 @@ PyObject* enable_pyston_lite(PyObject* _m) {
         Py_RETURN_NONE;
     }
 
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 9
+    void init_condattr_pyston_lite(void);
+    init_condattr_pyston_lite();
+#endif
+
     //fprintf(stderr, "jit initialized\n");
     Py_AtExit(aot_exit);
 

--- a/README.md
+++ b/README.md
@@ -127,3 +127,17 @@ python3 setup.py build
 ```
 
 You can set the `NOBOLT=1` environment variable for setup.py if you'd like to skip building bolt. You can also pass `NOPGO=1` and `NOLTO=1` if you'd like the fastest build times, such as for development.
+
+If you like to build pyston-lite with BOLT (currently only used on x86 Linux) for all supported CPython versions you will need to have python3.7 to python3.10 installed and in your path.
+For Ubuntu this can most easily done by adding the deadsnakes PPA:
+
+```
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt update
+sudo apt-get install python3.7-full python3.8-full python3.9-full python3.10-full
+```
+
+To compile wheels for all supported CPython versions and output them into wheelhouse/ run:
+```
+make package
+```

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -3,9 +3,7 @@
 PYTHON?=python3.8
 
 package:
-	# They have to be built sequentially in this order:
 	$(MAKE) build_wheels
-	$(MAKE) build_autoload_sdist
 
 ARCH:=$(shell uname -m)
 ifeq ($(ARCH),x86_64)
@@ -19,12 +17,8 @@ build_wheels:
 	docker run -e NOBOLT=1 $(BOLT_DOCKERFLAGS) -e PLAT=manylinux2014_$(ARCH) -v `pwd`/../../:/io quay.io/pypa/manylinux2014_$(ARCH) bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/"
 	$(BOLT_CMD)
 
-build_autoload_sdist:
-	bash -c "cd autoload; rm -rf dist; $(PYTHON) setup.py sdist"
-
 upload_wheels: env
 	env/bin/pip install twine
-	./env/bin/twine upload autoload/dist/pyston_lite_autoload* || true
 	./env/bin/twine upload wheelhouse/*.whl || true
 
 test_packages:

--- a/pyston/pyston_lite/autoload/setup.py
+++ b/pyston/pyston_lite/autoload/setup.py
@@ -36,6 +36,14 @@ class install_with_pth(install):
         if suffix.strip() == self._pth_contents.strip():
             self.install_lib = self.install_libbase
 
+# We want to build a platform specific wheel even though it only contains python code
+# From https://stackoverflow.com/questions/45150304/how-to-force-a-python-wheel-to-be-platform-specific-when-building-it
+class BinaryDistribution(Distribution):
+    """Distribution which always forces a binary package with platform name"""
+    def has_ext_modules(foo):
+        return True
+
+
 long_description = """
 pyston-lite-autoload is a small package that simply imports and enables
 [pyston-lite](https://pypi.org/project/pyston-lite/) on python startup. It is possible
@@ -54,4 +62,5 @@ setup(name="pyston_lite_autoload",
       install_requires=["pyston_lite==" + VERSION],
       long_description=long_description,
       long_description_content_type="text/markdown",
+      distclass=BinaryDistribution,
 )

--- a/pyston/pyston_lite/bolt_wheel.py
+++ b/pyston/pyston_lite/bolt_wheel.py
@@ -58,6 +58,6 @@ if __name__ == "__main__":
     args = sys.argv[1:]
 
     for a in args:
-        if "none-any" in a:
+        if "none-any" in a or "pyston_lite-" not in a:
             continue
         bolt_wheel(a)

--- a/pyston/pyston_lite/bolt_wheel.py
+++ b/pyston/pyston_lite/bolt_wheel.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -26,7 +27,9 @@ def bolt_wheel(wheel):
         so, = sos
         os.rename(so, so + ".prebolt")
 
-        check_call([sys.executable, "-m", "venv", envdir])
+        python_version = re.search("-cp(\d{2,3})-", wheel).group(1)
+        python_exe_name = "python{}.{}".format(python_version[0], python_version[1:])
+        check_call([python_exe_name, "-m", "venv", envdir])
 
         env_python = os.path.join(envdir, "bin/python3")
 
@@ -57,4 +60,4 @@ if __name__ == "__main__":
     for a in args:
         if "none-any" in a:
             continue
-        bolt_wheel(args[0])
+        bolt_wheel(a)

--- a/pyston/pyston_lite/build_wheels.sh
+++ b/pyston/pyston_lite/build_wheels.sh
@@ -4,23 +4,26 @@ set -ex
 
 cd $(dirname $0)
 
-PYTHON=/opt/python/cp38-cp38/bin/python3
-
 make -C ../LuaJIT clean
 make -C ../LuaJIT -j`nproc`
 make -C ../LuaJIT -j`nproc` install
+
 ln -sf luajit-2.1.0-beta3 /usr/local/bin/luajit
 
-# manylinux2014 doesn't come with a python3 symlink:
-if ! $(which python3) ; then
-    ln -s $PYTHON /usr/local/bin/
-fi
+for PYVER in cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310
+do
+    echo "#################################"
+    echo "Building pyston_lite for ${PYVER}"
+    PYTHON=/opt/python/${PYVER}/bin/python3
 
-$PYTHON -m pip wheel . --no-deps -w wheelhouse/
+    ln -sf $PYTHON /usr/local/bin/
 
-$PYTHON -m pip wheel autoload/ --no-deps -w wheelhouse/
+    $PYTHON -m pip wheel . --no-deps -w wheelhouse/
 
-rm -rf build pyston_lite.egg-info
+    $PYTHON -m pip wheel autoload/ --no-deps -w wheelhouse/
+
+    rm -rf build pyston_lite.egg-info
+done
 
 for whl in wheelhouse/*.whl; do
     if [[ $whl != *"none-any"* ]]; then

--- a/pyston/pyston_lite/build_wheels.sh
+++ b/pyston/pyston_lite/build_wheels.sh
@@ -26,7 +26,8 @@ do
 done
 
 for whl in wheelhouse/*.whl; do
-    if [[ $whl != *"none-any"* ]]; then
+    # ignore the pyston_lite_autoload packages - auditwheel errors on them
+    if [[ $whl != *"none-any"* ]] && [[ $whl == *"pyston_lite-"* ]]; then
         auditwheel repair $whl --plat $PLAT -w wheelhouse/
         rm $whl
     fi

--- a/pyston/pyston_lite/lib.c
+++ b/pyston/pyston_lite/lib.c
@@ -916,6 +916,43 @@ _PyAsyncGenValueWrapperNew(PyObject *val)
 }
 #endif
 
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 9
+
+#if defined(HAVE_PTHREAD_CONDATTR_SETCLOCK) && defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
+// monotonic is supported statically.  It doesn't mean it works on runtime.
+#define CONDATTR_MONOTONIC
+#endif
+
+#define MICROSECONDS_TO_TIMESPEC(microseconds, ts) \
+do { \
+    struct timeval tv; \
+    gettimeofday(&tv, NULL); \
+    tv.tv_usec += microseconds % 1000000; \
+    tv.tv_sec += microseconds / 1000000; \
+    tv.tv_sec += tv.tv_usec / 1000000; \
+    tv.tv_usec %= 1000000; \
+    ts.tv_sec = tv.tv_sec; \
+    ts.tv_nsec = tv.tv_usec * 1000; \
+} while(0)
+
+#ifdef CONDATTR_MONOTONIC
+// NULL when pthread_condattr_setclock(CLOCK_MONOTONIC) is not supported.
+static pthread_condattr_t *condattr_monotonic = NULL;
+#endif
+
+// Pyston change:
+//static void init_condattr(void)
+void init_condattr_pyston_lite(void)
+{
+#ifdef CONDATTR_MONOTONIC
+    static pthread_condattr_t ca;
+    pthread_condattr_init(&ca);
+    if (pthread_condattr_setclock(&ca, CLOCK_MONOTONIC) == 0) {
+        condattr_monotonic = &ca;  // Use monotonic clock
+    }
+#endif
+}
+
 #if defined(CONDATTR_MONOTONIC) || defined(HAVE_SEM_CLOCKWAIT)
 static void
 monotonic_abs_timeout(long long us, struct timespec *abs)
@@ -926,12 +963,22 @@ monotonic_abs_timeout(long long us, struct timespec *abs)
     abs->tv_sec  += abs->tv_nsec / 1000000000;
     abs->tv_nsec %= 1000000000;
 }
-#else
-#error "this should be defined"
 #endif
 void _PyThread_cond_after(long long us, struct timespec *abs) {
-    monotonic_abs_timeout(us, abs);
+#ifdef CONDATTR_MONOTONIC
+    if (condattr_monotonic) {
+        monotonic_abs_timeout(us, abs);
+        return;
+    }
+#endif
+
+    struct timespec ts;
+    MICROSECONDS_TO_TIMESPEC(us, ts);
+    *abs = ts;
 }
+
+#endif
+
 PyObject *
 _PyTuple_FromArray(PyObject *const *src, Py_ssize_t n)
 {


### PR DESCRIPTION
- `make package` builds now wheels for all supported python versions
- autoload package is now a binary package