### PR TITLE
Add musllinux builds

### DIFF
--- a/.github/workflows/build_pyston_lite_wheels.yml
+++ b/.github/workflows/build_pyston_lite_wheels.yml
@@ -1,33 +1,33 @@
 name: Build pyston_lite wheels
 
-on: [workflow_dispatch]
+# FIXME: Revert back
+on: [push]
 
 jobs:
-  build_pyston_lite_wheels_macos:
-    name: Building wheels on MacOS
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v2
-      - name: checkout submodules
-        run: |
-          git submodule update --init pyston/LuaJIT
-
-      - name: install macOS dependencies
-        run: |
-          brew install luajit-openresty gcc@11
-          ln -s /usr/local/opt/luajit-openresty/bin/luajit /usr/local/bin/
-          echo "CC=gcc-11" >> $GITHUB_ENV
-
-      - name: Build wheels
-        run: |
-          cd pyston/pyston_lite
-          PYSTON_LITE_NAME=pyston_lite make build_wheels_noclean
-          PYSTON_LITE_NAME=pyston      make build_wheels_noclean
-
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./pyston/pyston_lite/wheelhouse/
-
+#  build_pyston_lite_wheels_macos:
+#    name: Building wheels on MacOS
+#    runs-on: macos-11
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: checkout submodules
+#        run: |
+#          git submodule update --init pyston/LuaJIT
+#
+#      - name: install macOS dependencies
+#        run: |
+#          brew install luajit-openresty gcc@11
+#          ln -s /usr/local/opt/luajit-openresty/bin/luajit /usr/local/bin/
+#          echo "CC=gcc-11" >> $GITHUB_ENV
+#
+#      - name: Build wheels
+#        run: |
+#          cd pyston/pyston_lite
+#          PYSTON_LITE_NAME=pyston_lite make build_wheels_noclean
+#          PYSTON_LITE_NAME=pyston      make build_wheels_noclean
+#
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          path: ./pyston/pyston_lite/wheelhouse/
   build_pyston_lite_wheels_linux:
     name: Building wheels on Linux
     runs-on: ubuntu-20.04

--- a/.github/workflows/build_pyston_lite_wheels.yml
+++ b/.github/workflows/build_pyston_lite_wheels.yml
@@ -56,7 +56,7 @@ jobs:
           PYSTON_LITE_NAME=pyston_lite make build_wheels_noclean
           PYSTON_LITE_NAME=pyston      make build_wheels_noclean
         env:
-          POLICY=${{ matrix.policy }}
+          POLICY: ${{ matrix.policy }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_pyston_lite_wheels.yml
+++ b/.github/workflows/build_pyston_lite_wheels.yml
@@ -31,6 +31,9 @@ jobs:
   build_pyston_lite_wheels_linux:
     name: Building wheels on Linux
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        policy: [musllinux_1_1, manylinux2014]
     steps:
       - uses: actions/checkout@v2
       - name: checkout submodules
@@ -52,6 +55,8 @@ jobs:
           cd pyston/pyston_lite
           PYSTON_LITE_NAME=pyston_lite make build_wheels_noclean
           PYSTON_LITE_NAME=pyston      make build_wheels_noclean
+        env:
+          POLICY=${{ matrix.policy }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -1,5 +1,5 @@
 name: GitHub Actions CI
-on: [push, pull_request]
+on: [workflow_dispatch]
 jobs:
   conda-build:
     runs-on: ubuntu-20.04

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -21,7 +21,7 @@ build_wheels_noclean:
 	./build_wheels_macos.sh
 else
 build_wheels_noclean:
-	docker run -e PYSTON_LITE_NAME -e NOBOLT=1 $(BOLT_DOCKERFLAGS) -e PLAT=$(POLICY)_$(ARCH) \
+	docker run -e PYSTON_LITE_NAME -e NOBOLT=1 $(BOLT_DOCKERFLAGS) -e PLAT=$(POLICY)_$(ARCH) -e POLICY \
 		-v `pwd`/../../:/io quay.io/pypa/$(POLICY)_$(ARCH) \
 		bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/"
 	$(BOLT_CMD)

--- a/pyston/pyston_lite/Makefile
+++ b/pyston/pyston_lite/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := env/lite.stamp
 
 PYTHON?=python3.8
+POLICY?=manylinux2014
 
 package: build_wheels
 
@@ -20,7 +21,9 @@ build_wheels_noclean:
 	./build_wheels_macos.sh
 else
 build_wheels_noclean:
-	docker run -e PYSTON_LITE_NAME -e NOBOLT=1 $(BOLT_DOCKERFLAGS) -e PLAT=manylinux2014_$(ARCH) -v `pwd`/../../:/io quay.io/pypa/manylinux2014_$(ARCH) bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/"
+	docker run -e PYSTON_LITE_NAME -e NOBOLT=1 $(BOLT_DOCKERFLAGS) -e PLAT=$(POLICY)_$(ARCH) \
+		-v `pwd`/../../:/io quay.io/pypa/$(POLICY)_$(ARCH) \
+		bash -c "bash /io/pyston/pyston_lite/build_wheels.sh && chown -R $(shell id -u):$(shell id -g) /io/pyston/pyston_lite/"
 	$(BOLT_CMD)
 endif
 

--- a/pyston/pyston_lite/build_wheels.sh
+++ b/pyston/pyston_lite/build_wheels.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+POLICY=${POLICY:"manylinux2014"}
+
 cd $(dirname $0)
 
 make -C ../LuaJIT clean
@@ -10,7 +12,9 @@ make -C ../LuaJIT -j`nproc` install
 
 ln -sf luajit-2.1.0-beta3 /usr/local/bin/luajit
 
-for PYVER in cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310
+# FIXME: enable all again
+#for PYVER in cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310
+for PYVER in cp310-cp310
 do
     echo "#################################"
     echo "Building pyston_lite for ${PYVER}"
@@ -33,6 +37,6 @@ for whl in wheelhouse/*.whl; do
     elif [[ $whl == *"-linux_"* ]]; then
         # auditwheel refuses to repair the autoload packages since they
         # don't have any binary files. So just manually rename them.
-        mv $whl $(echo $whl | sed "s/linux/manylinux2014/")
+        mv $whl $(echo $whl | sed "s/linux/${$POLICY}/")
     fi
 done

--- a/pyston/pyston_lite/build_wheels.sh
+++ b/pyston/pyston_lite/build_wheels.sh
@@ -37,6 +37,6 @@ for whl in wheelhouse/*.whl; do
     elif [[ $whl == *"-linux_"* ]]; then
         # auditwheel refuses to repair the autoload packages since they
         # don't have any binary files. So just manually rename them.
-        mv $whl $(echo $whl | sed "s/linux/${$POLICY}/")
+        mv $whl $(echo $whl | sed "s/linux/${POLICY}/")
     fi
 done


### PR DESCRIPTION
This is an attempt at solving #279 

Does the build step that builds bolt also need to run inside of of the musllinux container?

Note: I temporarily disabled building for all pythons to allow CI to run a bit faster. I'll enabled again after verifying the approach