### PR TITLE
Add a bugfix from 3.10 to get the 3.10 tests passing

### DIFF
--- a/Python/aot_ceval.c
+++ b/Python/aot_ceval.c
@@ -8397,7 +8397,12 @@ maybe_call_line_trace(Py_tracefunc func, PyObject *obj,
         }
     }
     /* Always emit an opcode event if we're tracing all opcodes. */
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 10
+    // This fix was introduced in 3.10.8:
+    if (frame->f_trace_opcodes && result == 0) {
+#else
     if (frame->f_trace_opcodes) {
+#endif
         result = call_trace(func, obj, tstate, frame, trace_info, PyTrace_OPCODE, Py_None);
     }
     return result;


### PR DESCRIPTION
fixes the old test failure on 3.10. looks like there are also some new test failures; my guess is something is not fully pinned