### PR TITLE
pyston_lite: run external testsuites on amd64

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: checkout submodules
         run: |
-          git submodule update --init pyston/LuaJIT
+          git submodule update --init pyston/LuaJIT pyston/test/external/*
       - name: build pyston and test
         run: |
           # enable core dumps

--- a/.github/workflows/pyston_lite.sh
+++ b/.github/workflows/pyston_lite.sh
@@ -21,7 +21,7 @@ else
     sudo apt-get update
     # deadsnakes packages have slightly different name
     sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y python${PYTHON_VERSION}-full python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv libpython${PYTHON_VERSION}-testsuite python3-lib2to3 python3-distutils
-    sudo python${PYTHON_VERSION} -m ensurepip
+    sudo python${PYTHON_VERSION} -m ensurepip --upgrade
 
     if [ $PYTHON_VERSION == "3.9" ]
     then
@@ -38,6 +38,8 @@ fi
 
 sudo python${PYTHON_VERSION} -m pip install virtualenv
 
+sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y libssl-dev libsqlite3-dev zlib1g-dev libwebp-dev libjpeg-dev python${PYTHON_VERSION}-gdbm python${PYTHON_VERSION}-tk tk-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libbz2-dev nginx rustc time libffi-dev
+
 sudo chown -R `whoami` /pyston_dir
 
 cd /pyston_dir/pyston/pyston_lite
@@ -47,3 +49,8 @@ if [ -z ${NOBOLT+x} ]; then
 fi
 
 PYTHON=python${PYTHON_VERSION} make test -j$(nproc)
+
+# run external testsuites on amd64
+if [ `uname -m` == x86_64 ]; then
+    PYTHON=python${PYTHON_VERSION} make testsuites -j$(nproc)
+fi

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sudo apt-get install build-essential git cmake clang libssl-dev libsqlite3-dev l
 
 Extra dependencies for running the test suite:
 ```
-sudo apt-get install libwebp-dev libjpeg-dev python3.8-gdbm python3.8-tk python3.8-dev tk-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libbz2-dev nginx rustc time
+sudo apt-get install libwebp-dev libjpeg-dev python3.8-gdbm python3.8-tk python3.8-dev tk-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libbz2-dev nginx rustc time libffi-dev
 ```
 
 Extra dependencies for producing Pyston debian packages and portable directory release:

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -70,6 +70,34 @@ test: env/lite.stamp
 	./env/bin/python -c 'import test.support; test.support.check_impl_detail = lambda **kw: False; import test.test_code; test.test_code.test_main()'
 	./env/bin/python -m test -j0 -x test_code test_distutils test_ensurepip test_minidom test_site test_xml_etree test_xml_etree_c test_capi $(ADDITIONAL_TESTS_TO_SKIP)
 
+
+
+VIRTUALENV:=../../build/bootstrap_env/bin/virtualenv
+$(VIRTUALENV):
+	virtualenv -p $(PYTHON) ../../build/bootstrap_env
+	../../build/bootstrap_env/bin/pip install virtualenv
+
+# args: test_suffix test_binary
+define make_test_build
+$(eval
+../test/external/test_%.$(1): ../test/external/test_%.py $(2) | $(VIRTUALENV)
+	OPENSSL_CONF=$(abspath ../test/openssl_dev.cnf) bash -c "set -o pipefail; $(2) -u $$< 2>&1 | tee $$@_"
+	mv $$@_ $$@
+)
+endef
+
+$(call make_test_build,liteexpected,$(shell which $(PYTHON)))
+.PRECIOUS: ../test/external/test_%.liteexpected ../test/external/test_%.liteoutput
+$(call make_test_build,liteoutput,env/bin/python)
+
+.PHONY: test_%
+test_%: ../test/external/test_%.liteexpected ../test/external/test_%.liteoutput
+	$(PYTHON) ../test/external/helpers.py compare $< $(patsubst %.liteexpected,%.liteoutput,$<)
+
+EXTERNAL_TESTSUITES:=django urllib3 setuptools six requests sqlalchemy pandas numpy
+testsuites: env/lite.stamp $(patsubst %,test_%,$(EXTERNAL_TESTSUITES))
+
+
 ENV:=
 BENCH:=../macrobenchmarks/benchmarks/bm_flaskblogging/run_benchmark.py --legacy
 

--- a/pyston/test/external/django_requirements.txt
+++ b/pyston/test/external/django_requirements.txt
@@ -3,7 +3,7 @@ argon2-cffi==21.1.0
 asgiref==3.4.1
 async-timeout==3.0.1
 attrs==21.2.0
-backports.zoneinfo==0.2.1
+backports.zoneinfo==0.2.1;python_version<"3.9"
 bcrypt==3.2.0
 certifi==2021.5.30
 cffi==1.14.6

--- a/pyston/test/external/helpers.py
+++ b/pyston/test/external/helpers.py
@@ -224,6 +224,26 @@ def check_log(log, expected_log):
 
     return True
 
+def has_pyston_lite():
+    try:
+        import pyston_lite
+    except:
+        return False
+    return True
+
+def install_pyston_lite_into(py):
+    path_to_pyston_lite_src = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "pyston_lite")
+
+    # speedup compilation
+    env = os.environ.copy()
+    env["NOPGO"] = "1"
+    env["NOLTO"] = "1"
+    env["NOBOLT"] = "1"
+
+    subprocess.run([py, "setup.py", "install"], cwd=path_to_pyston_lite_src, env=env, capture_output=True)
+    subprocess.run([py, "setup.py", "install"], cwd=os.path.join(path_to_pyston_lite_src, "autoload"), capture_output=True)
+
+
 if __name__ == "__main__":
     if sys.argv[1] == "process_log":
         for l in sys.stdin:

--- a/pyston/test/external/test_django.py
+++ b/pyston/test/external/test_django.py
@@ -1,3 +1,4 @@
+import helpers
 import os
 import subprocess
 import sys
@@ -10,7 +11,8 @@ django_requirements.txt:
 - I froze the dependencies with pip freeze
 """
 
-if __name__ == "__main__":
+# test requires Python >= 3.8
+if __name__ == "__main__" and sys.version_info[:2] >= (3, 8):
     with tempfile.TemporaryDirectory() as tempdir:
         print("PYSTONTEST: on-failure-print If you see a WebP failure, you might have to install libwebp-dev, delete the cached pillow wheel, and try again")
 
@@ -27,6 +29,9 @@ if __name__ == "__main__":
         # So just make it think we have a second virtualenv setup to ignore:
         print("created virtual environment (step 2)")
         subprocess.check_call([os.path.join(env_dir, "bin/pip"), "install", "-r", rel("django_requirements.txt")])
+
+        if helpers.has_pyston_lite():
+            helpers.install_pyston_lite_into(os.path.join(env_dir, "bin/python3"))
 
         r = subprocess.call([os.path.join(env_dir, "bin/python3"), "-u", rel("django/tests/runtests.py"), "--parallel", "1"], cwd=tempdir)
         assert r in (0, 1), r

--- a/pyston/test/external/test_numpy.py
+++ b/pyston/test/external/test_numpy.py
@@ -1,3 +1,4 @@
+import helpers
 import os
 import shutil
 import subprocess
@@ -34,6 +35,9 @@ if __name__ == "__main__":
             f.write("gitdir: %s" % os.path.abspath(rel("../../../.git/modules/pyston/test/external/numpy")))
 
         subprocess.check_call([os.path.join(env_dir, "bin/pip"), "install", "-r", rel("numpy/test_requirements.txt")])
+
+        if helpers.has_pyston_lite():
+            helpers.install_pyston_lite_into(os.path.join(env_dir, "bin/python3"))
 
         libdir = "python" + sysconfig.get_config_var("VERSION")
 

--- a/pyston/test/external/test_pandas.py
+++ b/pyston/test/external/test_pandas.py
@@ -1,3 +1,4 @@
+import helpers
 import os
 import shutil
 import subprocess
@@ -5,8 +6,8 @@ import sys
 import sysconfig
 import tempfile
 
-
-if __name__ == "__main__":
+# test requires Python >= 3.8
+if __name__ == "__main__" and sys.version_info[:2] >= (3, 8):
     with tempfile.TemporaryDirectory() as tempdir:
         # Pandas has some tests that look flaky and are marked xfail
         print("PYSTONTEST: no-log-check")
@@ -32,6 +33,9 @@ if __name__ == "__main__":
         # pip uninstall pandas
         # pip freeze
         subprocess.check_call([os.path.join(env_dir, "bin/pip"), "install", "-r", rel("pandas_requirements.txt")])
+
+        if helpers.has_pyston_lite():
+            helpers.install_pyston_lite_into(os.path.join(env_dir, "bin/python3"))
 
         subprocess.check_call([os.path.join(env_dir, "bin/python"), "setup.py", "develop"], cwd=pandas_dir)
 

--- a/pyston/test/external/test_requests.py
+++ b/pyston/test/external/test_requests.py
@@ -1,3 +1,4 @@
+import helpers
 import os
 import subprocess
 import sys
@@ -18,6 +19,9 @@ if __name__ == "__main__":
         subprocess.check_call([rel("../../../build/bootstrap_env/bin/virtualenv"), "-p", sys.executable, env_dir])
 
         subprocess.check_call([os.path.join(env_dir, "bin/pip"), "install", "-r", rel("requests_requirements.txt")])
+
+        if helpers.has_pyston_lite():
+            helpers.install_pyston_lite_into(os.path.join(env_dir, "bin/python3"))
 
         # requests has some nondeterministic output
         r = subprocess.call([os.path.join(env_dir, "bin/python"), "-u", "setup.py", "test"], cwd=rel("requests"))

--- a/pyston/test/external/test_setuptools.py
+++ b/pyston/test/external/test_setuptools.py
@@ -1,3 +1,4 @@
+import helpers
 import os
 import shutil
 import subprocess
@@ -21,6 +22,10 @@ if __name__ == "__main__":
         shutil.copytree(rel("setuptools"), setuptools_dir)
 
         subprocess.check_call([os.path.join(env_dir, "bin/pip"), "install", "-r", rel("setuptools_requirements.txt")])
+
+        if helpers.has_pyston_lite():
+            helpers.install_pyston_lite_into(os.path.join(env_dir, "bin/python3"))
+
         # Small hack: the comparison script looks for virtualenv setups, which it thinks are ended
         # once packages are successfully installed.  If we have two pip install commands, it will
         # think virtualenv is done after the first one, and complain about the nondeterminism in the second one.

--- a/pyston/test/external/test_six.py
+++ b/pyston/test/external/test_six.py
@@ -1,3 +1,4 @@
+import helpers
 import os
 import subprocess
 import sys
@@ -12,6 +13,9 @@ if __name__ == "__main__":
         subprocess.check_call([rel("../../../build/bootstrap_env/bin/virtualenv"), "-p", sys.executable, env_dir])
 
         subprocess.check_call([os.path.join(env_dir, "bin/pip"), "install", "pytest"])
+
+        if helpers.has_pyston_lite():
+            helpers.install_pyston_lite_into(os.path.join(env_dir, "bin/python3"))
 
         r = subprocess.call([os.path.join(env_dir, "bin/pytest"), "-rfsxX"], cwd=rel("six"))
         assert r in (0, 1), r

--- a/pyston/test/external/test_sqlalchemy.py
+++ b/pyston/test/external/test_sqlalchemy.py
@@ -1,3 +1,4 @@
+import helpers
 import os
 import shutil
 import subprocess
@@ -22,6 +23,9 @@ if __name__ == "__main__":
         subprocess.check_call([rel("../../../build/bootstrap_env/bin/virtualenv"), "-p", sys.executable, env_dir])
 
         subprocess.check_call([os.path.join(env_dir, "bin/pip"), "install", "pytest", "tox"])
+
+        if helpers.has_pyston_lite():
+            helpers.install_pyston_lite_into(os.path.join(env_dir, "bin/python3"))
 
         # r = subprocess.call([os.path.join(env_dir, "bin/pytest"), "--db", "sqlite"], cwd=rel("sqlalchemy"))
         env = dict(os.environ)

--- a/pyston/test/external/test_urllib3.py
+++ b/pyston/test/external/test_urllib3.py
@@ -1,3 +1,4 @@
+import helpers
 import os
 import subprocess
 import sys
@@ -31,6 +32,9 @@ if __name__ == "__main__":
         # So just make it think we have a second virtualenv setup to ignore:
         print("created virtual environment (step 2)")
         subprocess.check_call([os.path.join(env_dir, "bin/pip"), "install", "-e", rel("urllib3"), "--use-feature=2020-resolver"])
+
+        if helpers.has_pyston_lite():
+            helpers.install_pyston_lite_into(os.path.join(env_dir, "bin/python3"))
 
         # urllib3 testsuite has some flaky tests, which generate nondeterministic
         # log lines and warnings.  Usually this is the right hash and expected results,


### PR DESCRIPTION
- skip django and pandas on 3.7 because of dependency problems
- it's important that pyston_lite* get's installed into the virtualenv the test run else we will not use pyston lite. I verified that it works by checking in a test that `'pyston_lite' in sys.modules == True`