### PR TITLE
pyston_lite: test all supported pyston_lite versions on the x86 macos CI 

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -153,8 +153,16 @@ jobs:
 
   pyston_lite_macos:
     runs-on: macos-11
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: checkout submodules
         run: |
           git submodule update --init pyston/LuaJIT
@@ -164,14 +172,17 @@ jobs:
           export PATH="/usr/local/opt/luajit-openresty/bin:$PATH"
           # gcc-11 is already in path
 
-          # install official python3.8 package
-          curl https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg -o python.pkg
-          sudo installer -pkg python.pkg -target /
-
           cd pyston/pyston_lite
 
+          python3 --version
+
+          # this 3.7 test does not work on new macos
+          if [[ ${{ matrix.python-version }} == "3.7" ]]; then
+            export ADDITIONAL_TESTS_TO_SKIP="${ADDITIONAL_TESTS_TO_SKIP} test_platform";
+          fi
+
           # pyston must be compiled by gcc not clang
-          CC=gcc-11 make test
+          CC=gcc-11 PYTHON=python3 make test
           SHOW_JIT_STATS=1 ./env/bin/python ../test/inplace_math.py
         env:
           # this tests are flaky

--- a/pyston/pyston_lite/setup.py
+++ b/pyston/pyston_lite/setup.py
@@ -80,8 +80,8 @@ class pyston_build_ext(build_ext):
             # (we could also try to clean things up but that seems more difficult)
             self.force = True
 
-            ext.extra_compile_args = extra_args + ["-fprofile-use"]
-            ext.extra_link_args = extra_link_args + ["-fprofile-use"]
+            ext.extra_compile_args = extra_args + ["-fprofile-use", "-fprofile-correction"]
+            ext.extra_link_args = extra_link_args + ["-fprofile-use", "-fprofile-correction"]
             super(pyston_build_ext, self).build_extension(ext)
 
             ext.extra_compile_args = extra_args


### PR DESCRIPTION
run cpython testsuite on macos for pyston_lite 3.7-3.10