### PR TITLE
make package: add suport for MacOS

### DIFF
--- a/.github/workflows/build_pyston_lite_wheels.yml
+++ b/.github/workflows/build_pyston_lite_wheels.yml
@@ -18,37 +18,14 @@ jobs:
           ln -s /usr/local/opt/luajit-openresty/bin/luajit /usr/local/bin/
           echo "CC=gcc-11" >> $GITHUB_ENV
 
-      - name: Build pyston_lite_autoload wheels
-        uses: pypa/cibuildwheel@v2.10.0
-        with:
-          package-dir: pyston/pyston_lite/autoload
-        env:
-          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
-          CIBW_SKIP: "*_i686 *musllinux*"
-          CIBW_BUILD_VERBOSITY: 2
-          # pyston does not work on macos before 11 (e.g. 10.15).
-          # If we specify 11 here default pip version says it's not compatible, in order to workaround it
-          # we specify 10.16 which does not really exist because it got renamed to 11.
-          CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=10.16
-
-      - name: Build pyston_lite wheels
-        uses: pypa/cibuildwheel@v2.10.0
-        with:
-          package-dir: pyston/pyston_lite
-        env:
-          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
-          CIBW_SKIP: "*_i686 *musllinux*"
-          CIBW_BUILD_VERBOSITY: 2
-          CIBW_BEFORE_ALL_LINUX: yum install -y luajit; make bolt -j`nproc`
-          CIBW_TEST_COMMAND: pip install pyston_lite_autoload --no-index --find-links file://${GITHUB_WORKSPACE}/wheelhouse/ && python -m test -j0 -x test_code test_distutils test_ensurepip test_minidom test_site test_xml_etree test_xml_etree_c test_capi test_bdb test_c_locale_coercion test_ctypes test_importlib test_ssl test_sysconfig test_platform test___all__ test_sundry test_sys
-          # pyston does not work on macos before 11 (e.g. 10.15).
-          # If we specify 11 here default pip version says it's not compatible, in order to workaround it
-          # we specify 10.16 which does not really exist because it got renamed to 11.
-          CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=10.16
+      - name: Build wheels
+        run: |
+          cd pyston/pyston_lite
+          make package
 
       - uses: actions/upload-artifact@v2
         with:
-          path: ./wheelhouse/
+          path: ./pyston/pyston_lite/wheelhouse/
 
   build_pyston_lite_wheels_linux:
     name: Building wheels on Linux

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -11,11 +11,18 @@ ifeq ($(ARCH),x86_64)
 	BOLT_CMD:=python3 bolt_wheel.py wheelhouse/*.whl
 endif
 
+ifeq ($(shell uname), Darwin)
+build_wheels:
+	git clean -x -i -d -f .
+	bash -c 'if [ -d wheelhouse ]; then sudo rm -rf wheelhouse ; fi'
+	./build_wheels_macos.sh
+else
 build_wheels:
 	git clean -x -i -d -f .
 	bash -c 'if [ -d wheelhouse ]; then sudo rm -rf wheelhouse ; fi'
 	docker run -e NOBOLT=1 $(BOLT_DOCKERFLAGS) -e PLAT=manylinux2014_$(ARCH) -v `pwd`/../../:/io quay.io/pypa/manylinux2014_$(ARCH) bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/"
 	$(BOLT_CMD)
+endif
 
 upload_wheels: env
 	env/bin/pip install twine

--- a/pyston/pyston_lite/build_wheels_macos.sh
+++ b/pyston/pyston_lite/build_wheels_macos.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# this script will not work if run outside of a CI per default
+# because it will not find all required python versions and can't install
+# the missing ones :(. On Mac only one Python can be installed system wide at a time.
+# set 'CI=1' when running the script to remove the CI check and let the script overwrite your system wide python...
+
+set -ex
+
+ENV_DIR=`mktemp -d`
+
+python3.8 -m venv $ENV_DIR
+${ENV_DIR}/bin/pip install cibuildwheel
+
+export CC=gcc-11
+export CIBW_BUILD="cp37-* cp38-* cp39-* cp310-*"
+export CIBW_SKIP="*_i686 *musllinux*"
+export CIBW_BUILD_VERBOSITY=2
+export CIBW_ENVIRONMENT="MACOSX_DEPLOYMENT_TARGET=10.16"
+
+${ENV_DIR}/bin/cibuildwheel --platform macos autoload/
+
+CIBW_TEST_COMMAND="pip install pyston_lite_autoload --no-index --find-links file://`pwd`/wheelhouse/ && python -m test -j0 -x test_code test_distutils test_ensurepip test_minidom test_site test_xml_etree test_xml_etree_c test_capi test_bdb test_c_locale_coercion test_ctypes test_importlib test_ssl test_sysconfig test_platform test___all__ test_sundry test_sys" \
+${ENV_DIR}/bin/cibuildwheel --platform macos 
+
+rm -rf ${ENV_DIR}
+


### PR DESCRIPTION
building packages outside the CI on Mac is annoying because it seems only one python official python version can be installed at a time which means the script will modify your system python... (only if `CI=1` is set else it will just abort when it can't find correct python version)

This changes make it very easy for me to build the ARM64 MacOS packages: I just need to run ''CI=1 make package" and it will automatically install the correct python versions and output the wheels
