### PR TITLE
Fix: unqualified std::move and missing va_start ident

### DIFF
--- a/pyston/nitrous/facts.cpp
+++ b/pyston/nitrous/facts.cpp
@@ -330,7 +330,7 @@ private:
                 op_facts = getFacts(incoming, at, facts, tree, indent + 2);
 
                 if (i == 0)
-                    phi_facts = move(op_facts);
+                    phi_facts = std::move(op_facts);
                 else
                     intersectInto(op_facts, phi_facts);
             }
@@ -592,11 +592,11 @@ Location Location::gepDest(int offset, int size) const {
     for (int i = 1; i < indirections.size(); i++)
         new_indirections.push_back(indirections[i]);
 
-    return Location(move(new_indirections));
+    return Location(std::move(new_indirections));
 }
 
 void registerFactDeriver(unique_ptr<FactDeriver> deriver) {
-    fact_derivers.push_back(move(deriver));
+    fact_derivers.push_back(std::move(deriver));
 }
 
 } // namespace nitrous

--- a/pyston/nitrous/interp.cpp
+++ b/pyston/nitrous/interp.cpp
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <stdarg.h>
 
 #include <ffi.h>
 
@@ -141,7 +142,7 @@ static pair<unique_ptr<Module>, unique_ptr<MemoryBuffer>> loadBitcodeFile(const 
     unique_ptr<Module> module;
     module = ExitOnErr(getLazyBitcodeModule(*MB, getContext()));
 
-    return make_pair(move(module), move(MB));
+    return make_pair(std::move(module), std::move(MB));
 }
 
 class BitcodeRegistry {
@@ -174,8 +175,8 @@ public:
         */
         data_layout = &module->getDataLayout();
 
-        loaded_modules.push_back(move(module));
-        loaded_module_data.push_back(move(module_and_buf.second));
+        loaded_modules.push_back(std::move(module));
+        loaded_module_data.push_back(std::move(module_and_buf.second));
     }
 
     Function* findFunction(string name) {

--- a/pyston/nitrous/jit.cpp
+++ b/pyston/nitrous/jit.cpp
@@ -188,8 +188,8 @@ TargetMachine& LLVMCompiler::getTargetMachine() {
 void* LLVMCompiler::compile(unique_ptr<Module> module, ThreadSafeContext context, const string& funcname) {
     ExitOnError ExitOnErr;
 
-    auto TSM = ThreadSafeModule(std::move(module), move(context));
-    ExitOnErr(jit->addModule(move(TSM)));
+    auto TSM = ThreadSafeModule(std::move(module), std::move(context));
+    ExitOnErr(jit->addModule(std::move(TSM)));
 
     auto Sym = ExitOnErr(jit->lookup(funcname));
     RELEASE_ASSERT(Sym, "uh oh");
@@ -414,7 +414,7 @@ LLVMJit::InlineInfo LLVMJit::inlineFunction(CallInst* call,
     //outs() << "after inlining:\n";
     //outs() << *module << '\n';
 
-    return { move(ifi.StaticAllocas) };
+    return { std::move(ifi.StaticAllocas) };
 }
 
 class NitrousAAResult : public AAResultBase<NitrousAAResult> {
@@ -679,7 +679,7 @@ char RemoveICmpPtrPass::ID = 0;
 
 vector<function<FunctionPass*(LLVMEvaluator& eval)>> pass_factories;
 void registerPassFactory(function<FunctionPass*(LLVMEvaluator& eval)> factory) {
-    pass_factories.push_back(move(factory));
+    pass_factories.push_back(std::move(factory));
 }
 
 void LLVMJit::optimizeFunc(LLVMEvaluator& eval) {
@@ -1144,7 +1144,7 @@ void* LLVMJit::finish(LLVMEvaluator& eval) {
     struct timespec start, end;
     if (nitrous_verbosity >= NITROUS_VERBOSITY_STATS)
         clock_gettime(CLOCK_REALTIME, &start);
-    auto r = compiler->compile(move(module), *llvm_context, func->getName().str());
+    auto r = compiler->compile(std::move(module), *llvm_context, func->getName().str());
 
     if (nitrous_verbosity >= NITROUS_VERBOSITY_STATS) {
         clock_gettime(CLOCK_REALTIME, &end);


### PR DESCRIPTION
Fixes build when using clang 16, and likely many other modern compilers.

Should not break build on older compilers (?) as far as I understand it. Please correct me if I'm mistaken on the latter.